### PR TITLE
Produce more helpful error if pkg-config not installed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -383,7 +383,19 @@ AS_IF([test "x$with_ffmpeg" != "xno"], [
 	      PKG_CONFIG_PATH=${with_ffmpeg}/lib/pkgconfig:$PKG_CONFIG_PATH
 	      export PKG_CONFIG_PATH
 	])
-	PKG_CHECK_MODULES([FFMPEG], libavutil libavformat libavcodec libswscale, HAVE_FFMPEG=yes)
+
+       AC_CHECK_PROG([PKGCONFIG],[pkg-config],[yes],[no])
+       AM_CONDITIONAL([FOUND_PKGCONFIG], [test "x$PKGCONFIG" = xyes])
+       AM_COND_IF([FOUND_PKGCONFIG],,[AC_MSG_ERROR([required package 'pkg-config' not found, please check motion_guide.html and install necessary dependencies.])])
+
+       AC_SUBST(FFMPEG_LIBS)
+       AC_SUBST(FFMPEG_CFLAGS)
+       FFMPEG_DEPS="libavutil libavformat libavcodec libswscale"
+       if pkg-config $FFMPEG_DEPS; then
+               FFMPEG_CFLAGS=`pkg-config --cflags $FFMPEG_DEPS`
+               FFMPEG_LIBS=`pkg-config --libs $FFMPEG_DEPS`
+               HAVE_FFMPEG="yes"
+       fi
 ])
 
 AS_IF([test "${HAVE_FFMPEG}" = "yes" ], [


### PR DESCRIPTION
Currently if users run autoreconf then configure without having
pkg-config installed, they see:

./configure: line 5283: syntax error near unexpected token FFMPEG,'
./configure: line 5283:    PKG_CHECK_MODULES(FFMPEG, libavutil
libavformat libavcodec libswscale, HAVE_FFMPEG=yes)'

This is not hugely helpful and causes support queries and confusion.
It is because the pkg.m4 file that defines PKG_CHECK_MODULES is not
available of pkg-config is not installed.

To work around this, remove PKG_CHECK_MODULES and do roughly the
equivalent calling pkg-config directly. To mirror the current
behaviour, we also add a test for pkg-config being present and abort
if it is not. (I am not 100% sure this is the desired behaviour, but
regardless this commit is still an improvement on what we currently
have.)