### PR TITLE
Pkg config

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Summary of Changes
+   * Better messages for pkg-config
    * Fix timelapse crash when selecting mpeg4
 Version 3.4.1 Changes Below
    * Added suggestion for including pkgconf as part of build requirements

--- a/configure.ac
+++ b/configure.ac
@@ -368,6 +368,14 @@ if test x$JPEG_SUPPORT != xyes ; then
   )
 fi
 
+#
+# Check for the pkg-config.  
+#
+
+AC_CHECK_PROG([PKGCONFIG],[pkg-config],[yes],[no])
+AM_CONDITIONAL([FOUND_PKGCONFIG], [test "x$PKGCONFIG" = xyes])
+AM_COND_IF([FOUND_PKGCONFIG],,[AC_MSG_ERROR([Required package 'pkg-config' not found, please check motion_guide.html and install necessary dependencies.])])
+
 
 #
 # Check for libavcodec and libavformat from ffmpeg
@@ -384,10 +392,6 @@ AS_IF([test "x$with_ffmpeg" != "xno"], [
 	      export PKG_CONFIG_PATH
 	])
 
-       AC_CHECK_PROG([PKGCONFIG],[pkg-config],[yes],[no])
-       AM_CONDITIONAL([FOUND_PKGCONFIG], [test "x$PKGCONFIG" = xyes])
-       AM_COND_IF([FOUND_PKGCONFIG],,[AC_MSG_ERROR([required package 'pkg-config' not found, please check motion_guide.html and install necessary dependencies.])])
-
        AC_SUBST(FFMPEG_LIBS)
        AC_SUBST(FFMPEG_CFLAGS)
        FFMPEG_DEPS="libavutil libavformat libavcodec libswscale"
@@ -395,6 +399,8 @@ AS_IF([test "x$with_ffmpeg" != "xno"], [
                FFMPEG_CFLAGS=`pkg-config --cflags $FFMPEG_DEPS`
                FFMPEG_LIBS=`pkg-config --libs $FFMPEG_DEPS`
                HAVE_FFMPEG="yes"
+       else
+              AC_MSG_ERROR([Required ffmpeg packages 'libavutil-dev libavformat-dev libavcodec-dev libswscale-dev' were not found.  Please check motion_guide.html and install necessary dependencies or use the '--without-ffmpeg' configuration option.])
        fi
 ])
 

--- a/configure.ac
+++ b/configure.ac
@@ -383,7 +383,19 @@ AS_IF([test "x$with_ffmpeg" != "xno"], [
 	      PKG_CONFIG_PATH=${with_ffmpeg}/lib/pkgconfig:$PKG_CONFIG_PATH
 	      export PKG_CONFIG_PATH
 	])
-	PKG_CHECK_MODULES([FFMPEG], libavutil libavformat libavcodec libswscale, HAVE_FFMPEG=yes)
+
+       AC_CHECK_PROG([PKGCONFIG],[pkg-config],[yes],[no])
+       AM_CONDITIONAL([FOUND_PKGCONFIG], [test "x$PKGCONFIG" = xyes])
+       AM_COND_IF([FOUND_PKGCONFIG],,[AC_MSG_ERROR([required package 'pkg-config' not found, please check motion_guide.html and install necessary dependencies.])])
+
+       AC_SUBST(FFMPEG_LIBS)
+       AC_SUBST(FFMPEG_CFLAGS)
+       FFMPEG_DEPS="libavutil libavformat libavcodec libswscale"
+       if pkg-config $FFMPEG_DEPS; then
+               FFMPEG_CFLAGS=`pkg-config --cflags $FFMPEG_DEPS`
+               FFMPEG_LIBS=`pkg-config --libs $FFMPEG_DEPS`
+               HAVE_FFMPEG="yes"
+       fi
 ])
 
 AS_IF([test "${HAVE_FFMPEG}" = "yes" ], [


### PR DESCRIPTION
This is a slight revision to the original.  The check for the pkg-config needed to be moved above the check for the ffmpeg.  This allows for the specification of the --without-ffmpeg option.  The original had the check for the pkg-config inside the IF condition.  Next, a ELSE clause was added to stop the configuration when users did not specify the --without-ffmpeg option and the required libraries are not found.