### PR TITLE
h264 codec: set crf option based on configured vbr

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -296,9 +296,9 @@ struct ffmpeg *ffmpeg_open(char *ffmpeg_video_codec, char *filename,
         c->codec_id == MY_CODEC_ID_HEVC){
         av_dict_set(&opts, "preset", "ultrafast", 0);
 
-        /* transforrm vbr (2 - 31) into crf (0 - 51) by scaling */
+        /* transform vbr (1 - 32767) into crf (0 - 51) by scaling */
         char crf[4];
-        snprintf(crf, 4, "%d", (int) ((vbr - 2) * 1.758));
+        snprintf(crf, 4, "%d", (int) ((vbr - 1) * 51.0 / 32766));
 
         av_dict_set(&opts, "tune", "zerolatency", 0);
     }

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -295,7 +295,11 @@ struct ffmpeg *ffmpeg_open(char *ffmpeg_video_codec, char *filename,
     if (c->codec_id == MY_CODEC_ID_H264 ||
         c->codec_id == MY_CODEC_ID_HEVC){
         av_dict_set(&opts, "preset", "ultrafast", 0);
-        av_dict_set(&opts, "crf", "18", 0);
+
+        /* transforrm vbr (2 - 31) into crf (0 - 51) by scaling */
+        char crf[4];
+        snprintf(crf, 4, "%d", (int) ((vbr - 2) * 1.758));
+
         av_dict_set(&opts, "tune", "zerolatency", 0);
     }
     if (strcmp(ffmpeg_video_codec, "ffv1") == 0) c->strict_std_compliance = -2;

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -300,6 +300,7 @@ struct ffmpeg *ffmpeg_open(char *ffmpeg_video_codec, char *filename,
         char crf[4];
         snprintf(crf, 4, "%d", (int) ((vbr - 1) * 51.0 / 32766));
 
+        av_dict_set(&opts, "crf", crf, 0);
         av_dict_set(&opts, "tune", "zerolatency", 0);
     }
     if (strcmp(ffmpeg_video_codec, "ffv1") == 0) c->strict_std_compliance = -2;


### PR DESCRIPTION
I wanted to be able to configure the movie quality when using the h264 codec. This sets the "crf" option according to the ffmpeg_variable_bitrate option.