### PR TITLE
Fix stack corruption in event_ffmpeg_timelapse

### DIFF
--- a/event.c
+++ b/event.c
@@ -649,7 +649,7 @@ static void event_ffmpeg_newfile(struct context *cnt,
         }
 
         if ((cnt->ffmpeg_output =
-            ffmpeg_open((char *)cnt->conf.ffmpeg_video_codec, cnt->newfilename, y, u, v,
+            ffmpeg_open(cnt->conf.ffmpeg_video_codec, cnt->newfilename, y, u, v,
                          cnt->imgs.width, cnt->imgs.height, cnt->movie_fps, cnt->conf.ffmpeg_bps,
                          cnt->conf.ffmpeg_vbr,TIMELAPSE_NONE)) == NULL) {
             MOTION_LOG(ERR, TYPE_EVENTS, SHOW_ERRNO, "%s: ffopen_open error creating (new) file [%s]",
@@ -677,9 +677,9 @@ static void event_ffmpeg_newfile(struct context *cnt,
         }
 
         if ((cnt->ffmpeg_output_debug =
-            ffmpeg_open((char *)cnt->conf.ffmpeg_video_codec, cnt->motionfilename, y, u, v,
-                         cnt->imgs.width, cnt->imgs.height, cnt->movie_fps, cnt->conf.ffmpeg_bps,
-                         cnt->conf.ffmpeg_vbr,TIMELAPSE_NONE)) == NULL) {
+            ffmpeg_open(cnt->conf.ffmpeg_video_codec, cnt->motionfilename, y, u, v,
+                        cnt->imgs.width, cnt->imgs.height, cnt->movie_fps, cnt->conf.ffmpeg_bps,
+                        cnt->conf.ffmpeg_vbr,TIMELAPSE_NONE)) == NULL) {
             MOTION_LOG(ERR, TYPE_EVENTS, SHOW_ERRNO, "%s: ffopen_open error creating (motion) file [%s]",
                        cnt->motionfilename);
             cnt->finish = 1;
@@ -703,8 +703,8 @@ static void event_ffmpeg_timelapse(struct context *cnt,
     if (!cnt->ffmpeg_timelapse) {
         char tmp[PATH_MAX];
         const char *timepath;
-        char codec_swf[3] = "swf";
-        char codec_mpeg[5] = "mpeg4";
+        const char *codec_swf = "swf";
+        const char *codec_mpeg = "mpeg4";
 
         /*
          *  conf.timepath would normally be defined but if someone deleted it by control interface

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -212,7 +212,7 @@ static AVOutputFormat *get_oformat(const char *codec, char *filename){
  *  Returns
  *      A new allocated ffmpeg struct or NULL if any error happens.
  */
-struct ffmpeg *ffmpeg_open(char *ffmpeg_video_codec, char *filename,
+struct ffmpeg *ffmpeg_open(const char *ffmpeg_video_codec, char *filename,
                            unsigned char *y, unsigned char *u, unsigned char *v,
                            int width, int height, int rate, int bps, int vbr, int tlapse)
 {

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -54,7 +54,7 @@ struct ffmpeg {
 void ffmpeg_init(void);
 
 struct ffmpeg *ffmpeg_open(
-    char *ffmpeg_video_codec,
+    const char *ffmpeg_video_codec,
     char *filename,
     unsigned char *y,    /* YUV420 Y plane */
     unsigned char *u,    /* YUV420 U plane */


### PR DESCRIPTION
The current definitions (char codec_swf[3] = "swf" etc) are declared
one character too short resulting in stack corruption or crashes in
some cases.

To avoid the possibility of an error at all, we change ffmpeg_open to
take a const char * as it doesn't need to alter the string.

Closes https://github.com/Mr-Dave/motion/issues/109