### PR TITLE
Produce more helpful error if pkg-config not installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -383,7 +383,19 @@ AS_IF([test "x$with_ffmpeg" != "xno"], [
 	      PKG_CONFIG_PATH=${with_ffmpeg}/lib/pkgconfig:$PKG_CONFIG_PATH
 	      export PKG_CONFIG_PATH
 	])
-	PKG_CHECK_MODULES([FFMPEG], libavutil libavformat libavcodec libswscale, HAVE_FFMPEG=yes)
+
+       AC_CHECK_PROG([PKGCONFIG],[pkg-config],[yes],[no])
+       AM_CONDITIONAL([FOUND_PKGCONFIG], [test "x$PKGCONFIG" = xyes])
+       AM_COND_IF([FOUND_PKGCONFIG],,[AC_MSG_ERROR([required program 'pkg-config' not found.])])
+
+       AC_SUBST(FFMPEG_LIBS)
+       AC_SUBST(FFMPEG_CFLAGS)
+       FFMPEG_DEPS="libavutil libavformat libavcodec libswscale"
+       if pkg-config $FFMPEG_DEPS; then
+               FFMPEG_CFLAGS=`pkg-config --cflags $FFMPEG_DEPS`
+               FFMPEG_LIBS=`pkg-config --libs $FFMPEG_DEPS`
+               HAVE_FFMPEG="yes"
+       fi
 ])
 
 AS_IF([test "${HAVE_FFMPEG}" = "yes" ], [

--- a/event.c
+++ b/event.c
@@ -649,7 +649,7 @@ static void event_ffmpeg_newfile(struct context *cnt,
         }
 
         if ((cnt->ffmpeg_output =
-            ffmpeg_open((char *)cnt->conf.ffmpeg_video_codec, cnt->newfilename, y, u, v,
+            ffmpeg_open(cnt->conf.ffmpeg_video_codec, cnt->newfilename, y, u, v,
                          cnt->imgs.width, cnt->imgs.height, cnt->movie_fps, cnt->conf.ffmpeg_bps,
                          cnt->conf.ffmpeg_vbr,TIMELAPSE_NONE)) == NULL) {
             MOTION_LOG(ERR, TYPE_EVENTS, SHOW_ERRNO, "%s: ffopen_open error creating (new) file [%s]",
@@ -677,9 +677,9 @@ static void event_ffmpeg_newfile(struct context *cnt,
         }
 
         if ((cnt->ffmpeg_output_debug =
-            ffmpeg_open((char *)cnt->conf.ffmpeg_video_codec, cnt->motionfilename, y, u, v,
-                         cnt->imgs.width, cnt->imgs.height, cnt->movie_fps, cnt->conf.ffmpeg_bps,
-                         cnt->conf.ffmpeg_vbr,TIMELAPSE_NONE)) == NULL) {
+            ffmpeg_open(cnt->conf.ffmpeg_video_codec, cnt->motionfilename, y, u, v,
+                        cnt->imgs.width, cnt->imgs.height, cnt->movie_fps, cnt->conf.ffmpeg_bps,
+                        cnt->conf.ffmpeg_vbr,TIMELAPSE_NONE)) == NULL) {
             MOTION_LOG(ERR, TYPE_EVENTS, SHOW_ERRNO, "%s: ffopen_open error creating (motion) file [%s]",
                        cnt->motionfilename);
             cnt->finish = 1;
@@ -703,8 +703,8 @@ static void event_ffmpeg_timelapse(struct context *cnt,
     if (!cnt->ffmpeg_timelapse) {
         char tmp[PATH_MAX];
         const char *timepath;
-        char codec_swf[3] = "swf";
-        char codec_mpeg[5] = "mpeg4";
+        const char *codec_swf = "swf";
+        const char *codec_mpeg = "mpeg4";
 
         /*
          *  conf.timepath would normally be defined but if someone deleted it by control interface

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -90,7 +90,7 @@ void my_frame_free(AVFrame *frame){
  *      0:  File doesn't exist
  *      1:  File exists
  */
-int timelapse_exists(const char *fname){
+static int timelapse_exists(const char *fname){
     FILE *file;
     file = fopen(fname, "r");
     if (file)
@@ -100,7 +100,7 @@ int timelapse_exists(const char *fname){
     }
     return 0;
 }
-int timelapse_append(struct ffmpeg *ffmpeg, AVPacket pkt){
+static int timelapse_append(struct ffmpeg *ffmpeg, AVPacket pkt){
     FILE *file;
 
     file = fopen(ffmpeg->oc->filename, "a");

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -212,7 +212,7 @@ static AVOutputFormat *get_oformat(const char *codec, char *filename){
  *  Returns
  *      A new allocated ffmpeg struct or NULL if any error happens.
  */
-struct ffmpeg *ffmpeg_open(char *ffmpeg_video_codec, char *filename,
+struct ffmpeg *ffmpeg_open(const char *ffmpeg_video_codec, char *filename,
                            unsigned char *y, unsigned char *u, unsigned char *v,
                            int width, int height, int rate, int bps, int vbr, int tlapse)
 {

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -54,7 +54,7 @@ struct ffmpeg {
 void ffmpeg_init(void);
 
 struct ffmpeg *ffmpeg_open(
-    char *ffmpeg_video_codec,
+    const char *ffmpeg_video_codec,
     char *filename,
     unsigned char *y,    /* YUV420 Y plane */
     unsigned char *u,    /* YUV420 U plane */

--- a/netcam_rtsp.c
+++ b/netcam_rtsp.c
@@ -31,7 +31,7 @@
  *
  * Determine whether pix_format is YUV420P
  */
-int netcam_check_pixfmt(netcam_context_ptr netcam){
+static int netcam_check_pixfmt(netcam_context_ptr netcam){
     int retcd;
 
     retcd = -1;
@@ -47,7 +47,7 @@ int netcam_check_pixfmt(netcam_context_ptr netcam){
  *
  * Null all the context
  */
-void netcam_rtsp_null_context(netcam_context_ptr netcam){
+static void netcam_rtsp_null_context(netcam_context_ptr netcam){
 
     netcam->rtsp->swsctx         = NULL;
     netcam->rtsp->swsframe_in    = NULL;
@@ -62,7 +62,7 @@ void netcam_rtsp_null_context(netcam_context_ptr netcam){
  *
  * Close all the context that could be open
  */
-void netcam_rtsp_close_context(netcam_context_ptr netcam){
+static void netcam_rtsp_close_context(netcam_context_ptr netcam){
 
     if (netcam->rtsp->swsctx       != NULL) sws_freeContext(netcam->rtsp->swsctx);
     if (netcam->rtsp->swsframe_in  != NULL) my_frame_free(netcam->rtsp->swsframe_in);
@@ -372,7 +372,7 @@ int netcam_read_rtsp_image(netcam_context_ptr netcam){
 *       Success     0(zero)
 *
 */
-int netcam_rtsp_resize_ntc(netcam_context_ptr netcam){
+static int netcam_rtsp_resize_ntc(netcam_context_ptr netcam){
 
     if ((netcam->width  != netcam->rtsp->codec_context->width) ||
         (netcam->height != netcam->rtsp->codec_context->height) ||
@@ -425,7 +425,7 @@ int netcam_rtsp_resize_ntc(netcam_context_ptr netcam){
 *       Success     0(zero)
 *
 */
-int netcam_rtsp_open_context(netcam_context_ptr netcam){
+static int netcam_rtsp_open_context(netcam_context_ptr netcam){
 
     int  retcd;
     char errstr[128];
@@ -531,7 +531,7 @@ int netcam_rtsp_open_context(netcam_context_ptr netcam){
 *       Success     0(zero)
 *
 */
-int netcam_rtsp_open_sws(netcam_context_ptr netcam){
+static int netcam_rtsp_open_sws(netcam_context_ptr netcam){
 
     netcam->width  = ((netcam->cnt->conf.width / 8) * 8);
     netcam->height = ((netcam->cnt->conf.height / 8) * 8);
@@ -605,7 +605,7 @@ int netcam_rtsp_open_sws(netcam_context_ptr netcam){
 *       Success     0(zero)
 *
 */
-int netcam_rtsp_resize(unsigned char *image , netcam_context_ptr netcam){
+static int netcam_rtsp_resize(unsigned char *image , netcam_context_ptr netcam){
 
     int      retcd;
     char     errstr[128];

--- a/webhttpd.c
+++ b/webhttpd.c
@@ -2000,7 +2000,7 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                             send_template(client_socket, res);
                         }
                         sprintf(res, "<a href=http://%s:%d> "
-                            "<img src=http://%s:%d/ border=0 width=%d%%></a/n>"
+                            "<img src=http://%s:%d/ border=0 width=%d%%></a>\n"
                             ,hostname,cnt[y]->conf.stream_port
                             ,hostname,cnt[y]->conf.stream_port
                             ,cnt[y]->conf.stream_preview_scale);


### PR DESCRIPTION
Currently if users run autoreconf then configure without having
pkg-config installed, they see:

./configure: line 5283: syntax error near unexpected token FFMPEG,'
./configure: line 5283:    PKG_CHECK_MODULES(FFMPEG, libavutil
libavformat libavcodec libswscale, HAVE_FFMPEG=yes)'

This is not hugely helpful and causes support queries and confusion.
It is because the pkg.m4 file that defines PKG_CHECK_MODULES is not
available of pkg-config is not installed.

To work around this, remove PKG_CHECK_MODULES and do roughly the
equivalent calling pkg-config directly. To mirror the current
behaviour, we also add a test for pkg-config being present and abort
if it is not. (I am not 100% sure this is the desired behaviour, but
regardless this commit is still an improvement on what we currently
have.)