### PR TITLE
support -b to force running in background

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -1561,11 +1561,14 @@ static void conf_cmdline(struct context *cnt, int thread)
      * if necessary. This is accomplished by calling mystrcpy();
      * see this function for more information.
      */
-    while ((c = getopt(conf->argc, conf->argv, "c:d:hmns?p:k:l:")) != EOF)
+    while ((c = getopt(conf->argc, conf->argv, "bc:d:hmns?p:k:l:")) != EOF)
         switch (c) {
         case 'c':
             if (thread == -1)
                 strcpy(cnt->conf_filename, optarg);
+            break;
+        case 'b':
+            cnt->daemon = 1;
             break;
         case 'n':
             cnt->daemon = 0;
@@ -2376,6 +2379,7 @@ static void usage()
     printf("\nusage:\tmotion [options]\n");
     printf("\n\n");
     printf("Possible options:\n\n");
+    printf("-b\t\t\tRun in background (daemon) mode.\n");
     printf("-n\t\t\tRun in non-daemon mode.\n");
     printf("-s\t\t\tRun in setup mode.\n");
     printf("-c config\t\tFull path and filename of config file.\n");

--- a/motion.1
+++ b/motion.1
@@ -3,7 +3,7 @@
 motion \-   Detect motion using a video4linux device
 .SH SYNOPSIS
 .B motion
-[ -hmns ] [ -c config file path ] [ -d log level ] [ -k log type ] [ -p process_id_file ] [ -l logfile ]
+[ -bhmns ] [ -c config file path ] [ -d log level ] [ -k log type ] [ -p process_id_file ] [ -l logfile ]
 .SH DESCRIPTION
 .I  Motion
 uses a video4linux device to detect motion. If motion is detected both normal
@@ -19,6 +19,9 @@ Show help screen.
 .TP
 .B \-m
 Disable motion detection at startup.
+.TP
+.B \-b
+Run in background (daemon) mode.
 .TP
 .B \-n
 Run in non-daemon mode.


### PR DESCRIPTION
Would you consider pulling this simple diff to add a command-line flag to force running in the background regardless of the config option? It's useful for init scripts to ensure that motion doesn't run in the foreground. Thanks!
