### PR TITLE
The timestamp- and the generic text no longer default to lower left/r…

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -896,7 +896,7 @@ config_param config_params[] = {
     {
     "timestamp_location",
     "# Where to place the timestamp-text. Can be upper-left, upper-right,\n"
-    "# bottom-left or bottom-right.\n"
+    "# center, bottom-left or bottom-right.\n"
     "# Default: Not defined = bottom-right\n",
     0,
     CONF_OFFSET(timestamp_location),
@@ -916,7 +916,7 @@ config_param config_params[] = {
     {
     "generic_text_location",
     "# Where to place the generic text. Can be upper-left, upper-right,\n"
-    "# ceter, bottom-left or bottom-right.\n"
+    "# center, bottom-left or bottom-right.\n"
     "# Default: Not defined = bottom-left\n",
     0,
     CONF_OFFSET(generic_text_location),
@@ -975,7 +975,7 @@ config_param config_params[] = {
     {
     "ext_event_location",
     "# Where to place the external event text. Can be upper-left, upper-right,\n"
-    "# bottom-left or bottom-right.\n"
+    "# center, bottom-left or bottom-right.\n"
     "# Default: Not defined = center\n",
     0,
     CONF_OFFSET(ext_event_location),

--- a/conf.h
+++ b/conf.h
@@ -128,9 +128,11 @@ struct config {
     unsigned int netcam_tolerant_check;
     unsigned int rtsp_uses_tcp;
     int text_changes;
-    const char *text_left;
-    const char *text_right;
+    const char *timestamp, *timestamp_location;
+    const char *generic_text, *generic_text_location;
     const char *text_event;
+    int ext_event_udp_listener_port, ext_event_show_time;
+    const char *ext_event_location;
     int text_double;
     const char *despeckle_filter;
     const char *area_detect;

--- a/draw.c
+++ b/draw.c
@@ -1083,11 +1083,10 @@ static int draw_textn(unsigned char *image, unsigned int startx, unsigned int st
     int pos, x, y, line_offset, next_char_offs;
     unsigned char *image_ptr, *char_ptr, **char_arr_ptr;
 
-    if (startx > width / 2)
-        startx -= len * (6 * (factor + 1));
-
     if (startx + len * 6 * (factor + 1) >= width)
         len = (width-startx-1)/(6*(factor+1));
+
+    printf("\t%d,%d (%d): %d\n", startx, starty, width, len);
     
     line_offset = width - 7 * (factor + 1);
     next_char_offs = width * 8 * (factor + 1) - 6 * (factor + 1);
@@ -1140,16 +1139,6 @@ int draw_text(unsigned char *image, unsigned int startx, unsigned int starty, un
     int num_nl = 0;
     const char *end, *begin;
     const int line_space = (factor + 1) * 9;
-    
-    /* Count the number of newlines in "text" so we scroll it up the image. */
-    end = text;
-
-    while ((end = strstr(end, NEWLINE))) {
-        num_nl++;
-        end += sizeof(NEWLINE)-1;
-    }
-
-    starty -= line_space * num_nl;
     
     begin = end = text;
 
@@ -1235,4 +1224,8 @@ void get_text_dimensions(const char *const str, const int big_chars, int *const 
         *width = cols * 7;
         *height = rows * 8;
     }
+}
+
+void get_space_dimension(const int big_chars, int *const width, int *const height) {
+	get_text_dimensions(" ", big_chars, width, height);
 }

--- a/draw.c
+++ b/draw.c
@@ -1204,14 +1204,35 @@ int initialize_chars(void)
 }
 
 void get_text_dimensions(const char *const str, const int big_chars, int *const width, int *const height) {
-    int len = strlen(str);
+    int cols = 0, rows = 0;
+    char *dummy = strdup(str), *curp = dummy;
+
+    for(;;) {
+        int clen;
+        char *lf = strstr(curp, "\\n");
+        if (lf)
+            *lf = 0x00;
+
+        rows++;
+
+        clen = strlen(curp);
+        if (clen > cols)
+            cols = clen;
+
+        if (!lf)
+            break;
+
+        curp = lf + 2;
+    }
+
+    free(dummy);
 
     if (big_chars) {
-        *width = len * 14;
-        *height = 16;
+        *width = cols * 14;
+        *height = rows * 16;
     }
     else {
-        *width = len * 7;
-        *height = 8;
+        *width = cols * 7;
+        *height = rows * 8;
     }
 }

--- a/draw.c
+++ b/draw.c
@@ -1203,3 +1203,15 @@ int initialize_chars(void)
     return 0;
 }
 
+void get_text_dimensions(const char *const str, const int big_chars, int *const width, int *const height) {
+    int len = strlen(str);
+
+    if (big_chars) {
+        *width = len * 14;
+        *height = 16;
+    }
+    else {
+        *width = len * 7;
+        *height = 8;
+    }
+}

--- a/draw.c
+++ b/draw.c
@@ -1086,8 +1086,6 @@ static int draw_textn(unsigned char *image, unsigned int startx, unsigned int st
     if (startx + len * 6 * (factor + 1) >= width)
         len = (width-startx-1)/(6*(factor+1));
 
-    printf("\t%d,%d (%d): %d\n", startx, starty, width, len);
-    
     line_offset = width - 7 * (factor + 1);
     next_char_offs = width * 8 * (factor + 1) - 6 * (factor + 1);
     
@@ -1136,22 +1134,22 @@ static int draw_textn(unsigned char *image, unsigned int startx, unsigned int st
  */
 int draw_text(unsigned char *image, unsigned int startx, unsigned int starty, unsigned int width, const char *text, unsigned int factor)
 {
-    int num_nl = 0;
-    const char *end, *begin;
+    const char *p = text;
     const int line_space = (factor + 1) * 9;
-    
-    begin = end = text;
 
-    while ((end = strstr(end, NEWLINE))) {
-        int len = end-begin;
+    for(;;) {
+        const char *end = strstr(p, NEWLINE);
+        int len = end ? end - p : strlen(p);
 
-        draw_textn(image, startx, starty, width, begin, len, factor);
-        end += sizeof(NEWLINE)-1;
-        begin = end;
+        draw_textn(image, startx, starty, width, p, len, factor);
+
+        if (!end)
+            break;
+
+        p = end + sizeof(NEWLINE) - 1;
+
         starty += line_space;
     }
-
-    draw_textn(image, startx, starty, width, begin, strlen(begin), factor);
 
     return 0;
 }

--- a/draw.h
+++ b/draw.h
@@ -1,3 +1,4 @@
 int initialize_chars(void);
 void get_text_dimensions(const char *const str, const int big_chars, int *const width, int *const height);
 int draw_text(unsigned char *image, unsigned int startx, unsigned int starty, unsigned int width, const char *text, unsigned int factor);
+void get_space_dimension(const int big_chars, int *const width, int *const height);

--- a/draw.h
+++ b/draw.h
@@ -1,0 +1,3 @@
+int initialize_chars(void);
+void get_text_dimensions(const char *const str, const int big_chars, int *const width, int *const height);
+int draw_text(unsigned char *image, unsigned int startx, unsigned int starty, unsigned int width, const char *text, unsigned int factor);

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -392,13 +392,38 @@ locate_motion_style box
 
 # Draws the timestamp using same options as C function strftime(3)
 # Default: %Y-%m-%d\n%T = date in ISO format and time in 24 hour clock
-# Text is placed in lower right corner
-text_right %Y-%m-%d\n%T-%q
+# Text is placed default in lower right corner. Change this with timestamp_location
+timestamp %Y-%m-%d\n%T-%q
+
+# Select where to place the "timestamp".
+# Default: Not defined = bottom-right
+# Can be bottom-left, bottom-right, upper-left, upper-right
+; timestamp bottom-right
 
 # Draw a user defined text on the images using same options as C function strftime(3)
 # Default: Not defined = no text
-# Text is placed in lower left corner
-; text_left CAMERA %t
+# Text is placed default in lower left corner. Change this with generic_text_location
+; generic_text CAMERA %t
+
+# Select where to place the "generic_text".
+# Default: Not defined = bottom-left
+# Can be bottom-left, bottom-right, upper-left, upper-right
+; generic_text_location bottom-left
+
+# Select a UDP port to listen on for text-messages. These then will be shown in the
+# image. Seen "send.py" for an example.
+# Default: Not defined = disabled
+# Can be any valid port-number.
+; ext_event_udp_listener_port 1888
+
+# How long to show a text.
+# Default: Not defined = 5 seconds
+# Can be any value >= 1 seconds
+; ext_event_show_time 5
+
+# Where to put the text. Can be bottom-left, bottom-right, upper-left, upper-right
+# Default: Not defined = upper-left
+; ext_event_location upper-left
 
 # Draw the number of changed pixed on the images (default: off)
 # Will normally be set to off except when you setup and adjust the motion settings

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -397,7 +397,7 @@ timestamp %Y-%m-%d\n%T-%q
 
 # Select where to place the "timestamp".
 # Default: Not defined = bottom-right
-# Can be bottom-left, bottom-right, upper-left, upper-right
+# Can be bottom-left, bottom-right, center, upper-left, upper-right
 ; timestamp bottom-right
 
 # Draw a user defined text on the images using same options as C function strftime(3)
@@ -407,7 +407,7 @@ timestamp %Y-%m-%d\n%T-%q
 
 # Select where to place the "generic_text".
 # Default: Not defined = bottom-left
-# Can be bottom-left, bottom-right, upper-left, upper-right
+# Can be bottom-left, bottom-right, center, upper-left, upper-right
 ; generic_text_location bottom-left
 
 # Select a UDP port to listen on for text-messages. These then will be shown in the
@@ -421,7 +421,7 @@ timestamp %Y-%m-%d\n%T-%q
 # Can be any value >= 1 seconds
 ; ext_event_show_time 5
 
-# Where to put the text. Can be bottom-left, bottom-right, upper-left, upper-right
+# Where to put the text. Can be bottom-left, bottom-right, center, upper-left, upper-right
 # Default: Not defined = upper-left
 ; ext_event_location upper-left
 

--- a/motion.c
+++ b/motion.c
@@ -1141,8 +1141,6 @@ void format_and_draw_text_at_location(struct context *const cnt, const char *con
     bottom = cnt->imgs.height - space_height - text_height;
     right = cnt->imgs.width - space_width - text_width;
 
-    printf("%dx%d %s %s\n", text_width, text_height, use_location, text);
-
     mystrftime(cnt, tmp, sizeof(tmp), text, &cnt->current_image->timestamp_tm, NULL, 0);
 
     if (strcasecmp(use_location, "bottom-left") == 0)

--- a/motion.h
+++ b/motion.h
@@ -54,6 +54,8 @@
 #include <sys/param.h>
 #include <stdint.h>
 
+#include <netinet/in.h>
+
 #define _LINUX_TIME_H 1
 #if defined(HAVE_LINUX_VIDEODEV_H) && (!defined(WITHOUT_V4L)) && (!defined(BSD))
 #include <linux/videodev.h>

--- a/motion.h
+++ b/motion.h
@@ -284,9 +284,7 @@ struct image_data {
  *               These values are set in rotate_init.
  */
 
-/* date/time drawing, draw.c */
-int draw_text(unsigned char *image, unsigned int startx, unsigned int starty, unsigned int width, const char *text, unsigned int factor);
-int initialize_chars(void);
+#include "draw.h"
 
 struct images {
     struct image_data *image_ring;    /* The base address of the image ring buffer */

--- a/send.py
+++ b/send.py
@@ -1,0 +1,17 @@
+#! /usr/bin/python
+
+# written by folkert@vanheusden.com
+
+# invocation:
+#   ./send.py "hello, this is my text"
+
+import json
+import socket
+import sys
+
+host = '127.0.0.1'
+udp_port = 1888
+text = sys.argv[1]
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.sendto(text, (host, udp_port))


### PR DESCRIPTION
```
The timestamp- and the generic text no longer default to lower left/right, they can now freely be chosen from left/right upper/bottom.

Added an external event interface which lets you add an extra free text to the image.
```
