### PR TITLE
Fix bad html in server home page

### DIFF
--- a/webhttpd.c
+++ b/webhttpd.c
@@ -2000,7 +2000,7 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                             send_template(client_socket, res);
                         }
                         sprintf(res, "<a href=http://%s:%d> "
-                            "<img src=http://%s:%d/ border=0 width=%d%%></a/n>"
+                            "<img src=http://%s:%d/ border=0 width=%d%%></a>\n"
                             ,hostname,cnt[y]->conf.stream_port
                             ,hostname,cnt[y]->conf.stream_port
                             ,cnt[y]->conf.stream_preview_scale);


### PR DESCRIPTION
The weird </a/n> tag in the html was presumably meant to be a </a> followed by a new line.