### PR TITLE
Initial support for MMAL camera on raspberry pi

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -31,14 +31,15 @@ examplesdir = $(datadir)/@PACKAGE_NAME@/examples
 # These variables contain compiler flags, object files to build and files to   #
 # install.                                                                     #
 ################################################################################
-CFLAGS       = @CFLAGS@ -Wall -DVERSION=\"@PACKAGE_VERSION@\" -Dsysconfdir=\"$(sysconfdir)\" @FFMPEG_CFLAGS@
+CFLAGS       = @CFLAGS@ -Wall -DVERSION=\"@PACKAGE_VERSION@\" -Dsysconfdir=\"$(sysconfdir)\" @FFMPEG_CFLAGS@ @MMAL_CFLAGS@
 LDFLAGS      = @LDFLAGS@
-LIBS         = @LIBS@  @FFMPEG_LIBS@
+LIBS         = @LIBS@  @MMAL_LIBS@ @FFMPEG_LIBS@
 VIDEO_OBJ    = @VIDEO@
 OBJ          = motion.o logger.o conf.o draw.o jpegutils.o vloopback_motion.o $(VIDEO_OBJ) \
 			   netcam.o netcam_ftp.o netcam_jpeg.o netcam_wget.o track.o \
 			   alg.o event.o picture.o rotate.o webhttpd.o \
-			   stream.o md5.o netcam_rtsp.o @FFMPEG_OBJ@ @SDL_OBJ@
+			   stream.o md5.o netcam_rtsp.o \
+			   @FFMPEG_OBJ@ @MMAL_OBJ@ @SDL_OBJ@
 SRC          = $(OBJ:.o=.c)
 DOC          = CHANGELOG COPYING CREDITS README motion_guide.html mask1.png normal.jpg outputmotion1.jpg outputnormal1.jpg
 EXAMPLES     = *.conf

--- a/conf.c
+++ b/conf.c
@@ -148,6 +148,10 @@ struct config conf_template = {
     netcam_proxy:                   NULL,
     netcam_tolerant_check:          0,
     rtsp_uses_tcp:                  1,
+#ifdef HAVE_MMAL
+    mmalcam_name:                   NULL,
+    mmalcam_control_params:         NULL,
+#endif
     text_changes:                   0,
     text_left:                      NULL,
     text_right:                     DEF_TIMESTAMP,
@@ -421,6 +425,27 @@ config_param config_params[] = {
     copy_bool,
     print_bool
     },
+#ifdef HAVE_MMAL
+    {
+    "mmalcam_name",
+    "# Name of camera to use if you are using a camera accessed through OpenMax/MMAL\n"
+    "# For the raspberry pi official camera, use vc.ril.camera"
+    "# Default: Not defined",
+    0,
+    CONF_OFFSET(mmalcam_name),
+    copy_string,
+    print_string
+    },
+    {
+    "mmalcam_control_params",
+    "# Camera control parameters (see raspivid/raspistill tool documentation)\n"
+    "# Default: Not defined",
+    0,
+    CONF_OFFSET(mmalcam_control_params),
+    copy_string,
+    print_string
+    },
+#endif
     {
     "auto_brightness",
     "# Let motion regulate the brightness of a video device (default: off).\n"

--- a/conf.h
+++ b/conf.h
@@ -127,6 +127,10 @@ struct config {
     const char *netcam_proxy;
     unsigned int netcam_tolerant_check;
     unsigned int rtsp_uses_tcp;
+#ifdef HAVE_MMAL
+    const char *mmalcam_name;
+    const char *mmalcam_control_params;
+#endif
     int text_changes;
     const char *text_left;
     const char *text_right;

--- a/configure.ac
+++ b/configure.ac
@@ -376,6 +376,24 @@ AC_CHECK_PROG([PKGCONFIG],[pkg-config],[yes],[no])
 AM_CONDITIONAL([FOUND_PKGCONFIG], [test "x$PKGCONFIG" = xyes])
 AM_COND_IF([FOUND_PKGCONFIG],,[AC_MSG_ERROR([Required package 'pkg-config' not found, please check motion_guide.html and install necessary dependencies.])])
 
+# Check for raspberry pi mmal interface
+#
+HAVE_MMAL=""
+LIBRASPBERRYPIDEVPATH="/opt/vc/include/interface/mmal"
+
+if test -d ${LIBRASPBERRYPIDEVPATH}; then
+       HAVE_MMAL="yes"
+fi
+
+AS_IF([test "${HAVE_MMAL}" = "yes" ], [
+           AC_SUBST(MMAL_CFLAGS)
+           AC_SUBST(MMAL_OBJ)
+           AC_SUBST(MMAL_LIBS)
+           MMAL_OBJ="mmalcam.o raspicam/RaspiCamControl.o raspicam/RaspiCLI.o"
+           MMAL_CFLAGS="-std=gnu99 -DHAVE_MMAL -Irasppicam -I/opt/vc/include"
+           MMAL_LIBS="-L/opt/vc/lib  -lmmal_core -lmmal_util -lmmal_vc_client -lvcos -lvchostif -lvchiq_arm"
+           AC_DEFINE([HAVE_MMAL], 1, [Define to 1 if we want MMAL])
+])
 
 #
 # Check for libavcodec and libavformat from ffmpeg
@@ -1112,7 +1130,6 @@ else
 	fi
 fi
 
-
 AC_SUBST(BIN_PATH)
 
 AC_CONFIG_FILES([
@@ -1199,6 +1216,16 @@ if test "${SDL_SUPPORT}" = "yes"; then
 	echo "SDL support:         Yes"
 else
 	echo "SDL support:         No"
+fi
+
+if test "${HAVE_MMAL}" = "yes"; then
+    echo "MMAL support:        Yes"
+    echo " ... MMAL_CFLAGS: $MMAL_CFLAGS"
+    echo " ... MMAL_OBJ: $MMAL_OBJ"
+    echo " ... MMAL_LIBS: $MMAL_LIBS"
+else
+    echo "MMAL support:        No"
+    echo " ... libraspberrypi-dev package not installed"
 fi
 
 if test "${HAVE_FFMPEG}" = "yes"; then

--- a/mmalcam.c
+++ b/mmalcam.c
@@ -1,0 +1,403 @@
+/*
+ * mmalcam.c
+ *
+ *    Raspberry Pi camera module using MMAL API.
+ *
+ *    Built upon functionality from the Raspberry Pi userland utility raspivid.
+ *
+ *    Copyright 2013 by Nicholas Tuckett
+ *    This software is distributed under the GNU public license version 2
+ *    See also the file 'COPYING'.
+ *
+ */
+
+#include "interface/vcos/vcos.h"
+#include "interface/mmal/mmal.h"
+#include "interface/mmal/mmal_buffer.h"
+#include "interface/mmal/mmal_port.h"
+#include "interface/mmal/util/mmal_util.h"
+#include "interface/mmal/util/mmal_util_params.h"
+#include "interface/mmal/util/mmal_default_components.h"
+#include "interface/mmal/util/mmal_connection.h"
+#include "raspicam/RaspiCamControl.h"
+
+#include "motion.h"
+#include "rotate.h"
+
+#define MMALCAM_OK		0
+#define MMALCAM_ERROR	-1
+
+#define MMAL_CAMERA_PREVIEW_PORT 0
+#define MMAL_CAMERA_VIDEO_PORT 1
+#define MMAL_CAMERA_CAPTURE_PORT 2
+#define VIDEO_FRAME_RATE_NUM 30
+#define VIDEO_FRAME_RATE_DEN 1
+#define VIDEO_OUTPUT_BUFFERS_NUM 3
+
+const int MAX_BITRATE = 30000000; // 30Mbits/s
+
+static void parse_camera_control_params(const char *control_params_str, RASPICAM_CAMERA_PARAMETERS *camera_params)
+{
+    char *control_params_tok = alloca(strlen(control_params_str) + 1);
+    strcpy(control_params_tok, control_params_str);
+
+    char *next_param = strtok(control_params_tok, " ");
+
+    while (next_param != NULL) {
+        char *param_val = strtok(NULL, " ");
+        if (raspicamcontrol_parse_cmdline(camera_params, next_param + 1, param_val) < 2) {
+            next_param = param_val;
+        } else {
+            next_param = strtok(NULL, " ");
+        }
+    }
+}
+
+static void check_disable_port(MMAL_PORT_T *port)
+{
+    if (port && port->is_enabled) {
+        mmal_port_disable(port);
+    }
+}
+
+static void camera_control_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+    if (buffer->cmd != MMAL_EVENT_PARAMETER_CHANGED) {
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "Received unexpected camera control callback event, 0x%08x",
+                buffer->cmd);
+    }
+
+    mmal_buffer_header_release(buffer);
+}
+
+static void camera_buffer_callback(MMAL_PORT_T *port, MMAL_BUFFER_HEADER_T *buffer)
+{
+    mmalcam_context_ptr mmalcam = (mmalcam_context_ptr) port->userdata;
+    mmal_queue_put(mmalcam->camera_buffer_queue, buffer);
+}
+
+static void set_port_format(mmalcam_context_ptr mmalcam, MMAL_ES_FORMAT_T *format)
+{
+    format->encoding = MMAL_ENCODING_OPAQUE;
+    format->encoding_variant = MMAL_ENCODING_I420;
+    format->es->video.width = mmalcam->width;
+    format->es->video.height = mmalcam->height;
+    format->es->video.crop.x = 0;
+    format->es->video.crop.y = 0;
+    format->es->video.crop.width = mmalcam->width;
+    format->es->video.crop.height = mmalcam->height;
+}
+
+static void set_video_port_format(mmalcam_context_ptr mmalcam, MMAL_ES_FORMAT_T *format)
+{
+    set_port_format(mmalcam, format);
+    format->es->video.frame_rate.num = mmalcam->framerate;
+    format->es->video.frame_rate.den = VIDEO_FRAME_RATE_DEN;
+}
+
+static int create_camera_component(mmalcam_context_ptr mmalcam, const char *mmalcam_name)
+{
+    MMAL_STATUS_T status;
+    MMAL_COMPONENT_T *camera_component;
+    MMAL_PORT_T *video_port = NULL;
+
+    status = mmal_component_create(mmalcam_name, &camera_component);
+
+    if (status != MMAL_SUCCESS) {
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "Failed to create MMAL camera component %s", mmalcam_name);
+        goto error;
+    }
+
+    if (camera_component->output_num == 0) {
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "MMAL camera %s doesn't have output ports", mmalcam_name);
+        goto error;
+    }
+
+    video_port = camera_component->output[MMAL_CAMERA_VIDEO_PORT];
+
+    status = mmal_port_enable(camera_component->control, camera_control_callback);
+
+    if (status) {
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "Unable to enable control port : error %d", status);
+        goto error;
+    }
+
+    //  set up the camera configuration
+    {
+        MMAL_PARAMETER_CAMERA_CONFIG_T cam_config = {
+                { MMAL_PARAMETER_CAMERA_CONFIG, sizeof(cam_config) },
+                .max_stills_w = mmalcam->width,
+                .max_stills_h = mmalcam->height,
+                .stills_yuv422 = 0,
+                .one_shot_stills = 0,
+                .max_preview_video_w = mmalcam->width,
+                .max_preview_video_h = mmalcam->height,
+                .num_preview_video_frames = 3,
+                .stills_capture_circular_buffer_height = 0,
+                .fast_preview_resume = 0,
+                .use_stc_timestamp = MMAL_PARAM_TIMESTAMP_MODE_RESET_STC };
+        mmal_port_parameter_set(camera_component->control, &cam_config.hdr);
+    }
+
+    set_video_port_format(mmalcam, video_port->format);
+    video_port->format->encoding = MMAL_ENCODING_I420;
+    status = mmal_port_format_commit(video_port);
+
+    if (status) {
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "camera video format couldn't be set");
+        goto error;
+    }
+
+    // Ensure there are enough buffers to avoid dropping frames
+    if (video_port->buffer_num < VIDEO_OUTPUT_BUFFERS_NUM) {
+        video_port->buffer_num = VIDEO_OUTPUT_BUFFERS_NUM;
+    }
+
+    status = mmal_component_enable(camera_component);
+
+    if (status) {
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "camera component couldn't be enabled");
+        goto error;
+    }
+
+    raspicamcontrol_set_all_parameters(camera_component, mmalcam->camera_parameters);
+    mmalcam->camera_component = camera_component;
+    mmalcam->camera_capture_port = video_port;
+    mmalcam->camera_capture_port->userdata = (struct MMAL_PORT_USERDATA_T*) mmalcam;
+    MOTION_LOG(NTC, TYPE_VIDEO, NO_ERRNO, "MMAL camera component created");
+    return MMALCAM_OK;
+
+    error: if (mmalcam->camera_component != NULL ) {
+        mmal_component_destroy(camera_component);
+        mmalcam->camera_component = NULL;
+    }
+
+    return MMALCAM_ERROR;
+}
+
+static void destroy_camera_component(mmalcam_context_ptr mmalcam)
+{
+    if (mmalcam->camera_component) {
+        mmal_component_destroy(mmalcam->camera_component);
+        mmalcam->camera_component = NULL;
+    }
+}
+
+static int create_camera_buffer_structures(mmalcam_context_ptr mmalcam)
+{
+    mmalcam->camera_buffer_pool = mmal_pool_create(mmalcam->camera_capture_port->buffer_num,
+            mmalcam->camera_capture_port->buffer_size);
+    if (mmalcam->camera_buffer_pool == NULL ) {
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "MMAL camera buffer pool creation failed");
+        return MMALCAM_ERROR;
+    }
+
+    mmalcam->camera_buffer_queue = mmal_queue_create();
+    if (mmalcam->camera_buffer_queue == NULL ) {
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "MMAL camera buffer queue creation failed");
+        return MMALCAM_ERROR;
+    }
+
+    return MMALCAM_OK;
+}
+
+static int send_pooled_buffers_to_port(MMAL_POOL_T *pool, MMAL_PORT_T *port)
+{
+    int num = mmal_queue_length(pool->queue);
+
+    for (int i = 0; i < num; i++) {
+        MMAL_BUFFER_HEADER_T *buffer = mmal_queue_get(pool->queue);
+
+        if (!buffer) {
+            MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "Unable to get a required buffer %d from pool queue", i);
+            return MMALCAM_ERROR;
+        }
+
+        if (mmal_port_send_buffer(port, buffer) != MMAL_SUCCESS) {
+            MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "Unable to send a buffer to port (%d)", i);
+            return MMALCAM_ERROR;
+        }
+    }
+
+    return MMALCAM_OK;
+}
+
+static void destroy_camera_buffer_structures(mmalcam_context_ptr mmalcam)
+{
+    if (mmalcam->camera_buffer_queue != NULL ) {
+        mmal_queue_destroy(mmalcam->camera_buffer_queue);
+        mmalcam->camera_buffer_queue = NULL;
+    }
+
+    if (mmalcam->camera_buffer_pool != NULL ) {
+        mmal_pool_destroy(mmalcam->camera_buffer_pool);
+        mmalcam->camera_buffer_pool = NULL;
+    }
+}
+
+/**
+ * mmalcam_start
+ *
+ *      This routine is called from the main motion thread.  It's job is
+ *      to open up the requested camera device via MMAL and do any required
+ *      initialisation.
+ *
+ * Parameters:
+ *
+ *      cnt     Pointer to the motion context structure for this device.
+ *
+ * Returns:     0 on success
+ *              -1 on any failure
+ */
+
+int mmalcam_start(struct context *cnt)
+{
+    mmalcam_context_ptr mmalcam;
+
+    cnt->mmalcam = (mmalcam_context*) mymalloc(sizeof(struct mmalcam_context));
+    memset(cnt->mmalcam, 0, sizeof(mmalcam_context));
+    mmalcam = cnt->mmalcam;
+    mmalcam->cnt = cnt;
+
+    MOTION_LOG(ALR, TYPE_VIDEO, NO_ERRNO,
+            "%s: MMAL Camera thread starting... for camera (%s) of %d x %d at %d fps",
+            cnt->conf.mmalcam_name, cnt->conf.width, cnt->conf.height, cnt->conf.frame_limit);
+
+    mmalcam->camera_parameters = (RASPICAM_CAMERA_PARAMETERS*)malloc(sizeof(RASPICAM_CAMERA_PARAMETERS));
+    if (mmalcam->camera_parameters == NULL) {
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "camera params couldn't be allocated");
+        return MMALCAM_ERROR;
+    }
+
+    raspicamcontrol_set_defaults(mmalcam->camera_parameters);
+    mmalcam->width = cnt->conf.width;
+    mmalcam->height = cnt->conf.height;
+    mmalcam->framerate = cnt->conf.frame_limit;
+
+    if (cnt->conf.mmalcam_control_params) {
+        parse_camera_control_params(cnt->conf.mmalcam_control_params, mmalcam->camera_parameters);
+    }
+
+    cnt->imgs.width = mmalcam->width;
+    cnt->imgs.height = mmalcam->height;
+    cnt->imgs.size = (mmalcam->width * mmalcam->height * 3) / 2;
+    cnt->imgs.motionsize = mmalcam->width * mmalcam->height;
+    cnt->imgs.type = VIDEO_PALETTE_YUV420P;
+
+    int retval = create_camera_component(mmalcam, cnt->conf.mmalcam_name);
+
+    if (retval == 0) {
+        retval = create_camera_buffer_structures(mmalcam);
+    }
+
+    if (retval == 0) {
+        if (mmal_port_enable(mmalcam->camera_capture_port, camera_buffer_callback)) {
+            MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "MMAL camera capture port enabling failed");
+            retval = MMALCAM_ERROR;
+        }
+    }
+
+    if (retval == 0) {
+        if (mmal_port_parameter_set_boolean(mmalcam->camera_capture_port, MMAL_PARAMETER_CAPTURE, 1)
+                != MMAL_SUCCESS) {
+            MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "MMAL camera capture start failed");
+            retval = MMALCAM_ERROR;
+        }
+    }
+
+    if (retval == 0) {
+        retval = send_pooled_buffers_to_port(mmalcam->camera_buffer_pool, mmalcam->camera_capture_port);
+    }
+
+    return retval;
+}
+
+/**
+ * mmalcam_cleanup
+ *
+ *      This routine shuts down any MMAL resources, then releases any allocated data
+ *      within the mmalcam context and frees the context itself.
+ *      This function is also called from motion_init if first time connection
+ *      fails and we start retrying until we get a valid first frame from the
+ *      camera.
+ *
+ * Parameters:
+ *
+ *      mmalcam          Pointer to a mmalcam context
+ *
+ * Returns:              Nothing.
+ *
+ */
+void mmalcam_cleanup(struct mmalcam_context *mmalcam)
+{
+    MOTION_LOG(ALR, TYPE_VIDEO, NO_ERRNO, "MMAL Camera cleanup");
+
+    if (mmalcam != NULL ) {
+        if (mmalcam->camera_component) {
+            check_disable_port(mmalcam->camera_capture_port);
+            mmal_component_disable(mmalcam->camera_component);
+            destroy_camera_buffer_structures(mmalcam);
+            destroy_camera_component(mmalcam);
+        }
+
+        if (mmalcam->camera_parameters) {
+            free(mmalcam->camera_parameters);
+        }
+
+        free(mmalcam);
+    }
+}
+
+/**
+ * mmalcam_next
+ *
+ *      This routine is called when the main 'motion' thread wants a new
+ *      frame of video.  It fetches the most recent frame available from
+ *      the Pi camera already in YUV420P, and returns it to motion.
+ *
+ * Parameters:
+ *      cnt             Pointer to the context for this thread
+ *      image           Pointer to a buffer for the returned image
+ *
+ * Returns:             Error code
+ */
+int mmalcam_next(struct context *cnt, unsigned char *map)
+{
+    mmalcam_context_ptr mmalcam;
+
+    if ((!cnt) || (!cnt->mmalcam))
+        return NETCAM_FATAL_ERROR;
+
+    mmalcam = cnt->mmalcam;
+
+    MMAL_BUFFER_HEADER_T *camera_buffer = mmal_queue_wait(mmalcam->camera_buffer_queue);
+
+    if (camera_buffer->cmd == 0 && (camera_buffer->flags & MMAL_BUFFER_HEADER_FLAG_FRAME_END)
+            && camera_buffer->length == cnt->imgs.size) {
+        mmal_buffer_header_mem_lock(camera_buffer);
+        memcpy(map, camera_buffer->data, cnt->imgs.size);
+        mmal_buffer_header_mem_unlock(camera_buffer);
+    } else {
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "%s: cmd %d flags %08x size %d/%d at %08x",
+                camera_buffer->cmd, camera_buffer->flags, camera_buffer->length, camera_buffer->alloc_size, camera_buffer->data);
+    }
+
+    mmal_buffer_header_release(camera_buffer);
+
+    if (mmalcam->camera_capture_port->is_enabled) {
+        MMAL_STATUS_T status;
+        MMAL_BUFFER_HEADER_T *new_buffer = mmal_queue_get(mmalcam->camera_buffer_pool->queue);
+
+        if (new_buffer) {
+            status = mmal_port_send_buffer(mmalcam->camera_capture_port, new_buffer);
+        }
+
+        if (!new_buffer || status != MMAL_SUCCESS)
+            MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "Unable to return a buffer to the camera video port");
+    }
+
+    if (cnt->rotate_data.degrees > 0)
+        rotate_map(cnt, map);
+
+    return 0;
+}

--- a/mmalcam.h
+++ b/mmalcam.h
@@ -1,0 +1,34 @@
+/*
+ * mmalcam.h
+ *
+ *    Include file for mmalcam.c
+ *
+ *    Copyright 2013 by Nicholas Tuckett
+ *    This software is distributed under the GNU public license version 2
+ *    See also the file 'COPYING'.
+ */
+
+#ifndef MMALCAM_H_
+#define MMALCAM_H_
+
+typedef struct mmalcam_context *mmalcam_context_ptr;
+
+typedef struct mmalcam_context {
+    struct context *cnt;        /* pointer to parent motion
+                                   context structure */
+    int width;
+    int height;
+    int framerate;
+
+    struct MMAL_COMPONENT_T *camera_component;
+    struct MMAL_PORT_T *camera_capture_port;
+    struct MMAL_POOL_T *camera_buffer_pool;
+    struct MMAL_QUEUE_T *camera_buffer_queue;
+    struct raspicam_camera_parameters_s *camera_parameters;
+} mmalcam_context;
+
+int mmalcam_start (struct context *);
+int mmalcam_next (struct context *, unsigned char *);
+void mmalcam_cleanup (struct mmalcam_context *);
+
+#endif /* MMALCAM_H_ */

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -140,6 +140,14 @@ netcam_tolerant_check off
 # Default: on
 rtsp_uses_tcp on
 
+# Name of camera to use if you are using a camera accessed through OpenMax/MMAL
+# Default: Not defined
+; mmalcam_name vc.ril.camera
+
+# Camera control parameters (see raspivid/raspistill tool documentation)
+# Default: Not defined
+; mmalcam_control_params -hf
+
 # Let motion regulate the brightness of a video device (default: off).
 # The auto_brightness feature uses the brightness option as its target value.
 # If brightness is zero auto_brightness will adjust to average brightness value 128.

--- a/motion.h
+++ b/motion.h
@@ -218,6 +218,10 @@ struct images;
 #include "track.h"
 #include "netcam.h"
 
+#ifdef HAVE_MMAL
+#include "mmalcam.h"
+#endif
+
 /* 
  * Structure to hold images information
  * The idea is that this should have all information about a picture e.g. diffs, timestamp etc.
@@ -353,6 +357,9 @@ struct context {
     struct images imgs;
     struct trackoptions track;
     struct netcam_context *netcam;
+#ifdef HAVE_MMAL
+    struct mmalcam_context *mmalcam;
+#endif
     struct image_data *current_image;        /* Pointer to a structure where the image, diffs etc is stored */
     unsigned int new_img;
 

--- a/raspicam/README.txt
+++ b/raspicam/README.txt
@@ -1,0 +1,11 @@
+The files in this directory are used in the MMAL/RaspberryPI camera
+support code. The files were taken from the Raspberry PI userland git
+repository:
+
+https://github.com/raspberrypi/userland
+
+The files are unchanged from the userland versions.
+
+They are used to parse an options string and setup the camera
+parameters appropriately. The format of the string is the same as
+other raspberry pi camera tools.

--- a/raspicam/RaspiCLI.c
+++ b/raspicam/RaspiCLI.c
@@ -1,0 +1,155 @@
+/*
+Copyright (c) 2013, Broadcom Europe Ltd
+Copyright (c) 2013, James Hughes
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/**
+ * \file RaspiCLI.c
+ * Code for handling command line parameters
+ *
+ * \date 4th March 2013
+ * \Author: James Hughes
+ *
+ * Description
+ *
+ * Some functions/structures for command line parameter parsing
+ *
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <memory.h>
+
+#include "interface/vcos/vcos.h"
+
+#include "RaspiCLI.h"
+
+
+/**
+ * Convert a string from command line to a comand_id from the list
+ *
+ * @param commands Array of command to check
+ * @param num_command Number of commands in the array
+ * @param arg String to search for in the list
+ * @param num_parameters Returns the number of parameters used by the command
+ *
+ * @return command ID if found, -1 if not found
+ *
+ */
+int raspicli_get_command_id(const COMMAND_LIST *commands, const int num_commands, const char *arg, int *num_parameters)
+{
+   int command_id = -1;
+   int j;
+
+   vcos_assert(commands);
+   vcos_assert(num_parameters);
+   vcos_assert(arg);
+
+   if (!commands || !num_parameters || !arg)
+      return -1;
+
+   for (j = 0; j < num_commands; j++)
+   {
+      if (!strcmp(arg, commands[j].command) ||
+          !strcmp(arg, commands[j].abbrev))
+      {
+         // match
+         command_id = commands[j].id;
+         *num_parameters = commands[j].num_parameters;
+         break;
+      }
+   }
+
+   return command_id;
+}
+
+
+/**
+ * Display the list of commands in help format
+ *
+ * @param commands Array of command to check
+ * @param num_command Number of commands in the arry
+ *
+ *
+ */
+void raspicli_display_help(const COMMAND_LIST *commands, const int num_commands)
+{
+   int i;
+
+   vcos_assert(commands);
+
+   if (!commands)
+      return;
+
+   for (i = 0; i < num_commands; i++)
+   {
+      fprintf(stdout, "-%s, -%s\t: %s\n", commands[i].abbrev,
+         commands[i].command, commands[i].help);
+   }
+}
+
+
+/**
+ * Function to take a string, a mapping, and return the int equivalent
+ * @param str Incoming string to match
+ * @param map Mapping data
+ * @param num_refs The number of items in the mapping data
+ * @return The integer match for the string, or -1 if no match
+ */
+int raspicli_map_xref(const char *str, const XREF_T *map, int num_refs)
+{
+   int i;
+
+   for (i=0;i<num_refs;i++)
+   {
+      if (!strcasecmp(str, map[i].mode))
+      {
+         return map[i].mmal_mode;
+      }
+   }
+   return -1;
+}
+
+/**
+ * Function to take a mmal enum (as int) and return the string equivalent
+ * @param en Incoming int to match
+ * @param map Mapping data
+ * @param num_refs The number of items in the mapping data
+ * @return const pointer to string, or NULL if no match
+ */
+const char *raspicli_unmap_xref(const int en, XREF_T *map, int num_refs)
+{
+   int i;
+
+   for (i=0;i<num_refs;i++)
+   {
+      if (en == map[i].mmal_mode)
+      {
+         return map[i].mode;
+      }
+   }
+   return NULL;
+}

--- a/raspicam/RaspiCLI.h
+++ b/raspicam/RaspiCLI.h
@@ -1,0 +1,56 @@
+/*
+Copyright (c) 2013, Broadcom Europe Ltd
+Copyright (c) 2013, James Hughes
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef RASPICLI_H_
+#define RASPICLI_H_
+
+typedef struct
+{
+   int id;
+   char *command;
+   char *abbrev;
+   char *help;
+   int num_parameters;
+} COMMAND_LIST;
+
+/// Cross reference structure, mode string against mode id
+typedef struct xref_t
+{
+   char *mode;
+   int mmal_mode;
+} XREF_T;
+
+
+void raspicli_display_help(const COMMAND_LIST *commands, const int num_commands);
+int raspicli_get_command_id(const COMMAND_LIST *commands, const int num_commands, const char *arg, int *num_parameters);
+
+int raspicli_map_xref(const char *str, const XREF_T *map, int num_refs);
+const char *raspicli_unmap_xref(const int en, XREF_T *map, int num_refs);
+
+
+#endif

--- a/raspicam/RaspiCamControl.c
+++ b/raspicam/RaspiCamControl.c
@@ -1,0 +1,1568 @@
+/*
+Copyright (c) 2013, Broadcom Europe Ltd
+Copyright (c) 2013, James Hughes
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <stdio.h>
+#include <memory.h>
+#include <ctype.h>
+
+#include "interface/vcos/vcos.h"
+
+#include "interface/vmcs_host/vc_vchi_gencmd.h"
+#include "interface/mmal/mmal.h"
+#include "interface/mmal/mmal_logging.h"
+#include "interface/mmal/util/mmal_util.h"
+#include "interface/mmal/util/mmal_util_params.h"
+#include "interface/mmal/util/mmal_default_components.h"
+#include "RaspiCamControl.h"
+#include "RaspiCLI.h"
+
+/// Structure to cross reference exposure strings against the MMAL parameter equivalent
+static XREF_T  exposure_map[] =
+{
+   {"off",           MMAL_PARAM_EXPOSUREMODE_OFF},
+   {"auto",          MMAL_PARAM_EXPOSUREMODE_AUTO},
+   {"night",         MMAL_PARAM_EXPOSUREMODE_NIGHT},
+   {"nightpreview",  MMAL_PARAM_EXPOSUREMODE_NIGHTPREVIEW},
+   {"backlight",     MMAL_PARAM_EXPOSUREMODE_BACKLIGHT},
+   {"spotlight",     MMAL_PARAM_EXPOSUREMODE_SPOTLIGHT},
+   {"sports",        MMAL_PARAM_EXPOSUREMODE_SPORTS},
+   {"snow",          MMAL_PARAM_EXPOSUREMODE_SNOW},
+   {"beach",         MMAL_PARAM_EXPOSUREMODE_BEACH},
+   {"verylong",      MMAL_PARAM_EXPOSUREMODE_VERYLONG},
+   {"fixedfps",      MMAL_PARAM_EXPOSUREMODE_FIXEDFPS},
+   {"antishake",     MMAL_PARAM_EXPOSUREMODE_ANTISHAKE},
+   {"fireworks",     MMAL_PARAM_EXPOSUREMODE_FIREWORKS}
+};
+
+static const int exposure_map_size = sizeof(exposure_map) / sizeof(exposure_map[0]);
+
+/// Structure to cross reference awb strings against the MMAL parameter equivalent
+static XREF_T awb_map[] =
+{
+   {"off",           MMAL_PARAM_AWBMODE_OFF},
+   {"auto",          MMAL_PARAM_AWBMODE_AUTO},
+   {"sun",           MMAL_PARAM_AWBMODE_SUNLIGHT},
+   {"cloud",         MMAL_PARAM_AWBMODE_CLOUDY},
+   {"shade",         MMAL_PARAM_AWBMODE_SHADE},
+   {"tungsten",      MMAL_PARAM_AWBMODE_TUNGSTEN},
+   {"fluorescent",   MMAL_PARAM_AWBMODE_FLUORESCENT},
+   {"incandescent",  MMAL_PARAM_AWBMODE_INCANDESCENT},
+   {"flash",         MMAL_PARAM_AWBMODE_FLASH},
+   {"horizon",       MMAL_PARAM_AWBMODE_HORIZON}
+};
+
+static const int awb_map_size = sizeof(awb_map) / sizeof(awb_map[0]);
+
+/// Structure to cross reference image effect against the MMAL parameter equivalent
+static XREF_T imagefx_map[] =
+{
+   {"none",          MMAL_PARAM_IMAGEFX_NONE},
+   {"negative",      MMAL_PARAM_IMAGEFX_NEGATIVE},
+   {"solarise",      MMAL_PARAM_IMAGEFX_SOLARIZE},
+   {"sketch",        MMAL_PARAM_IMAGEFX_SKETCH},
+   {"denoise",       MMAL_PARAM_IMAGEFX_DENOISE},
+   {"emboss",        MMAL_PARAM_IMAGEFX_EMBOSS},
+   {"oilpaint",      MMAL_PARAM_IMAGEFX_OILPAINT},
+   {"hatch",         MMAL_PARAM_IMAGEFX_HATCH},
+   {"gpen",          MMAL_PARAM_IMAGEFX_GPEN},
+   {"pastel",        MMAL_PARAM_IMAGEFX_PASTEL},
+   {"watercolour",   MMAL_PARAM_IMAGEFX_WATERCOLOUR},
+   {"film",          MMAL_PARAM_IMAGEFX_FILM},
+   {"blur",          MMAL_PARAM_IMAGEFX_BLUR},
+   {"saturation",    MMAL_PARAM_IMAGEFX_SATURATION},
+   {"colourswap",    MMAL_PARAM_IMAGEFX_COLOURSWAP},
+   {"washedout",     MMAL_PARAM_IMAGEFX_WASHEDOUT},
+   {"posterise",     MMAL_PARAM_IMAGEFX_POSTERISE},
+   {"colourpoint",   MMAL_PARAM_IMAGEFX_COLOURPOINT},
+   {"colourbalance", MMAL_PARAM_IMAGEFX_COLOURBALANCE},
+   {"cartoon",       MMAL_PARAM_IMAGEFX_CARTOON}
+ };
+
+static const int imagefx_map_size = sizeof(imagefx_map) / sizeof(imagefx_map[0]);
+
+static XREF_T metering_mode_map[] =
+{
+   {"average",       MMAL_PARAM_EXPOSUREMETERINGMODE_AVERAGE},
+   {"spot",          MMAL_PARAM_EXPOSUREMETERINGMODE_SPOT},
+   {"backlit",       MMAL_PARAM_EXPOSUREMETERINGMODE_BACKLIT},
+   {"matrix",        MMAL_PARAM_EXPOSUREMETERINGMODE_MATRIX}
+};
+
+static const int metering_mode_map_size = sizeof(metering_mode_map)/sizeof(metering_mode_map[0]);
+
+static XREF_T drc_mode_map[] =
+{
+   {"off",           MMAL_PARAMETER_DRC_STRENGTH_OFF},
+   {"low",           MMAL_PARAMETER_DRC_STRENGTH_LOW},
+   {"med",           MMAL_PARAMETER_DRC_STRENGTH_MEDIUM},
+   {"high",          MMAL_PARAMETER_DRC_STRENGTH_HIGH}
+};
+
+static const int drc_mode_map_size = sizeof(drc_mode_map)/sizeof(drc_mode_map[0]);
+
+static XREF_T stereo_mode_map[] =
+{
+   {"off",           MMAL_STEREOSCOPIC_MODE_NONE},
+   {"sbs",           MMAL_STEREOSCOPIC_MODE_SIDE_BY_SIDE},
+   {"tb",            MMAL_STEREOSCOPIC_MODE_TOP_BOTTOM},
+};
+
+static const int stereo_mode_map_size = sizeof(stereo_mode_map)/sizeof(stereo_mode_map[0]);
+
+
+#define CommandSharpness   0
+#define CommandContrast    1
+#define CommandBrightness  2
+#define CommandSaturation  3
+#define CommandISO         4
+#define CommandVideoStab   5
+#define CommandEVComp      6
+#define CommandExposure    7
+#define CommandAWB         8
+#define CommandImageFX     9
+#define CommandColourFX    10
+#define CommandMeterMode   11
+#define CommandRotation    12
+#define CommandHFlip       13
+#define CommandVFlip       14
+#define CommandROI         15
+#define CommandShutterSpeed 16
+#define CommandAwbGains    17
+#define CommandDRCLevel    18
+#define CommandStatsPass   19
+#define CommandAnnotate    20
+#define CommandStereoMode  21
+#define CommandStereoDecimate 22
+#define CommandStereoSwap  23
+#define CommandAnnotateExtras 24
+
+static COMMAND_LIST  cmdline_commands[] =
+{
+   {CommandSharpness,   "-sharpness", "sh", "Set image sharpness (-100 to 100)",  1},
+   {CommandContrast,    "-contrast",  "co", "Set image contrast (-100 to 100)",  1},
+   {CommandBrightness,  "-brightness","br", "Set image brightness (0 to 100)",  1},
+   {CommandSaturation,  "-saturation","sa", "Set image saturation (-100 to 100)", 1},
+   {CommandISO,         "-ISO",       "ISO","Set capture ISO",  1},
+   {CommandVideoStab,   "-vstab",     "vs", "Turn on video stabilisation", 0},
+   {CommandEVComp,      "-ev",        "ev", "Set EV compensation - steps of 1/6 stop",  1},
+   {CommandExposure,    "-exposure",  "ex", "Set exposure mode (see Notes)", 1},
+   {CommandAWB,         "-awb",       "awb","Set AWB mode (see Notes)", 1},
+   {CommandImageFX,     "-imxfx",     "ifx","Set image effect (see Notes)", 1},
+   {CommandColourFX,    "-colfx",     "cfx","Set colour effect (U:V)",  1},
+   {CommandMeterMode,   "-metering",  "mm", "Set metering mode (see Notes)", 1},
+   {CommandRotation,    "-rotation",  "rot","Set image rotation (0-359)", 1},
+   {CommandHFlip,       "-hflip",     "hf", "Set horizontal flip", 0},
+   {CommandVFlip,       "-vflip",     "vf", "Set vertical flip", 0},
+   {CommandROI,         "-roi",       "roi","Set region of interest (x,y,w,d as normalised coordinates [0.0-1.0])", 1},
+   {CommandShutterSpeed,"-shutter",   "ss", "Set shutter speed in microseconds", 1},
+   {CommandAwbGains,    "-awbgains",  "awbg", "Set AWB gains - AWB mode must be off", 1},
+   {CommandDRCLevel,    "-drc",       "drc", "Set DRC Level (see Notes)", 1},
+   {CommandStatsPass,   "-stats",     "st", "Force recomputation of statistics on stills capture pass"},
+   {CommandAnnotate,    "-annotate",  "a",  "Enable/Set annotate flags or text", 1},
+   {CommandStereoMode,  "-stereo",    "3d", "Select stereoscopic mode", 1},
+   {CommandStereoDecimate,"-decimate","dec", "Half width/height of stereo image"},
+   {CommandStereoSwap,  "-3dswap",    "3dswap", "Swap camera order for stereoscopic"},
+   {CommandAnnotateExtras,"-annotateex","ae",  "Set extra annotation parameters (text size, text colour(hex YUV), bg colour(hex YUV))", 2},
+};
+
+static int cmdline_commands_size = sizeof(cmdline_commands) / sizeof(cmdline_commands[0]);
+
+
+#define parameter_reset -99999
+
+/**
+ * Update the passed in parameter according to the rest of the parameters
+ * passed in.
+ *
+ *
+ * @return 0 if reached end of cycle for this parameter, !0 otherwise
+ */
+static int update_cycle_parameter(int *option, int min, int max, int increment)
+{
+   vcos_assert(option);
+   if (!option)
+      return 0;
+
+   if (*option == parameter_reset)
+      *option = min - increment;
+
+   *option += increment;
+
+   if (*option > max)
+   {
+      *option = parameter_reset;
+      return 0;
+   }
+   else
+      return 1;
+}
+
+
+/**
+ * Test/Demo code to cycle through a bunch of camera settings
+ * This code is pretty hacky so please don't complain!!
+ * It only does stuff that should have a visual impact (hence demo!)
+ * This will override any user supplied parameters
+ *
+ * Each call of this function will move on to the next setting
+ *
+ * @param camera Pointer to the camera to change settings on.
+ * @return 0 if reached end of complete sequence, !0 otherwise
+ */
+
+int raspicamcontrol_cycle_test(MMAL_COMPONENT_T *camera)
+{
+   static int parameter = 0;
+   static int parameter_option = parameter_reset; // which value the parameter currently has
+
+   vcos_assert(camera);
+
+   // We are going to cycle through all the relevant entries in the parameter block
+   // and send options to the camera.
+   if (parameter == 0)
+   {
+      // sharpness
+      if (update_cycle_parameter(&parameter_option, -100, 100, 10))
+         raspicamcontrol_set_sharpness(camera, parameter_option);
+      else
+      {
+         raspicamcontrol_set_sharpness(camera, 0);
+         parameter++;
+      }
+   }
+   else
+   if (parameter == 1)
+   {
+      // contrast
+      if (update_cycle_parameter(&parameter_option, -100, 100, 10))
+         raspicamcontrol_set_contrast(camera, parameter_option);
+      else
+      {
+         raspicamcontrol_set_contrast(camera, 0);
+         parameter++;
+      }
+   }
+   else
+   if (parameter == 2)
+   {
+      // brightness
+      if (update_cycle_parameter(&parameter_option, 0, 100, 10))
+         raspicamcontrol_set_brightness(camera, parameter_option);
+      else
+      {
+         raspicamcontrol_set_brightness(camera, 50);
+         parameter++;
+      }
+   }
+   else
+   if (parameter == 3)
+   {
+      // contrast
+      if (update_cycle_parameter(&parameter_option, -100, 100, 10))
+         raspicamcontrol_set_saturation(camera, parameter_option);
+      else
+      {
+         parameter++;
+         raspicamcontrol_set_saturation(camera, 0);
+      }
+   }
+   else
+   if (parameter == 4)
+   {
+      // EV
+      if (update_cycle_parameter(&parameter_option, -10, 10, 4))
+         raspicamcontrol_set_exposure_compensation(camera, parameter_option);
+      else
+      {
+         raspicamcontrol_set_exposure_compensation(camera, 0);
+         parameter++;
+      }
+   }
+   else
+   if (parameter == 5)
+   {
+      // MMAL_PARAM_EXPOSUREMODE_T
+      if (update_cycle_parameter(&parameter_option, 0, exposure_map_size, 1))
+         raspicamcontrol_set_exposure_mode(camera, exposure_map[parameter_option].mmal_mode);
+      else
+      {
+         raspicamcontrol_set_exposure_mode(camera, MMAL_PARAM_EXPOSUREMODE_AUTO);
+         parameter++;
+      }
+   }
+   else
+   if (parameter == 6)
+   {
+      // MMAL_PARAM_AWB_T
+      if (update_cycle_parameter(&parameter_option, 0, awb_map_size, 1))
+         raspicamcontrol_set_awb_mode(camera, awb_map[parameter_option].mmal_mode);
+      else
+      {
+         raspicamcontrol_set_awb_mode(camera, MMAL_PARAM_AWBMODE_AUTO);
+         parameter++;
+      }
+   }
+   if (parameter == 7)
+   {
+      // MMAL_PARAM_IMAGEFX_T
+      if (update_cycle_parameter(&parameter_option, 0, imagefx_map_size, 1))
+         raspicamcontrol_set_imageFX(camera, imagefx_map[parameter_option].mmal_mode);
+      else
+      {
+         raspicamcontrol_set_imageFX(camera, MMAL_PARAM_IMAGEFX_NONE);
+         parameter++;
+      }
+   }
+   if (parameter == 8)
+   {
+      MMAL_PARAM_COLOURFX_T colfx = {0,0,0};
+      switch (parameter_option)
+      {
+         case parameter_reset :
+            parameter_option = 1;
+            colfx.u = 128;
+            colfx.v = 128;
+            break;
+         case 1 :
+            parameter_option = 2;
+            colfx.u = 100;
+            colfx.v = 200;
+            break;
+         case 2 :
+            parameter_option = parameter_reset;
+            colfx.enable = 0;
+            parameter++;
+            break;
+      }
+      raspicamcontrol_set_colourFX(camera, &colfx);
+   }
+
+   // Orientation
+   if (parameter == 9)
+   {
+      switch (parameter_option)
+      {
+      case parameter_reset:
+         raspicamcontrol_set_rotation(camera, 90);
+         parameter_option = 1;
+         break;
+
+      case 1 :
+         raspicamcontrol_set_rotation(camera, 180);
+         parameter_option = 2;
+         break;
+
+      case 2 :
+         raspicamcontrol_set_rotation(camera, 270);
+         parameter_option = 3;
+         break;
+
+      case 3 :
+      {
+         raspicamcontrol_set_rotation(camera, 0);
+         raspicamcontrol_set_flips(camera, 1,0);
+         parameter_option = 4;
+         break;
+      }
+      case 4 :
+      {
+         raspicamcontrol_set_flips(camera, 0,1);
+         parameter_option = 5;
+         break;
+      }
+      case 5 :
+      {
+         raspicamcontrol_set_flips(camera, 1, 1);
+         parameter_option = 6;
+         break;
+      }
+      case 6 :
+      {
+         raspicamcontrol_set_flips(camera, 0, 0);
+         parameter_option = parameter_reset;
+         parameter++;
+         break;
+      }
+      }
+   }
+
+   if (parameter == 10)
+   {
+      parameter = 1;
+      return 0;
+   }
+
+   return 1;
+}
+
+
+
+/**
+ * Convert string to the MMAL parameter for exposure mode
+ * @param str Incoming string to match
+ * @return MMAL parameter matching the string, or the AUTO option if no match found
+ */
+static MMAL_PARAM_EXPOSUREMODE_T exposure_mode_from_string(const char *str)
+{
+   int i = raspicli_map_xref(str, exposure_map, exposure_map_size);
+
+   if( i != -1)
+      return (MMAL_PARAM_EXPOSUREMODE_T)i;
+
+   vcos_log_error("Unknown exposure mode: %s", str);
+   return MMAL_PARAM_EXPOSUREMODE_AUTO;
+}
+
+/**
+ * Convert string to the MMAL parameter for AWB mode
+ * @param str Incoming string to match
+ * @return MMAL parameter matching the string, or the AUTO option if no match found
+ */
+static MMAL_PARAM_AWBMODE_T awb_mode_from_string(const char *str)
+{
+   int i = raspicli_map_xref(str, awb_map, awb_map_size);
+
+   if( i != -1)
+      return (MMAL_PARAM_AWBMODE_T)i;
+
+   vcos_log_error("Unknown awb mode: %s", str);
+   return MMAL_PARAM_AWBMODE_AUTO;
+}
+
+/**
+ * Convert string to the MMAL parameter for image effects mode
+ * @param str Incoming string to match
+ * @return MMAL parameter matching the strong, or the AUTO option if no match found
+ */
+MMAL_PARAM_IMAGEFX_T imagefx_mode_from_string(const char *str)
+{
+   int i = raspicli_map_xref(str, imagefx_map, imagefx_map_size);
+
+   if( i != -1)
+     return (MMAL_PARAM_IMAGEFX_T)i;
+
+   vcos_log_error("Unknown image fx: %s", str);
+   return MMAL_PARAM_IMAGEFX_NONE;
+}
+
+/**
+ * Convert string to the MMAL parameter for exposure metering mode
+ * @param str Incoming string to match
+ * @return MMAL parameter matching the string, or the AUTO option if no match found
+ */
+static MMAL_PARAM_EXPOSUREMETERINGMODE_T metering_mode_from_string(const char *str)
+{
+   int i = raspicli_map_xref(str, metering_mode_map, metering_mode_map_size);
+
+   if( i != -1)
+      return (MMAL_PARAM_EXPOSUREMETERINGMODE_T)i;
+
+   vcos_log_error("Unknown metering mode: %s", str);
+   return MMAL_PARAM_EXPOSUREMETERINGMODE_AVERAGE;
+}
+
+/**
+ * Convert string to the MMAL parameter for DRC level
+ * @param str Incoming string to match
+ * @return MMAL parameter matching the string, or the AUTO option if no match found
+ */
+static MMAL_PARAMETER_DRC_STRENGTH_T drc_mode_from_string(const char *str)
+{
+   int i = raspicli_map_xref(str, drc_mode_map, drc_mode_map_size);
+
+   if( i != -1)
+      return (MMAL_PARAMETER_DRC_STRENGTH_T)i;
+
+   vcos_log_error("Unknown DRC level: %s", str);
+   return MMAL_PARAMETER_DRC_STRENGTH_OFF;
+}
+
+/**
+ * Convert string to the MMAL parameter for exposure metering mode
+ * @param str Incoming string to match
+ * @return MMAL parameter matching the string, or the AUTO option if no match found
+ */
+static MMAL_STEREOSCOPIC_MODE_T stereo_mode_from_string(const char *str)
+{
+   int i = raspicli_map_xref(str, stereo_mode_map, stereo_mode_map_size);
+
+   if( i != -1)
+      return (MMAL_STEREOSCOPIC_MODE_T)i;
+
+   vcos_log_error("Unknown metering mode: %s", str);
+   return MMAL_STEREOSCOPIC_MODE_NONE;
+}
+
+/**
+ * Parse a possible command pair - command and parameter
+ * @param arg1 Command
+ * @param arg2 Parameter (could be NULL)
+ * @return How many parameters were used, 0,1,2
+ */
+int raspicamcontrol_parse_cmdline(RASPICAM_CAMERA_PARAMETERS *params, const char *arg1, const char *arg2)
+{
+   int command_id, used = 0, num_parameters;
+
+   if (!arg1)
+       return 0;
+
+   command_id = raspicli_get_command_id(cmdline_commands, cmdline_commands_size, arg1, &num_parameters);
+
+   // If invalid command, or we are missing a parameter, drop out
+   if (command_id==-1 || (command_id != -1 && num_parameters > 0 && arg2 == NULL))
+      return 0;
+
+   switch (command_id)
+   {
+   case CommandSharpness : // sharpness - needs single number parameter
+      sscanf(arg2, "%d", &params->sharpness);
+      used = 2;
+      break;
+
+   case CommandContrast : // contrast - needs single number parameter
+      sscanf(arg2, "%d", &params->contrast);
+      used = 2;
+      break;
+
+   case CommandBrightness : // brightness - needs single number parameter
+      sscanf(arg2, "%d", &params->brightness);
+      used = 2;
+      break;
+
+   case CommandSaturation : // saturation - needs single number parameter
+      sscanf(arg2, "%d", &params->saturation);
+      used = 2;
+      break;
+
+   case CommandISO : // ISO - needs single number parameter
+      sscanf(arg2, "%d", &params->ISO);
+      used = 2;
+      break;
+
+   case CommandVideoStab : // video stabilisation - if here, its on
+      params->videoStabilisation = 1;
+      used = 1;
+      break;
+
+   case CommandEVComp : // EV - needs single number parameter
+      sscanf(arg2, "%d", &params->exposureCompensation);
+      used = 2;
+      break;
+
+   case CommandExposure : // exposure mode - needs string
+      params->exposureMode = exposure_mode_from_string(arg2);
+      used = 2;
+      break;
+
+   case CommandAWB : // AWB mode - needs single number parameter
+      params->awbMode = awb_mode_from_string(arg2);
+      used = 2;
+      break;
+
+   case CommandImageFX : // Image FX - needs string
+      params->imageEffect = imagefx_mode_from_string(arg2);
+      used = 2;
+      break;
+
+   case CommandColourFX : // Colour FX - needs string "u:v"
+      sscanf(arg2, "%d:%d", &params->colourEffects.u, &params->colourEffects.v);
+      params->colourEffects.enable = 1;
+      used = 2;
+      break;
+
+   case CommandMeterMode:
+      params->exposureMeterMode = metering_mode_from_string(arg2);
+      used = 2;
+      break;
+
+   case CommandRotation : // Rotation - degree
+      sscanf(arg2, "%d", &params->rotation);
+      used = 2;
+      break;
+
+   case CommandHFlip :
+      params->hflip  = 1;
+      used = 1;
+      break;
+
+   case CommandVFlip :
+      params->vflip = 1;
+      used = 1;
+      break;
+
+   case CommandROI :
+   {
+      double x,y,w,h;
+      int args;
+
+      args = sscanf(arg2, "%lf,%lf,%lf,%lf", &x,&y,&w,&h);
+
+      if (args != 4 || x > 1.0 || y > 1.0 || w > 1.0 || h > 1.0)
+      {
+         return 0;
+      }
+
+      // Make sure we stay within bounds
+      if (x + w > 1.0)
+         w = 1 - x;
+
+      if (y + h > 1.0)
+         h = 1 - y;
+
+      params->roi.x = x;
+      params->roi.y = y;
+      params->roi.w = w;
+      params->roi.h = h;
+
+      used = 2;
+      break;
+   }
+
+   case CommandShutterSpeed : // Shutter speed needs single number parameter
+   {
+      sscanf(arg2, "%d", &params->shutter_speed);
+      used = 2;
+      break;
+   }
+
+   case CommandAwbGains :
+      {
+      double r,b;
+      int args;
+
+      args = sscanf(arg2, "%lf,%lf", &r,&b);
+
+      if (args != 2 || r > 8.0 || b > 8.0)
+      {
+         return 0;
+      }
+
+      params->awb_gains_r = r;
+      params->awb_gains_b = b;
+
+      used = 2;
+      break;
+      }
+
+   case CommandDRCLevel:
+   {
+      params->drc_level = drc_mode_from_string(arg2);
+      used = 2;
+      break;
+   }
+
+   case CommandStatsPass:
+   {
+      params->stats_pass = MMAL_TRUE;
+      used = 1;
+      break;
+   }
+
+   case CommandAnnotate:
+   {
+      char dummy;
+      unsigned int bitmask;
+      // If parameter is a number, assume its a bitmask, otherwise a string
+      if (sscanf(arg2, "%u%c", &bitmask, &dummy) == 1)
+      {
+         params->enable_annotate |= bitmask;
+      }
+      else
+      {
+         params->enable_annotate |= ANNOTATE_USER_TEXT;
+         //copy string char by char and replace "\n" with newline character
+         unsigned char c;
+         char const *s = arg2;
+         char *t = &params->annotate_string[0];
+         int n=0;
+         while ((c = *s++) && n < MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3-1)
+         {
+            if (c == '\\' && *s)
+            {
+               switch (c = *s++)
+               {
+                  case 'n':
+                  c = '\n';
+                  break;
+
+                  default:
+                  c = '\\';
+                  s--;
+                  break;
+               }
+            }
+            *(t++) = c;
+            n++;
+         }
+         *t='\0';
+
+         //params->annotate_string[MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3-1] = '\0';
+      }
+      used=2;
+      break;
+   }
+
+   case CommandAnnotateExtras:
+   {
+      // 3 parameters - text size (6-80), text colour (Hex VVUUYY) and background colour (Hex VVUUYY)
+      sscanf(arg2, "%u,%X,%X", &params->annotate_text_size,
+                               &params->annotate_text_colour,
+                               &params->annotate_bg_colour);
+      used=2;
+      break;
+   }
+
+   case CommandStereoMode:
+   {
+      params->stereo_mode.mode = stereo_mode_from_string(arg2);
+      used = 2;
+      break;
+   }
+
+   case CommandStereoDecimate:
+   {
+      params->stereo_mode.decimate = MMAL_TRUE;
+      used = 1;
+      break;
+   }
+
+   case CommandStereoSwap:
+   {
+      params->stereo_mode.swap_eyes = MMAL_TRUE;
+      used = 1;
+      break;
+   }
+
+   }
+
+   return used;
+}
+
+/**
+ * Display help for command line options
+ */
+void raspicamcontrol_display_help()
+{
+   int i;
+
+   fprintf(stdout, "\nImage parameter commands\n\n");
+
+   raspicli_display_help(cmdline_commands, cmdline_commands_size);
+
+   fprintf(stdout, "\n\nNotes\n\nExposure mode options :\n%s", exposure_map[0].mode );
+
+   for (i=1;i<exposure_map_size;i++)
+   {
+      fprintf(stdout, ",%s", exposure_map[i].mode);
+   }
+
+   fprintf(stdout, "\n\nAWB mode options :\n%s", awb_map[0].mode );
+
+   for (i=1;i<awb_map_size;i++)
+   {
+      fprintf(stdout, ",%s", awb_map[i].mode);
+   }
+
+   fprintf(stdout, "\n\nImage Effect mode options :\n%s", imagefx_map[0].mode );
+
+   for (i=1;i<imagefx_map_size;i++)
+   {
+      fprintf(stdout, ",%s", imagefx_map[i].mode);
+   }
+
+   fprintf(stdout, "\n\nMetering Mode options :\n%s", metering_mode_map[0].mode );
+
+   for (i=1;i<metering_mode_map_size;i++)
+   {
+      fprintf(stdout, ",%s", metering_mode_map[i].mode);
+   }
+
+   fprintf(stdout, "\n\nDynamic Range Compression (DRC) options :\n%s", drc_mode_map[0].mode );
+
+   for (i=1;i<drc_mode_map_size;i++)
+   {
+      fprintf(stdout, ",%s", drc_mode_map[i].mode);
+   }
+
+   fprintf(stdout, "\n");
+}
+
+
+/**
+ * Dump contents of camera parameter structure to stderr for debugging/verbose logging
+ *
+ * @param params Const pointer to parameters structure to dump
+ */
+void raspicamcontrol_dump_parameters(const RASPICAM_CAMERA_PARAMETERS *params)
+{
+   const char *exp_mode = raspicli_unmap_xref(params->exposureMode, exposure_map, exposure_map_size);
+   const char *awb_mode = raspicli_unmap_xref(params->awbMode, awb_map, awb_map_size);
+   const char *image_effect = raspicli_unmap_xref(params->imageEffect, imagefx_map, imagefx_map_size);
+   const char *metering_mode = raspicli_unmap_xref(params->exposureMeterMode, metering_mode_map, metering_mode_map_size);
+
+   fprintf(stderr, "Sharpness %d, Contrast %d, Brightness %d\n", params->sharpness, params->contrast, params->brightness);
+   fprintf(stderr, "Saturation %d, ISO %d, Video Stabilisation %s, Exposure compensation %d\n", params->saturation, params->ISO, params->videoStabilisation ? "Yes": "No", params->exposureCompensation);
+   fprintf(stderr, "Exposure Mode '%s', AWB Mode '%s', Image Effect '%s'\n", exp_mode, awb_mode, image_effect);
+   fprintf(stderr, "Metering Mode '%s', Colour Effect Enabled %s with U = %d, V = %d\n", metering_mode, params->colourEffects.enable ? "Yes":"No", params->colourEffects.u, params->colourEffects.v);
+   fprintf(stderr, "Rotation %d, hflip %s, vflip %s\n", params->rotation, params->hflip ? "Yes":"No",params->vflip ? "Yes":"No");
+   fprintf(stderr, "ROI x %lf, y %f, w %f h %f\n", params->roi.x, params->roi.y, params->roi.w, params->roi.h);
+}
+
+/**
+ * Convert a MMAL status return value to a simple boolean of success
+ * ALso displays a fault if code is not success
+ *
+ * @param status The error code to convert
+ * @return 0 if status is success, 1 otherwise
+ */
+int mmal_status_to_int(MMAL_STATUS_T status)
+{
+   if (status == MMAL_SUCCESS)
+      return 0;
+   else
+   {
+      switch (status)
+      {
+      case MMAL_ENOMEM :   vcos_log_error("Out of memory"); break;
+      case MMAL_ENOSPC :   vcos_log_error("Out of resources (other than memory)"); break;
+      case MMAL_EINVAL:    vcos_log_error("Argument is invalid"); break;
+      case MMAL_ENOSYS :   vcos_log_error("Function not implemented"); break;
+      case MMAL_ENOENT :   vcos_log_error("No such file or directory"); break;
+      case MMAL_ENXIO :    vcos_log_error("No such device or address"); break;
+      case MMAL_EIO :      vcos_log_error("I/O error"); break;
+      case MMAL_ESPIPE :   vcos_log_error("Illegal seek"); break;
+      case MMAL_ECORRUPT : vcos_log_error("Data is corrupt \attention FIXME: not POSIX"); break;
+      case MMAL_ENOTREADY :vcos_log_error("Component is not ready \attention FIXME: not POSIX"); break;
+      case MMAL_ECONFIG :  vcos_log_error("Component is not configured \attention FIXME: not POSIX"); break;
+      case MMAL_EISCONN :  vcos_log_error("Port is already connected "); break;
+      case MMAL_ENOTCONN : vcos_log_error("Port is disconnected"); break;
+      case MMAL_EAGAIN :   vcos_log_error("Resource temporarily unavailable. Try again later"); break;
+      case MMAL_EFAULT :   vcos_log_error("Bad address"); break;
+      default :            vcos_log_error("Unknown status error"); break;
+      }
+
+      return 1;
+   }
+}
+
+/**
+ * Give the supplied parameter block a set of default values
+ * @params Pointer to parameter block
+ */
+void raspicamcontrol_set_defaults(RASPICAM_CAMERA_PARAMETERS *params)
+{
+   vcos_assert(params);
+
+   params->sharpness = 0;
+   params->contrast = 0;
+   params->brightness = 50;
+   params->saturation = 0;
+   params->ISO = 0;                    // 0 = auto
+   params->videoStabilisation = 0;
+   params->exposureCompensation = 0;
+   params->exposureMode = MMAL_PARAM_EXPOSUREMODE_AUTO;
+   params->exposureMeterMode = MMAL_PARAM_EXPOSUREMETERINGMODE_AVERAGE;
+   params->awbMode = MMAL_PARAM_AWBMODE_AUTO;
+   params->imageEffect = MMAL_PARAM_IMAGEFX_NONE;
+   params->colourEffects.enable = 0;
+   params->colourEffects.u = 128;
+   params->colourEffects.v = 128;
+   params->rotation = 0;
+   params->hflip = params->vflip = 0;
+   params->roi.x = params->roi.y = 0.0;
+   params->roi.w = params->roi.h = 1.0;
+   params->shutter_speed = 0;          // 0 = auto
+   params->awb_gains_r = 0;      // Only have any function if AWB OFF is used.
+   params->awb_gains_b = 0;
+   params->drc_level = MMAL_PARAMETER_DRC_STRENGTH_OFF;
+   params->stats_pass = MMAL_FALSE;
+   params->enable_annotate = 0;
+   params->annotate_string[0] = '\0';
+   params->annotate_text_size = 0;	//Use firmware default
+   params->annotate_text_colour = -1;   //Use firmware default
+   params->annotate_bg_colour = -1;     //Use firmware default
+   params->stereo_mode.mode = MMAL_STEREOSCOPIC_MODE_NONE;
+   params->stereo_mode.decimate = MMAL_FALSE;
+   params->stereo_mode.swap_eyes = MMAL_FALSE;
+}
+
+/**
+ * Get all the current camera parameters from specified camera component
+ * @param camera Pointer to camera component
+ * @param params Pointer to parameter block to accept settings
+ * @return 0 if successful, non-zero if unsuccessful
+ */
+int raspicamcontrol_get_all_parameters(MMAL_COMPONENT_T *camera, RASPICAM_CAMERA_PARAMETERS *params)
+{
+   vcos_assert(camera);
+   vcos_assert(params);
+
+   if (!camera || !params)
+      return 1;
+
+/* TODO : Write these get functions
+   params->sharpness = raspicamcontrol_get_sharpness(camera);
+   params->contrast = raspicamcontrol_get_contrast(camera);
+   params->brightness = raspicamcontrol_get_brightness(camera);
+   params->saturation = raspicamcontrol_get_saturation(camera);
+   params->ISO = raspicamcontrol_get_ISO(camera);
+   params->videoStabilisation = raspicamcontrol_get_video_stabilisation(camera);
+   params->exposureCompensation = raspicamcontrol_get_exposure_compensation(camera);
+   params->exposureMode = raspicamcontrol_get_exposure_mode(camera);
+   params->awbMode = raspicamcontrol_get_awb_mode(camera);
+   params->imageEffect = raspicamcontrol_get_image_effect(camera);
+   params->colourEffects = raspicamcontrol_get_colour_effect(camera);
+   params->thumbnailConfig = raspicamcontrol_get_thumbnail_config(camera);
+*/
+   return 0;
+}
+
+/**
+ * Set the specified camera to all the specified settings
+ * @param camera Pointer to camera component
+ * @param params Pointer to parameter block containing parameters
+ * @return 0 if successful, none-zero if unsuccessful.
+ */
+int raspicamcontrol_set_all_parameters(MMAL_COMPONENT_T *camera, const RASPICAM_CAMERA_PARAMETERS *params)
+{
+   int result;
+
+   result  = raspicamcontrol_set_saturation(camera, params->saturation);
+   result += raspicamcontrol_set_sharpness(camera, params->sharpness);
+   result += raspicamcontrol_set_contrast(camera, params->contrast);
+   result += raspicamcontrol_set_brightness(camera, params->brightness);
+   result += raspicamcontrol_set_ISO(camera, params->ISO);
+   result += raspicamcontrol_set_video_stabilisation(camera, params->videoStabilisation);
+   result += raspicamcontrol_set_exposure_compensation(camera, params->exposureCompensation);
+   result += raspicamcontrol_set_exposure_mode(camera, params->exposureMode);
+   result += raspicamcontrol_set_metering_mode(camera, params->exposureMeterMode);
+   result += raspicamcontrol_set_awb_mode(camera, params->awbMode);
+   result += raspicamcontrol_set_awb_gains(camera, params->awb_gains_r, params->awb_gains_b);
+   result += raspicamcontrol_set_imageFX(camera, params->imageEffect);
+   result += raspicamcontrol_set_colourFX(camera, &params->colourEffects);
+   //result += raspicamcontrol_set_thumbnail_parameters(camera, &params->thumbnailConfig);  TODO Not working for some reason
+   result += raspicamcontrol_set_rotation(camera, params->rotation);
+   result += raspicamcontrol_set_flips(camera, params->hflip, params->vflip);
+   result += raspicamcontrol_set_ROI(camera, params->roi);
+   result += raspicamcontrol_set_shutter_speed(camera, params->shutter_speed);
+   result += raspicamcontrol_set_DRC(camera, params->drc_level);
+   result += raspicamcontrol_set_stats_pass(camera, params->stats_pass);
+   result += raspicamcontrol_set_annotate(camera, params->enable_annotate, params->annotate_string,
+                       params->annotate_text_size,
+                       params->annotate_text_colour,
+                       params->annotate_bg_colour);
+
+   return result;
+}
+
+/**
+ * Adjust the saturation level for images
+ * @param camera Pointer to camera component
+ * @param saturation Value to adjust, -100 to 100
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_saturation(MMAL_COMPONENT_T *camera, int saturation)
+{
+   int ret = 0;
+
+   if (!camera)
+      return 1;
+
+   if (saturation >= -100 && saturation <= 100)
+   {
+      MMAL_RATIONAL_T value = {saturation, 100};
+      ret = mmal_status_to_int(mmal_port_parameter_set_rational(camera->control, MMAL_PARAMETER_SATURATION, value));
+   }
+   else
+   {
+      vcos_log_error("Invalid saturation value");
+      ret = 1;
+   }
+
+   return ret;
+}
+
+/**
+ * Set the sharpness of the image
+ * @param camera Pointer to camera component
+ * @param sharpness Sharpness adjustment -100 to 100
+ */
+int raspicamcontrol_set_sharpness(MMAL_COMPONENT_T *camera, int sharpness)
+{
+   int ret = 0;
+
+   if (!camera)
+      return 1;
+
+   if (sharpness >= -100 && sharpness <= 100)
+   {
+      MMAL_RATIONAL_T value = {sharpness, 100};
+      ret = mmal_status_to_int(mmal_port_parameter_set_rational(camera->control, MMAL_PARAMETER_SHARPNESS, value));
+   }
+   else
+   {
+      vcos_log_error("Invalid sharpness value");
+      ret = 1;
+   }
+
+   return ret;
+}
+
+/**
+ * Set the contrast adjustment for the image
+ * @param camera Pointer to camera component
+ * @param contrast Contrast adjustment -100 to  100
+ * @return
+ */
+int raspicamcontrol_set_contrast(MMAL_COMPONENT_T *camera, int contrast)
+{
+   int ret = 0;
+
+   if (!camera)
+      return 1;
+
+   if (contrast >= -100 && contrast <= 100)
+   {
+      MMAL_RATIONAL_T value = {contrast, 100};
+      ret = mmal_status_to_int(mmal_port_parameter_set_rational(camera->control, MMAL_PARAMETER_CONTRAST, value));
+   }
+   else
+   {
+      vcos_log_error("Invalid contrast value");
+      ret = 1;
+   }
+
+   return ret;
+}
+
+/**
+ * Adjust the brightness level for images
+ * @param camera Pointer to camera component
+ * @param brightness Value to adjust, 0 to 100
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_brightness(MMAL_COMPONENT_T *camera, int brightness)
+{
+   int ret = 0;
+
+   if (!camera)
+      return 1;
+
+   if (brightness >= 0 && brightness <= 100)
+   {
+      MMAL_RATIONAL_T value = {brightness, 100};
+      ret = mmal_status_to_int(mmal_port_parameter_set_rational(camera->control, MMAL_PARAMETER_BRIGHTNESS, value));
+   }
+   else
+   {
+      vcos_log_error("Invalid brightness value");
+      ret = 1;
+   }
+
+   return ret;
+}
+
+/**
+ * Adjust the ISO used for images
+ * @param camera Pointer to camera component
+ * @param ISO Value to set TODO :
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_ISO(MMAL_COMPONENT_T *camera, int ISO)
+{
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set_uint32(camera->control, MMAL_PARAMETER_ISO, ISO));
+}
+
+/**
+ * Adjust the metering mode for images
+ * @param camera Pointer to camera component
+ * @param saturation Value from following
+ *   - MMAL_PARAM_EXPOSUREMETERINGMODE_AVERAGE,
+ *   - MMAL_PARAM_EXPOSUREMETERINGMODE_SPOT,
+ *   - MMAL_PARAM_EXPOSUREMETERINGMODE_BACKLIT,
+ *   - MMAL_PARAM_EXPOSUREMETERINGMODE_MATRIX
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_metering_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOSUREMETERINGMODE_T m_mode )
+{
+   MMAL_PARAMETER_EXPOSUREMETERINGMODE_T meter_mode = {{MMAL_PARAMETER_EXP_METERING_MODE,sizeof(meter_mode)},
+                                                      m_mode};
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &meter_mode.hdr));
+}
+
+
+/**
+ * Set the video stabilisation flag. Only used in video mode
+ * @param camera Pointer to camera component
+ * @param saturation Flag 0 off 1 on
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_video_stabilisation(MMAL_COMPONENT_T *camera, int vstabilisation)
+{
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set_boolean(camera->control, MMAL_PARAMETER_VIDEO_STABILISATION, vstabilisation));
+}
+
+/**
+ * Adjust the exposure compensation for images (EV)
+ * @param camera Pointer to camera component
+ * @param exp_comp Value to adjust, -10 to +10
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_exposure_compensation(MMAL_COMPONENT_T *camera, int exp_comp)
+{
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set_int32(camera->control, MMAL_PARAMETER_EXPOSURE_COMP , exp_comp));
+}
+
+
+/**
+ * Set exposure mode for images
+ * @param camera Pointer to camera component
+ * @param mode Exposure mode to set from
+ *   - MMAL_PARAM_EXPOSUREMODE_OFF,
+ *   - MMAL_PARAM_EXPOSUREMODE_AUTO,
+ *   - MMAL_PARAM_EXPOSUREMODE_NIGHT,
+ *   - MMAL_PARAM_EXPOSUREMODE_NIGHTPREVIEW,
+ *   - MMAL_PARAM_EXPOSUREMODE_BACKLIGHT,
+ *   - MMAL_PARAM_EXPOSUREMODE_SPOTLIGHT,
+ *   - MMAL_PARAM_EXPOSUREMODE_SPORTS,
+ *   - MMAL_PARAM_EXPOSUREMODE_SNOW,
+ *   - MMAL_PARAM_EXPOSUREMODE_BEACH,
+ *   - MMAL_PARAM_EXPOSUREMODE_VERYLONG,
+ *   - MMAL_PARAM_EXPOSUREMODE_FIXEDFPS,
+ *   - MMAL_PARAM_EXPOSUREMODE_ANTISHAKE,
+ *   - MMAL_PARAM_EXPOSUREMODE_FIREWORKS,
+ *
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_exposure_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOSUREMODE_T mode)
+{
+   MMAL_PARAMETER_EXPOSUREMODE_T exp_mode = {{MMAL_PARAMETER_EXPOSURE_MODE,sizeof(exp_mode)}, mode};
+
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &exp_mode.hdr));
+}
+
+
+/**
+ * Set the aWB (auto white balance) mode for images
+ * @param camera Pointer to camera component
+ * @param awb_mode Value to set from
+ *   - MMAL_PARAM_AWBMODE_OFF,
+ *   - MMAL_PARAM_AWBMODE_AUTO,
+ *   - MMAL_PARAM_AWBMODE_SUNLIGHT,
+ *   - MMAL_PARAM_AWBMODE_CLOUDY,
+ *   - MMAL_PARAM_AWBMODE_SHADE,
+ *   - MMAL_PARAM_AWBMODE_TUNGSTEN,
+ *   - MMAL_PARAM_AWBMODE_FLUORESCENT,
+ *   - MMAL_PARAM_AWBMODE_INCANDESCENT,
+ *   - MMAL_PARAM_AWBMODE_FLASH,
+ *   - MMAL_PARAM_AWBMODE_HORIZON,
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_awb_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_AWBMODE_T awb_mode)
+{
+   MMAL_PARAMETER_AWBMODE_T param = {{MMAL_PARAMETER_AWB_MODE,sizeof(param)}, awb_mode};
+
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &param.hdr));
+}
+
+int raspicamcontrol_set_awb_gains(MMAL_COMPONENT_T *camera, float r_gain, float b_gain)
+{
+   MMAL_PARAMETER_AWB_GAINS_T param = {{MMAL_PARAMETER_CUSTOM_AWB_GAINS,sizeof(param)}, {0,0}, {0,0}};
+
+   if (!camera)
+      return 1;
+
+   if (!r_gain || !b_gain)
+      return 0;
+
+   param.r_gain.num = (unsigned int)(r_gain * 65536);
+   param.b_gain.num = (unsigned int)(b_gain * 65536);
+   param.r_gain.den = param.b_gain.den = 65536;
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &param.hdr));
+}
+
+/**
+ * Set the image effect for the images
+ * @param camera Pointer to camera component
+ * @param imageFX Value from
+ *   - MMAL_PARAM_IMAGEFX_NONE,
+ *   - MMAL_PARAM_IMAGEFX_NEGATIVE,
+ *   - MMAL_PARAM_IMAGEFX_SOLARIZE,
+ *   - MMAL_PARAM_IMAGEFX_POSTERIZE,
+ *   - MMAL_PARAM_IMAGEFX_WHITEBOARD,
+ *   - MMAL_PARAM_IMAGEFX_BLACKBOARD,
+ *   - MMAL_PARAM_IMAGEFX_SKETCH,
+ *   - MMAL_PARAM_IMAGEFX_DENOISE,
+ *   - MMAL_PARAM_IMAGEFX_EMBOSS,
+ *   - MMAL_PARAM_IMAGEFX_OILPAINT,
+ *   - MMAL_PARAM_IMAGEFX_HATCH,
+ *   - MMAL_PARAM_IMAGEFX_GPEN,
+ *   - MMAL_PARAM_IMAGEFX_PASTEL,
+ *   - MMAL_PARAM_IMAGEFX_WATERCOLOUR,
+ *   - MMAL_PARAM_IMAGEFX_FILM,
+ *   - MMAL_PARAM_IMAGEFX_BLUR,
+ *   - MMAL_PARAM_IMAGEFX_SATURATION,
+ *   - MMAL_PARAM_IMAGEFX_COLOURSWAP,
+ *   - MMAL_PARAM_IMAGEFX_WASHEDOUT,
+ *   - MMAL_PARAM_IMAGEFX_POSTERISE,
+ *   - MMAL_PARAM_IMAGEFX_COLOURPOINT,
+ *   - MMAL_PARAM_IMAGEFX_COLOURBALANCE,
+ *   - MMAL_PARAM_IMAGEFX_CARTOON,
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_imageFX(MMAL_COMPONENT_T *camera, MMAL_PARAM_IMAGEFX_T imageFX)
+{
+   MMAL_PARAMETER_IMAGEFX_T imgFX = {{MMAL_PARAMETER_IMAGE_EFFECT,sizeof(imgFX)}, imageFX};
+
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &imgFX.hdr));
+}
+
+/* TODO :what to do with the image effects parameters?
+   MMAL_PARAMETER_IMAGEFX_PARAMETERS_T imfx_param = {{MMAL_PARAMETER_IMAGE_EFFECT_PARAMETERS,sizeof(imfx_param)},
+                              imageFX, 0, {0}};
+mmal_port_parameter_set(camera->control, &imfx_param.hdr);
+                             */
+
+/**
+ * Set the colour effect  for images (Set UV component)
+ * @param camera Pointer to camera component
+ * @param colourFX  Contains enable state and U and V numbers to set (e.g. 128,128 = Black and white)
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_colourFX(MMAL_COMPONENT_T *camera, const MMAL_PARAM_COLOURFX_T *colourFX)
+{
+   MMAL_PARAMETER_COLOURFX_T colfx = {{MMAL_PARAMETER_COLOUR_EFFECT,sizeof(colfx)}, 0, 0, 0};
+
+   if (!camera)
+      return 1;
+
+   colfx.enable = colourFX->enable;
+   colfx.u = colourFX->u;
+   colfx.v = colourFX->v;
+
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &colfx.hdr));
+
+}
+
+
+/**
+ * Set the rotation of the image
+ * @param camera Pointer to camera component
+ * @param rotation Degree of rotation (any number, but will be converted to 0,90,180 or 270 only)
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_rotation(MMAL_COMPONENT_T *camera, int rotation)
+{
+   int ret;
+   int my_rotation = ((rotation % 360 ) / 90) * 90;
+
+   ret = mmal_port_parameter_set_int32(camera->output[0], MMAL_PARAMETER_ROTATION, my_rotation);
+   mmal_port_parameter_set_int32(camera->output[1], MMAL_PARAMETER_ROTATION, my_rotation);
+   mmal_port_parameter_set_int32(camera->output[2], MMAL_PARAMETER_ROTATION, my_rotation);
+
+   return ret;
+}
+
+/**
+ * Set the flips state of the image
+ * @param camera Pointer to camera component
+ * @param hflip If true, horizontally flip the image
+ * @param vflip If true, vertically flip the image
+ *
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_flips(MMAL_COMPONENT_T *camera, int hflip, int vflip)
+{
+   MMAL_PARAMETER_MIRROR_T mirror = {{MMAL_PARAMETER_MIRROR, sizeof(MMAL_PARAMETER_MIRROR_T)}, MMAL_PARAM_MIRROR_NONE};
+
+   if (hflip && vflip)
+      mirror.value = MMAL_PARAM_MIRROR_BOTH;
+   else
+   if (hflip)
+      mirror.value = MMAL_PARAM_MIRROR_HORIZONTAL;
+   else
+   if (vflip)
+      mirror.value = MMAL_PARAM_MIRROR_VERTICAL;
+
+   mmal_port_parameter_set(camera->output[0], &mirror.hdr);
+   mmal_port_parameter_set(camera->output[1], &mirror.hdr);
+   return mmal_port_parameter_set(camera->output[2], &mirror.hdr);
+}
+
+/**
+ * Set the ROI of the sensor to use for captures/preview
+ * @param camera Pointer to camera component
+ * @param rect   Normalised coordinates of ROI rectangle
+ *
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_ROI(MMAL_COMPONENT_T *camera, PARAM_FLOAT_RECT_T rect)
+{
+   MMAL_PARAMETER_INPUT_CROP_T crop = {{MMAL_PARAMETER_INPUT_CROP, sizeof(MMAL_PARAMETER_INPUT_CROP_T)}};
+
+   crop.rect.x = (65536 * rect.x);
+   crop.rect.y = (65536 * rect.y);
+   crop.rect.width = (65536 * rect.w);
+   crop.rect.height = (65536 * rect.h);
+
+   return mmal_port_parameter_set(camera->control, &crop.hdr);
+}
+
+/**
+ * Adjust the exposure time used for images
+ * @param camera Pointer to camera component
+ * @param shutter speed in microseconds
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_shutter_speed(MMAL_COMPONENT_T *camera, int speed)
+{
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set_uint32(camera->control, MMAL_PARAMETER_SHUTTER_SPEED, speed));
+}
+
+/**
+ * Adjust the Dynamic range compression level
+ * @param camera Pointer to camera component
+ * @param strength Strength of DRC to apply
+ *        MMAL_PARAMETER_DRC_STRENGTH_OFF
+ *        MMAL_PARAMETER_DRC_STRENGTH_LOW
+ *        MMAL_PARAMETER_DRC_STRENGTH_MEDIUM
+ *        MMAL_PARAMETER_DRC_STRENGTH_HIGH
+ *
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_DRC(MMAL_COMPONENT_T *camera, MMAL_PARAMETER_DRC_STRENGTH_T strength)
+{
+   MMAL_PARAMETER_DRC_T drc = {{MMAL_PARAMETER_DYNAMIC_RANGE_COMPRESSION, sizeof(MMAL_PARAMETER_DRC_T)}, strength};
+
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &drc.hdr));
+}
+
+int raspicamcontrol_set_stats_pass(MMAL_COMPONENT_T *camera, int stats_pass)
+{
+   if (!camera)
+      return 1;
+
+   return mmal_status_to_int(mmal_port_parameter_set_boolean(camera->control, MMAL_PARAMETER_CAPTURE_STATS_PASS, stats_pass));
+}
+
+
+/**
+ * Set the annotate data
+ * @param camera Pointer to camera component
+ * @param Bitmask of required annotation data. 0 for off.
+ * @param If set, a pointer to text string to use instead of bitmask, max length 32 characters
+ *
+ * @return 0 if successful, non-zero if any parameters out of range
+ */
+int raspicamcontrol_set_annotate(MMAL_COMPONENT_T *camera, const int settings, const char *string,
+                const int text_size, const int text_colour, const int bg_colour)
+{
+   MMAL_PARAMETER_CAMERA_ANNOTATE_V3_T annotate =
+      {{MMAL_PARAMETER_ANNOTATE, sizeof(MMAL_PARAMETER_CAMERA_ANNOTATE_V3_T)}};
+
+   if (settings)
+   {
+      time_t t = time(NULL);
+      struct tm tm = *localtime(&t);
+      char tmp[MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3];
+      int process_datetime = 1;
+
+      annotate.enable = 1;
+
+      if (settings & (ANNOTATE_APP_TEXT | ANNOTATE_USER_TEXT))
+      {
+         if ((settings & (ANNOTATE_TIME_TEXT | ANNOTATE_DATE_TEXT)) && strchr(string,'%') != NULL)
+         {  //string contains strftime parameter?
+            strftime(annotate.text, MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3, string, &tm );
+            process_datetime = 0;
+         }else{
+            strncpy(annotate.text, string, MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3);
+         }
+         annotate.text[MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3-1] = '\0';
+      }
+
+      if (process_datetime && (settings & ANNOTATE_TIME_TEXT))
+      {
+         if(strlen(annotate.text)){
+            strftime(tmp, 32, " %X", &tm );
+         }else{
+            strftime(tmp, 32, "%X", &tm );
+         }
+         strncat(annotate.text, tmp, MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3 - strlen(annotate.text) - 1);
+      }
+
+      if (process_datetime && (settings & ANNOTATE_DATE_TEXT))
+      {
+         if(strlen(annotate.text)){
+            strftime(tmp, 32, " %x", &tm );
+         }else{
+            strftime(tmp, 32, "%x", &tm );
+         }
+         strncat(annotate.text, tmp, MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V3 - strlen(annotate.text) - 1);
+      }
+
+      if (settings & ANNOTATE_SHUTTER_SETTINGS)
+         annotate.show_shutter = MMAL_TRUE;
+
+      if (settings & ANNOTATE_GAIN_SETTINGS)
+         annotate.show_analog_gain = MMAL_TRUE;
+
+      if (settings & ANNOTATE_LENS_SETTINGS)
+         annotate.show_lens = MMAL_TRUE;
+
+      if (settings & ANNOTATE_CAF_SETTINGS)
+         annotate.show_caf = MMAL_TRUE;
+
+      if (settings & ANNOTATE_MOTION_SETTINGS)
+         annotate.show_motion = MMAL_TRUE;
+
+      if (settings & ANNOTATE_FRAME_NUMBER)
+         annotate.show_frame_num = MMAL_TRUE;
+
+      if (settings & ANNOTATE_BLACK_BACKGROUND)
+         annotate.enable_text_background = MMAL_TRUE;
+
+      annotate.text_size = text_size;
+
+      if (text_colour != -1)
+      {
+         annotate.custom_text_colour = MMAL_TRUE;
+         annotate.custom_text_Y = text_colour&0xff;
+         annotate.custom_text_U = (text_colour>>8)&0xff;
+         annotate.custom_text_V = (text_colour>>16)&0xff;
+      }
+      else
+         annotate.custom_text_colour = MMAL_FALSE;
+
+      if (bg_colour != -1)
+      {
+         annotate.custom_background_colour = MMAL_TRUE;
+         annotate.custom_background_Y = bg_colour&0xff;
+         annotate.custom_background_U = (bg_colour>>8)&0xff;
+         annotate.custom_background_V = (bg_colour>>16)&0xff;
+      }
+      else
+         annotate.custom_background_colour = MMAL_FALSE;
+    }
+    else
+       annotate.enable = 0;
+
+   return mmal_status_to_int(mmal_port_parameter_set(camera->control, &annotate.hdr));
+}
+
+int raspicamcontrol_set_stereo_mode(MMAL_PORT_T *port, MMAL_PARAMETER_STEREOSCOPIC_MODE_T *stereo_mode)
+{
+   MMAL_PARAMETER_STEREOSCOPIC_MODE_T stereo = { {MMAL_PARAMETER_STEREOSCOPIC_MODE, sizeof(stereo)},
+                               MMAL_STEREOSCOPIC_MODE_NONE, MMAL_FALSE, MMAL_FALSE };
+   if (stereo_mode->mode != MMAL_STEREOSCOPIC_MODE_NONE)
+   {
+      stereo.mode = stereo_mode->mode;
+      stereo.decimate = stereo_mode->decimate;
+      stereo.swap_eyes = stereo_mode->swap_eyes;
+   }
+   return mmal_status_to_int(mmal_port_parameter_set(port, &stereo.hdr));
+}
+
+/**
+ * Asked GPU how much memory it has allocated
+ *
+ * @return amount of memory in MB
+ */
+static int raspicamcontrol_get_mem_gpu(void)
+{
+   char response[80] = "";
+   int gpu_mem = 0;
+   if (vc_gencmd(response, sizeof response, "get_mem gpu") == 0)
+      vc_gencmd_number_property(response, "gpu", &gpu_mem);
+   return gpu_mem;
+}
+
+/**
+ * Ask GPU about its camera abilities
+ * @param supported None-zero if software supports the camera 
+ * @param detected  None-zero if a camera has been detected
+ */
+static void raspicamcontrol_get_camera(int *supported, int *detected)
+{
+   char response[80] = "";
+   if (vc_gencmd(response, sizeof response, "get_camera") == 0)
+   {
+      if (supported)
+         vc_gencmd_number_property(response, "supported", supported);
+      if (detected)
+         vc_gencmd_number_property(response, "detected", detected);
+   }
+}
+
+/**
+ * Check to see if camera is supported, and we have allocated enough meooryAsk GPU about its camera abilities
+ * @param supported None-zero if software supports the camera 
+ * @param detected  None-zero if a camera has been detected
+ */
+void raspicamcontrol_check_configuration(int min_gpu_mem)
+{
+   int gpu_mem = raspicamcontrol_get_mem_gpu();
+   int supported = 0, detected = 0;
+   raspicamcontrol_get_camera(&supported, &detected);
+   if (!supported)
+      vcos_log_error("Camera is not enabled in this build. Try running \"sudo raspi-config\" and ensure that \"camera\" has been enabled\n");
+   else if (gpu_mem < min_gpu_mem)
+      vcos_log_error("Only %dM of gpu_mem is configured. Try running \"sudo raspi-config\" and ensure that \"memory_split\" has a value of %d or greater\n", gpu_mem, min_gpu_mem);
+   else if (!detected)
+      vcos_log_error("Camera is not detected. Please check carefully the camera module is installed correctly\n");
+   else
+      vcos_log_error("Failed to run camera app. Please check for firmware updates\n");
+}
+

--- a/raspicam/RaspiCamControl.h
+++ b/raspicam/RaspiCamControl.h
@@ -1,0 +1,217 @@
+/*
+Copyright (c) 2013, Broadcom Europe Ltd
+Copyright (c) 2013, James Hughes
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the copyright holder nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef RASPICAMCONTROL_H_
+#define RASPICAMCONTROL_H_
+
+/* Various parameters
+ *
+ * Exposure Mode
+ *          MMAL_PARAM_EXPOSUREMODE_OFF,
+            MMAL_PARAM_EXPOSUREMODE_AUTO,
+            MMAL_PARAM_EXPOSUREMODE_NIGHT,
+            MMAL_PARAM_EXPOSUREMODE_NIGHTPREVIEW,
+            MMAL_PARAM_EXPOSUREMODE_BACKLIGHT,
+            MMAL_PARAM_EXPOSUREMODE_SPOTLIGHT,
+            MMAL_PARAM_EXPOSUREMODE_SPORTS,
+            MMAL_PARAM_EXPOSUREMODE_SNOW,
+            MMAL_PARAM_EXPOSUREMODE_BEACH,
+            MMAL_PARAM_EXPOSUREMODE_VERYLONG,
+            MMAL_PARAM_EXPOSUREMODE_FIXEDFPS,
+            MMAL_PARAM_EXPOSUREMODE_ANTISHAKE,
+            MMAL_PARAM_EXPOSUREMODE_FIREWORKS,
+ *
+ * AWB Mode
+ *          MMAL_PARAM_AWBMODE_OFF,
+            MMAL_PARAM_AWBMODE_AUTO,
+            MMAL_PARAM_AWBMODE_SUNLIGHT,
+            MMAL_PARAM_AWBMODE_CLOUDY,
+            MMAL_PARAM_AWBMODE_SHADE,
+            MMAL_PARAM_AWBMODE_TUNGSTEN,
+            MMAL_PARAM_AWBMODE_FLUORESCENT,
+            MMAL_PARAM_AWBMODE_INCANDESCENT,
+            MMAL_PARAM_AWBMODE_FLASH,
+            MMAL_PARAM_AWBMODE_HORIZON,
+ *
+ * Image FX
+            MMAL_PARAM_IMAGEFX_NONE,
+            MMAL_PARAM_IMAGEFX_NEGATIVE,
+            MMAL_PARAM_IMAGEFX_SOLARIZE,
+            MMAL_PARAM_IMAGEFX_POSTERIZE,
+            MMAL_PARAM_IMAGEFX_WHITEBOARD,
+            MMAL_PARAM_IMAGEFX_BLACKBOARD,
+            MMAL_PARAM_IMAGEFX_SKETCH,
+            MMAL_PARAM_IMAGEFX_DENOISE,
+            MMAL_PARAM_IMAGEFX_EMBOSS,
+            MMAL_PARAM_IMAGEFX_OILPAINT,
+            MMAL_PARAM_IMAGEFX_HATCH,
+            MMAL_PARAM_IMAGEFX_GPEN,
+            MMAL_PARAM_IMAGEFX_PASTEL,
+            MMAL_PARAM_IMAGEFX_WATERCOLOUR,
+            MMAL_PARAM_IMAGEFX_FILM,
+            MMAL_PARAM_IMAGEFX_BLUR,
+            MMAL_PARAM_IMAGEFX_SATURATION,
+            MMAL_PARAM_IMAGEFX_COLOURSWAP,
+            MMAL_PARAM_IMAGEFX_WASHEDOUT,
+            MMAL_PARAM_IMAGEFX_POSTERISE,
+            MMAL_PARAM_IMAGEFX_COLOURPOINT,
+            MMAL_PARAM_IMAGEFX_COLOURBALANCE,
+            MMAL_PARAM_IMAGEFX_CARTOON,
+
+ */
+
+/// Annotate bitmask options
+/// Supplied by user on command line
+#define ANNOTATE_USER_TEXT          1
+/// Supplied by app using this module
+#define ANNOTATE_APP_TEXT           2
+/// Insert current date
+#define ANNOTATE_DATE_TEXT          4
+// Insert current time
+#define ANNOTATE_TIME_TEXT          8
+
+#define ANNOTATE_SHUTTER_SETTINGS   16
+#define ANNOTATE_CAF_SETTINGS       32
+#define ANNOTATE_GAIN_SETTINGS      64
+#define ANNOTATE_LENS_SETTINGS      128
+#define ANNOTATE_MOTION_SETTINGS    256
+#define ANNOTATE_FRAME_NUMBER       512
+#define ANNOTATE_BLACK_BACKGROUND   1024
+
+
+// There isn't actually a MMAL structure for the following, so make one
+typedef struct mmal_param_colourfx_s
+{
+   int enable;       /// Turn colourFX on or off
+   int u,v;          /// U and V to use
+} MMAL_PARAM_COLOURFX_T;
+
+typedef struct mmal_param_thumbnail_config_s
+{
+   int enable;
+   int width,height;
+   int quality;
+} MMAL_PARAM_THUMBNAIL_CONFIG_T;
+
+typedef struct param_float_rect_s
+{
+   double x;
+   double y;
+   double w;
+   double h;
+} PARAM_FLOAT_RECT_T;
+
+/// struct contain camera settings
+typedef struct raspicam_camera_parameters_s
+{
+   int sharpness;             /// -100 to 100
+   int contrast;              /// -100 to 100
+   int brightness;            ///  0 to 100
+   int saturation;            ///  -100 to 100
+   int ISO;                   ///  TODO : what range?
+   int videoStabilisation;    /// 0 or 1 (false or true)
+   int exposureCompensation;  /// -10 to +10 ?
+   MMAL_PARAM_EXPOSUREMODE_T exposureMode;
+   MMAL_PARAM_EXPOSUREMETERINGMODE_T exposureMeterMode;
+   MMAL_PARAM_AWBMODE_T awbMode;
+   MMAL_PARAM_IMAGEFX_T imageEffect;
+   MMAL_PARAMETER_IMAGEFX_PARAMETERS_T imageEffectsParameters;
+   MMAL_PARAM_COLOURFX_T colourEffects;
+   int rotation;              /// 0-359
+   int hflip;                 /// 0 or 1
+   int vflip;                 /// 0 or 1
+   PARAM_FLOAT_RECT_T  roi;   /// region of interest to use on the sensor. Normalised [0,1] values in the rect
+   int shutter_speed;         /// 0 = auto, otherwise the shutter speed in ms
+   float awb_gains_r;         /// AWB red gain
+   float awb_gains_b;         /// AWB blue gain
+   MMAL_PARAMETER_DRC_STRENGTH_T drc_level;  // Strength of Dynamic Range compression to apply
+   MMAL_BOOL_T stats_pass;    /// Stills capture statistics pass on/off
+   int enable_annotate;       /// Flag to enable the annotate, 0 = disabled, otherwise a bitmask of what needs to be displayed
+   char annotate_string[MMAL_CAMERA_ANNOTATE_MAX_TEXT_LEN_V2]; /// String to use for annotate - overrides certain bitmask settings
+   int annotate_text_size;    // Text size for annotation
+   int annotate_text_colour;  // Text colour for annotation
+   int annotate_bg_colour;    // Background colour for annotation
+   MMAL_PARAMETER_STEREOSCOPIC_MODE_T stereo_mode;
+} RASPICAM_CAMERA_PARAMETERS;
+
+
+void raspicamcontrol_check_configuration(int min_gpu_mem);
+
+int raspicamcontrol_parse_cmdline(RASPICAM_CAMERA_PARAMETERS *params, const char *arg1, const char *arg2);
+void raspicamcontrol_display_help();
+int raspicamcontrol_cycle_test(MMAL_COMPONENT_T *camera);
+
+int raspicamcontrol_set_all_parameters(MMAL_COMPONENT_T *camera, const RASPICAM_CAMERA_PARAMETERS *params);
+int raspicamcontrol_get_all_parameters(MMAL_COMPONENT_T *camera, RASPICAM_CAMERA_PARAMETERS *params);
+void raspicamcontrol_dump_parameters(const RASPICAM_CAMERA_PARAMETERS *params);
+
+void raspicamcontrol_set_defaults(RASPICAM_CAMERA_PARAMETERS *params);
+
+void raspicamcontrol_check_configuration(int min_gpu_mem);
+
+// Individual setting functions
+int raspicamcontrol_set_saturation(MMAL_COMPONENT_T *camera, int saturation);
+int raspicamcontrol_set_sharpness(MMAL_COMPONENT_T *camera, int sharpness);
+int raspicamcontrol_set_contrast(MMAL_COMPONENT_T *camera, int contrast);
+int raspicamcontrol_set_brightness(MMAL_COMPONENT_T *camera, int brightness);
+int raspicamcontrol_set_ISO(MMAL_COMPONENT_T *camera, int ISO);
+int raspicamcontrol_set_metering_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOSUREMETERINGMODE_T mode);
+int raspicamcontrol_set_video_stabilisation(MMAL_COMPONENT_T *camera, int vstabilisation);
+int raspicamcontrol_set_exposure_compensation(MMAL_COMPONENT_T *camera, int exp_comp);
+int raspicamcontrol_set_exposure_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_EXPOSUREMODE_T mode);
+int raspicamcontrol_set_awb_mode(MMAL_COMPONENT_T *camera, MMAL_PARAM_AWBMODE_T awb_mode);
+int raspicamcontrol_set_awb_gains(MMAL_COMPONENT_T *camera, float r_gain, float b_gain);
+int raspicamcontrol_set_imageFX(MMAL_COMPONENT_T *camera, MMAL_PARAM_IMAGEFX_T imageFX);
+int raspicamcontrol_set_colourFX(MMAL_COMPONENT_T *camera, const MMAL_PARAM_COLOURFX_T *colourFX);
+int raspicamcontrol_set_rotation(MMAL_COMPONENT_T *camera, int rotation);
+int raspicamcontrol_set_flips(MMAL_COMPONENT_T *camera, int hflip, int vflip);
+int raspicamcontrol_set_ROI(MMAL_COMPONENT_T *camera, PARAM_FLOAT_RECT_T rect);
+int raspicamcontrol_set_shutter_speed(MMAL_COMPONENT_T *camera, int speed_ms);
+int raspicamcontrol_set_DRC(MMAL_COMPONENT_T *camera, MMAL_PARAMETER_DRC_STRENGTH_T strength);
+int raspicamcontrol_set_stats_pass(MMAL_COMPONENT_T *camera, int stats_pass);
+int raspicamcontrol_set_annotate(MMAL_COMPONENT_T *camera, const int bitmask, const char *string,
+                                 const int text_size, const int text_colour, const int bg_colour);
+int raspicamcontrol_set_stereo_mode(MMAL_PORT_T *port, MMAL_PARAMETER_STEREOSCOPIC_MODE_T *stereo_mode);
+
+//Individual getting functions
+int raspicamcontrol_get_saturation(MMAL_COMPONENT_T *camera);
+int raspicamcontrol_get_sharpness(MMAL_COMPONENT_T *camera);
+int raspicamcontrol_get_contrast(MMAL_COMPONENT_T *camera);
+int raspicamcontrol_get_brightness(MMAL_COMPONENT_T *camera);
+int raspicamcontrol_get_ISO(MMAL_COMPONENT_T *camera);
+MMAL_PARAM_EXPOSUREMETERINGMODE_T raspicamcontrol_get_metering_mode(MMAL_COMPONENT_T *camera);
+int raspicamcontrol_get_video_stabilisation(MMAL_COMPONENT_T *camera);
+int raspicamcontrol_get_exposure_compensation(MMAL_COMPONENT_T *camera);
+MMAL_PARAM_THUMBNAIL_CONFIG_T raspicamcontrol_get_thumbnail_parameters(MMAL_COMPONENT_T *camera);
+MMAL_PARAM_EXPOSUREMODE_T raspicamcontrol_get_exposure_mode(MMAL_COMPONENT_T *camera);
+MMAL_PARAM_AWBMODE_T raspicamcontrol_get_awb_mode(MMAL_COMPONENT_T *camera);
+MMAL_PARAM_IMAGEFX_T raspicamcontrol_get_imageFX(MMAL_COMPONENT_T *camera);
+MMAL_PARAM_COLOURFX_T raspicamcontrol_get_colourFX(MMAL_COMPONENT_T *camera);
+
+
+#endif /* RASPICAMCONTROL_H_ */


### PR DESCRIPTION
Originally by dozencrows on github; mostly this commit:

https://github.com/dozencrows/motion/commit/6d1ed5bd011d83b6358daf86a20c60cb50d0418c

Changes to merge back into motion upstream made by Joseph Heenan (with
help from lowflyerUK on github, see https://github.com/dozencrows/motion/pull/1 ):

- changed back to using autoconf etc as per the main project
- submitted the one change we need to the raspicam files back upstream
  ( https://github.com/raspberrypi/userland/pull/332 )
- imported latest versions of files in raspicam, now exactly match upstream
- added README.txt to raspicam directory with brief explanation
- replaced some tabs with spaces
- removed dependency on checkout of raspberrypi userland repo; now we
  use the headers provided by libraspberrypi-dev
- merged in a couple of the trivial later bugfix commits
- merged in mmalcam_control_params commit to allow config of camera options
- fixed many merge conflicts rebased on top of latest upstream motion