### PR TITLE
ffmpeg fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 Summary of Changes
+   * Fix timelapse crash when selecting mpeg4
+Version 3.4.1 Changes Below
    * Added suggestion for including pkgconf as part of build requirements
    * Swap sequence of user ffmpeg path and PKG_CONFIG_PATH
    * Allow : in non standard locations of netcam_url path.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 Summary of Changes
+   * ffmpeg_variable_bitrate to values of 0-100 and ffmpeg fixes
    * Better messages for pkg-config
    * Fix timelapse crash when selecting mpeg4
 Version 3.4.1 Changes Below

--- a/event.c
+++ b/event.c
@@ -700,7 +700,7 @@ static void event_ffmpeg_timelapse(struct context *cnt,
     if (!cnt->ffmpeg_timelapse) {
         char tmp[PATH_MAX];
         const char *timepath;
-        const char *codec_swf = "swf";
+        const char *codec_mpg = "mpg";
         const char *codec_mpeg = "mpeg4";
 
         /*
@@ -730,11 +730,11 @@ static void event_ffmpeg_timelapse(struct context *cnt,
             v = u + (width * height) / 4;
         }
 
-        if (strcmp(cnt->conf.ffmpeg_video_codec,"swf") == 0) {
-            MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s: Timelapse using swf codec.");
+        if (strcmp(cnt->conf.ffmpeg_video_codec,"mpg") == 0) {
+            MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s: Timelapse using mpg codec.");
             MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s: Events will be appended to file");
             cnt->ffmpeg_timelapse =
-                ffmpeg_open(codec_swf,cnt->timelapsefilename, y, u, v
+                ffmpeg_open(codec_mpg,cnt->timelapsefilename, y, u, v
                         ,cnt->imgs.width, cnt->imgs.height, 24
                         ,cnt->conf.ffmpeg_bps,cnt->conf.ffmpeg_vbr,TIMELAPSE_APPEND);
         } else {

--- a/event.c
+++ b/event.c
@@ -584,8 +584,7 @@ static void event_new_video(struct context *cnt,
 
     cnt->movie_fps = cnt->lastrate;
 
-    MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s FPS %d",
-               cnt->movie_fps);
+    MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s Source FPS %d", cnt->movie_fps);
 
     if (cnt->movie_fps < 2) cnt->movie_fps = 2;
 }
@@ -785,11 +784,12 @@ static void event_ffmpeg_put(struct context *cnt,
         unsigned char *u, *v;
 
         if (cnt->imgs.type == VIDEO_PALETTE_GREY)
-            u = cnt->ffmpeg_timelapse->udata;
+            u = cnt->ffmpeg_output->udata;
         else
             u = y + (width * height);
 
         v = u + (width * height) / 4;
+
         if (ffmpeg_put_other_image(cnt->ffmpeg_output, y, u, v) == -1) {
             cnt->finish = 1;
             cnt->restart = 0;

--- a/event.c
+++ b/event.c
@@ -640,6 +640,10 @@ static void event_ffmpeg_newfile(struct context *cnt,
       * different types of movies checking for crashes, warnings, etc.
      */
     codec = cnt->conf.ffmpeg_video_codec;
+    if (strcmp(codec, "ogg") == 0) {
+        MOTION_LOG(WRN, TYPE_ENCODER, NO_ERRNO, "%s The ogg container is no longer supported.  Changing to mpeg4");
+        codec = "mpeg4";
+    }
     if (strcmp(codec, "test") == 0) {
         MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO, "%s Running test of the various output formats.");
         codenbr = cnt->event_nr % 10;
@@ -780,7 +784,14 @@ static void event_ffmpeg_timelapse(struct context *cnt,
             v = u + (width * height) / 4;
         }
 
-        if (strcmp(cnt->conf.ffmpeg_video_codec,"mpg") == 0) {
+
+        if ((strcmp(cnt->conf.ffmpeg_video_codec,"mpg") == 0) ||
+            (strcmp(cnt->conf.ffmpeg_video_codec,"swf") == 0) ){
+
+            if (strcmp(cnt->conf.ffmpeg_video_codec,"swf") == 0) {
+                MOTION_LOG(WRN, TYPE_EVENTS, NO_ERRNO, "%s: The swf container for timelapse no longer supported.  Using mpg container.");
+            }
+
             MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s: Timelapse using mpg codec.");
             MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s: Events will be appended to file");
             cnt->ffmpeg_timelapse =

--- a/event.c
+++ b/event.c
@@ -587,10 +587,7 @@ static void event_new_video(struct context *cnt,
     MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s FPS %d",
                cnt->movie_fps);
 
-    if (cnt->movie_fps > 30)
-        cnt->movie_fps = 30;
-    else if (cnt->movie_fps < 2)
-        cnt->movie_fps = 2;
+    if (cnt->movie_fps < 2) cnt->movie_fps = 2;
 }
 
 #ifdef HAVE_FFMPEG

--- a/event.c
+++ b/event.c
@@ -608,7 +608,7 @@ static void event_ffmpeg_newfile(struct context *cnt,
     unsigned char *convbuf, *y, *u, *v;
     char stamp[PATH_MAX];
     const char *moviepath;
-    char codec[8];
+    const char *codec;
     long codenbr;
 
     if (!cnt->conf.ffmpeg_output && !cnt->conf.ffmpeg_output_debug)
@@ -629,46 +629,50 @@ static void event_ffmpeg_newfile(struct context *cnt,
      *  motion movies get the same name as normal movies plus an appended 'm'
      *  PATH_MAX - 4 to allow for .mpg to be appended without overflow
      */
-     /* Set up a testing / evaluation codec which will use a different
-      * codec for the events.
+
+     /* The following section allows for testing of all the various containers
+      * that Motion permits. The container type is pre-pended to the name of the
+      * file so that we can determine which container type created what movie.
+      * The intent for this is be used for developer testing when the ffmpeg libs
+      * change or the code inside our ffmpeg module changes.  For each event, the
+      * container type will change.  This way, you can turn on emulate motion, then
+      * specify a maximum movie time and let Motion run for days creating all the
+      * different types of movies checking for crashes, warnings, etc.
      */
-    snprintf(codec, sizeof(codec), "%s", cnt->conf.ffmpeg_video_codec);
+    codec = cnt->conf.ffmpeg_video_codec;
     if (strcmp(codec, "test") == 0) {
         MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO, "%s Running test of the various output formats.");
-        codenbr = cnt->event_nr;
-        while (codenbr > 10){
-          codenbr -= 10;
-        }
+        codenbr = cnt->event_nr % 10;
         switch (codenbr) {
         case 1:
-            snprintf(codec, sizeof(codec), "%s", "mpeg4");
+            codec = "mpeg4";
             break;
         case 2:
-            snprintf(codec, sizeof(codec), "%s", "msmpeg4");
+            codec = "msmpeg4";
             break;
         case 3:
-            snprintf(codec, sizeof(codec), "%s", "swf");
+            codec = "swf";
             break;
         case 4:
-            snprintf(codec, sizeof(codec), "%s", "flv");
+            codec = "flv";
             break;
         case 5:
-            snprintf(codec, sizeof(codec), "%s", "ffv1");
+            codec = "ffv1";
             break;
         case 6:
-            snprintf(codec, sizeof(codec), "%s", "mov");
+            codec = "mov";
             break;
         case 7:
-            snprintf(codec, sizeof(codec), "%s", "mp4");
+            codec = "mp4";
             break;
         case 8:
-            snprintf(codec, sizeof(codec), "%s", "mkv");
+            codec = "mkv";
             break;
         case 9:
-            snprintf(codec, sizeof(codec), "%s", "hevc");
+            codec = "hevc";
             break;
         default:
-            snprintf(codec, sizeof(codec), "%s", "msmpeg4");
+            codec = "msmpeg4";
             break;
         }
         snprintf(cnt->motionfilename, PATH_MAX - 4, "%s/%s_%sm", cnt->conf.filepath, codec, stamp);

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -207,7 +207,7 @@ static AVOutputFormat *get_oformat(const char *codec, char *filename){
      * We also dynamically add the file extension to the filename here.
      */
     if (strcmp(codec, "tlapse") == 0) {
-        ext = ".swf";
+        ext = ".mpg";
         of = av_guess_format ("mpeg2video", NULL, NULL);
         if (of) of->video_codec = MY_CODEC_ID_MPEG2VIDEO;
     } else if (strcmp(codec, "mpeg4") == 0) {

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -60,6 +60,7 @@
 #define MY_CODEC_ID_MPEG2VIDEO CODEC_ID_MPEG2VIDEO
 #define MY_CODEC_ID_H264      CODEC_ID_H264
 #define MY_CODEC_ID_HEVC      CODEC_ID_H264
+
 #endif
 /*********************************************/
 AVFrame *my_frame_alloc(void){
@@ -207,7 +208,7 @@ static AVOutputFormat *get_oformat(const char *codec, char *filename){
      */
     if (strcmp(codec, "tlapse") == 0) {
         ext = ".swf";
-        of = av_guess_format("swf", NULL, NULL);
+        of = av_guess_format ("mpeg2video", NULL, NULL);
         if (of) of->video_codec = MY_CODEC_ID_MPEG2VIDEO;
     } else if (strcmp(codec, "mpeg4") == 0) {
         ext = ".avi";
@@ -752,6 +753,7 @@ AVFrame *ffmpeg_prepare_frame(struct ffmpeg *ffmpeg, unsigned char *y,
     if (ffmpeg->vbr)
         picture->quality = ffmpeg->vbr;
 
+
     /* Setup pointers and line widths. */
     picture->data[0] = y;
     picture->data[1] = u;
@@ -759,6 +761,10 @@ AVFrame *ffmpeg_prepare_frame(struct ffmpeg *ffmpeg, unsigned char *y,
     picture->linesize[0] = ffmpeg->c->width;
     picture->linesize[1] = ffmpeg->c->width / 2;
     picture->linesize[2] = ffmpeg->c->width / 2;
+
+    picture->format = ffmpeg->c->pix_fmt;
+    picture->width  = ffmpeg->c->width;
+    picture->height = ffmpeg->c->height;
 
     return picture;
 }

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -183,10 +183,10 @@ void ffmpeg_init(){
         " libavformat version %d.%d.%d"
         , LIBAVCODEC_VERSION_MAJOR, LIBAVCODEC_VERSION_MINOR, LIBAVCODEC_VERSION_MICRO
         , LIBAVFORMAT_VERSION_MAJOR, LIBAVFORMAT_VERSION_MINOR, LIBAVFORMAT_VERSION_MICRO);
+
     av_register_all();
     avcodec_register_all();
     av_log_set_callback((void *)ffmpeg_avcodec_log);
-    av_log_set_level(AV_LOG_ERROR);
 }
 /**
  * get_oformat
@@ -783,8 +783,13 @@ void ffmpeg_avcodec_log(void *ignoreme ATTRIBUTE_UNUSED, int errno_flag, const c
     vsnprintf(buf, sizeof(buf), fmt, vl);
 
     /* If the debug_level is correct then send the message to the motion logging routine. */
-    MOTION_LOG(DBG, TYPE_ENCODER, NO_ERRNO, "%s: %s - flag %d",
-               buf, errno_flag);
+    if (errno_flag <= AV_LOG_ERROR) {
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: %s", buf);
+    } else if (errno_flag <= AV_LOG_WARNING) {
+        MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO, "%s: %s", buf);
+    } else if (errno_flag < AV_LOG_DEBUG){
+        MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s: %s", buf);
+    }
 }
 
 #endif /* HAVE_FFMPEG */

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -178,9 +178,11 @@ int timelapse_append(struct ffmpeg *ffmpeg, AVPacket pkt){
  *      Function returns nothing.
  */
 void ffmpeg_init(){
-    MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO, "%s: ffmpeg LIBAVCODEC_BUILD %d"
-               " LIBAVFORMAT_BUILD %d", LIBAVCODEC_BUILD,
-               LIBAVFORMAT_BUILD);
+    MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO, 
+        "%s: ffmpeg libavcodec version %d.%d.%d"
+        " libavformat version %d.%d.%d"
+        , LIBAVCODEC_VERSION_MAJOR, LIBAVCODEC_VERSION_MINOR, LIBAVCODEC_VERSION_MICRO
+        , LIBAVFORMAT_VERSION_MAJOR, LIBAVFORMAT_VERSION_MINOR, LIBAVFORMAT_VERSION_MICRO);
     av_register_all();
     avcodec_register_all();
     av_log_set_callback((void *)ffmpeg_avcodec_log);
@@ -361,7 +363,7 @@ struct ffmpeg *ffmpeg_open(const char *ffmpeg_video_codec, char *filename,
     } else {
         ffmpeg->vbr = 0;
     }
-    MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO, "%s vbr/crf for codec: %d", ffmpeg->vbr);
+    MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s vbr/crf for codec: %d", ffmpeg->vbr);
 
     if (c->codec_id == MY_CODEC_ID_H264 ||
         c->codec_id == MY_CODEC_ID_HEVC){
@@ -390,7 +392,7 @@ struct ffmpeg *ffmpeg_open(const char *ffmpeg_video_codec, char *filename,
         if (codec->supported_framerates) {
             const AVRational *fps = codec->supported_framerates;
             while (fps->num) {
-                MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO, "%s Reported FPS Supported %d/%d", fps->num, fps->den);
+                MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s Reported FPS Supported %d/%d", fps->num, fps->den);
                 fps++;
             }
         }
@@ -412,7 +414,7 @@ struct ffmpeg *ffmpeg_open(const char *ffmpeg_video_codec, char *filename,
 
     }
     av_dict_free(&opts);
-    MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO, "%s Selected Output FPS %d", c->time_base.den);
+    MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s Selected Output FPS %d", c->time_base.den);
 
     ffmpeg->video_outbuf = NULL;
     if (!(ffmpeg->oc->oformat->flags & AVFMT_RAWPICTURE)) {
@@ -781,7 +783,7 @@ void ffmpeg_avcodec_log(void *ignoreme ATTRIBUTE_UNUSED, int errno_flag, const c
     vsnprintf(buf, sizeof(buf), fmt, vl);
 
     /* If the debug_level is correct then send the message to the motion logging routine. */
-    MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s: %s - flag %d",
+    MOTION_LOG(DBG, TYPE_ENCODER, NO_ERRNO, "%s: %s - flag %d",
                buf, errno_flag);
 }
 

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -10,6 +10,7 @@
 
 #include <errno.h>
 #include <libavformat/avformat.h>
+#include <libavutil/imgutils.h>
 #include <libavutil/mathematics.h>
 
 #if (LIBAVFORMAT_VERSION_MAJOR >= 56)
@@ -91,6 +92,11 @@ int ffmpeg_put_frame(struct ffmpeg *, AVFrame *);
 void ffmpeg_cleanups(struct ffmpeg *);
 AVFrame *ffmpeg_prepare_frame(struct ffmpeg *, unsigned char *,
                               unsigned char *, unsigned char *);
+int my_image_get_buffer_size(enum AVPixelFormat pix_fmt, int width, int height);
+int my_image_copy_to_buffer(AVFrame *frame,uint8_t *buffer_ptr,enum AVPixelFormat pix_fmt,int width,int height,int dest_size);
+int my_image_fill_arrays(AVFrame *frame,uint8_t *buffer_ptr,enum AVPixelFormat pix_fmt,int width,int height);
+void my_packet_unref(AVPacket pkt);
+
 #endif
 
 #endif /* _INCLUDE_FFMPEG_H_ */

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -86,6 +86,8 @@ void ffmpeg_close(struct ffmpeg *);
 void ffmpeg_avcodec_log(void *, int, const char *, va_list);
 
 #ifdef HAVE_FFMPEG
+int timelapse_exists(const char *fname);
+int timelapse_append(struct ffmpeg *ffmpeg, AVPacket pkt);
 AVFrame *my_frame_alloc(void);
 void my_frame_free(AVFrame *frame);
 int ffmpeg_put_frame(struct ffmpeg *, AVFrame *);

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -46,6 +46,7 @@ struct ffmpeg {
     int vbr;                /* variable bitrate setting */
     char codec[20];         /* codec name */
     int tlapse;
+    struct timeval start_time;
 #else
     int dummy;
 #endif

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -320,9 +320,8 @@ ffmpeg_variable_bitrate 0
 # it requires no installation of codec on the Windows client.
 # swf - gives you a flash film with extension .swf
 # flv - gives you a flash video with extension .flv
-# ffv1 - FF video codec 1 for Lossless Encoding ( experimental )
-# mov - QuickTime ( testing )
-# ogg - Ogg/Theora ( testing )
+# ffv1 - FF video codec 1 for Lossless Encoding
+# mov - QuickTime
 # mp4 - MPEG-4 Part 14 H264 encoding
 # mkv - Matroska H264 encoding
 # hevc - H.265 / HEVC (High Efficiency Video Coding)

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -303,7 +303,7 @@ ffmpeg_bps 400000
 # Enables and defines variable bitrate for the ffmpeg encoder.
 # ffmpeg_bps is ignored if variable bitrate is enabled.
 # Valid values: 0 (default) = fixed bitrate defined by ffmpeg_bps,
-# or the range 2 - 31 where 2 means best quality and 31 is worst.
+# or the range 1 - 100 where 1 means worst quality and 100 is best.
 ffmpeg_variable_bitrate 0
 
 # Codec to used by ffmpeg for the video compression.

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -308,7 +308,7 @@ ffmpeg_variable_bitrate 0
 
 # Codec to used by ffmpeg for the video compression.
 # Timelapse videos have two options.
-#   swf - Creates swf file with mpeg-2 encoding.
+#   mpg - Creates mpg file with mpeg-2 encoding.
 #     If motion is shutdown and restarted, new pics will be appended
 #     to any previously created file with name indicated for timelapse.
 #   mpeg4 - Creates avi file with the default encoding.
@@ -460,12 +460,12 @@ picture_filename %v-%Y%m%d%H%M%S-%q
 
 # File path for motion triggered ffmpeg films (movies) relative to target_dir
 # Default: %v-%Y%m%d%H%M%S
-# File extensions(.swf .avi) are automatically added so do not include them
+# File extensions(.mpg .avi) are automatically added so do not include them
 movie_filename %v-%Y%m%d%H%M%S
 
 # File path for timelapse movies relative to target_dir
 # Default: %Y%m%d-timelapse
-# File extensions(.swf .avi) are automatically added so do not include them
+# File extensions(.mpg .avi) are automatically added so do not include them
 timelapse_filename %Y%m%d-timelapse
 
 ############################################################

--- a/motion.1
+++ b/motion.1
@@ -931,7 +931,7 @@ This option is ignored if ffmpeg_variable_bitrate is not 0.
 .B ffmpeg_variable_bitrate
 .RS 
 .nf 
-Values: 0, 2 to 31
+Values: 0 to 100
 Default: 0
 Description: 
 .fi
@@ -939,8 +939,8 @@ Description:
 Enable and define the variable bitrate for the ffmpeg encoder.
 ffmpeg_bps is ignored if variable bitrate is enabled.
 When specified as 0, use the fixed bitrate defined by ffmpeg_bps.
-When defined as 2 - 31 vary the quality of the movie.  
-A value of 2 is best quality versus a value of 31 is worst quality.
+When defined as 1 - 100 varies the quality of the movie.
+A value of 1 is worst quality versus a value of 100 is best quality.
 .RE
 .RE
 

--- a/motion.1
+++ b/motion.1
@@ -952,7 +952,7 @@ Values:
 .RS
 Timelapse videos:
 .RS
-swf - Creates swf file with mpeg-2 encoding.
+mpg - Creates mpg file with mpeg-2 encoding.
 mpeg4 - Creates avi file with the default encoding.
 .RE
 Motion videos:
@@ -975,7 +975,7 @@ Description:
 .RS
 The container and codec to use when creating videos.  
 When creating timelapse videos, there are only two options and the processing varies due to container/codec limitations.  
-For swf timelapse videos, if motion is shutdown and restarted, new pics will be appended 
+For mpg timelapse videos, if motion is shutdown and restarted, new pics will be appended 
 to any previously created file with name indicated for timelapse.
 For mpeg4 timelapse videos, if motion is shutdown and restarted, new pics will create a 
 new file with the name indicated for timelapse.
@@ -1255,7 +1255,7 @@ Description:
 .fi
 .RS
 File path for timelapse movies relative to target_dir.
-The file extensions(.swf .avi) are automatically added so do not include them
+The file extensions(.mpg .avi) are automatically added so do not include them
 This option accepts the conversion specifiers included at the end of this manual.
 .RE
 .RE

--- a/motion_guide.html
+++ b/motion_guide.html
@@ -3315,7 +3315,7 @@ Experiment for the value that gives you the desired compromise between size and 
 <p></p> 
 <ul>
   <li> Type: Discrete Strings</li>
-  <li> Range / Valid values: mpeg1, mpeg4, msmpeg4, swf, flv, ffv1</li>
+  <li> Range / Valid values: mpeg1, mpeg4, msmpeg4, swf, flv, ffv1, mov, ogg, mp4, mkv, hevc</li>
   <li> Default: mpeg4</li>
 </ul> 
 <p></p>
@@ -3323,7 +3323,7 @@ Codec to be used by ffmpeg for the video compression.
 <p></p>
 Timelapse videos have two options.
 <ul>
-<li>swf - Creates swf file with mpeg-2 encoding. If motion is shutdown and restarted, new pics will be appended
+<li>mpg - Creates mpg file with mpeg-2 encoding. If motion is shutdown and restarted, new pics will be appended
      to any previously created file with name indicated for timelapse.</li>
 <li>mpeg4 - Creates avi file with the default encoding.  If motion is shutdown and restarted, new pics will 
 create a new file with the name indicated for timelapse.</li>

--- a/motion_guide.html
+++ b/motion_guide.html
@@ -3298,14 +3298,14 @@ This option is ignored if ffmpeg_variable_bitrate is not 0 (disabled).
 <p></p> 
 <ul>
   <li> Type: Integer</li>
-  <li> Range / Valid values: 0, 2 - 31</li>
+  <li> Range / Valid values: 0 - 100</li>
   <li> Default: 0 (disabled)</li>
 </ul> 
 <p></p>
 Enables and defines variable bitrate for the ffmpeg encoder. 
 The option of ffmpeg_bps is ignored if variable bitrate is enabled. 
-A value of 0 disables this option while values 2 - 31 are applicable when a 
-variable bit rate is desired.  The value of 2 means best quality and 31 is worst.
+A value of 0 disables this option while values 1 - 100 varies the quality
+of the movie.  The value of 1 means worst quality and 100 is the best quality.
 <p></p>
 Experiment for the value that gives you the desired compromise between size and quality.
 <p></p>

--- a/netcam.c
+++ b/netcam.c
@@ -1130,7 +1130,7 @@ static int netcam_read_html_jpeg(netcam_context_ptr netcam)
     if (buffer->content_length != 0)
         remaining = buffer->content_length;
     else
-        remaining = 999999;
+        remaining = 9999999;
 
     /* Now read in the data. */
     while (remaining) {

--- a/netcam_rtsp.c
+++ b/netcam_rtsp.c
@@ -377,14 +377,14 @@ int netcam_read_rtsp_image(netcam_context_ptr netcam){
 */
 int netcam_rtsp_resize_ntc(netcam_context_ptr netcam){
 
-    if ((netcam->width  != netcam->rtsp->codec_context->width) ||
-        (netcam->height != netcam->rtsp->codec_context->height) ||
+    if ((netcam->width  != (unsigned)netcam->rtsp->codec_context->width) ||
+        (netcam->height != (unsigned)netcam->rtsp->codec_context->height) ||
         (netcam_check_pixfmt(netcam) != 0) ){
         MOTION_LOG(NTC, TYPE_NETCAM, NO_ERRNO, "%s: ");
         MOTION_LOG(NTC, TYPE_NETCAM, NO_ERRNO, "%s: ****************************************************************");
         MOTION_LOG(NTC, TYPE_NETCAM, NO_ERRNO, "%s: The network camera is sending pictures in a different");
-        if ((netcam->width  != netcam->rtsp->codec_context->width) ||
-            (netcam->height != netcam->rtsp->codec_context->height)) {
+        if ((netcam->width  != (unsigned)netcam->rtsp->codec_context->width) ||
+            (netcam->height != (unsigned)netcam->rtsp->codec_context->height)) {
             if (netcam_check_pixfmt(netcam) != 0) {
                 MOTION_LOG(NTC, TYPE_NETCAM, NO_ERRNO, "%s: size than specified in the config and also a ");
                 MOTION_LOG(NTC, TYPE_NETCAM, NO_ERRNO, "%s: different picture format.  The picture is being");
@@ -759,7 +759,9 @@ void netcam_shutdown_rtsp(netcam_context_ptr netcam){
     netcam->rtsp = NULL;
 
 #else  /* No FFmpeg/Libav */
-        MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: FFmpeg/Libav not found on computer.  No RTSP support");
+    /* Stop compiler warnings */
+    netcam->rtsp->status = RTSP_NOTCONNECTED;
+    MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: FFmpeg/Libav not found on computer.  No RTSP support");
 #endif /* End #ifdef HAVE_FFMPEG */
 }
 
@@ -892,6 +894,8 @@ int netcam_setup_rtsp(netcam_context_ptr netcam, struct url_t *url){
   return 0;
 
 #else  /* No FFmpeg/Libav */
+    /* Stop compiler warnings */
+    if (url->port == url->port) netcam->rtsp->status = RTSP_NOTCONNECTED;
     MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: FFmpeg/Libav not found on computer.  No RTSP support");
     return -1;
 #endif /* End #ifdef HAVE_FFMPEG */
@@ -917,8 +921,8 @@ int netcam_setup_rtsp(netcam_context_ptr netcam, struct url_t *url){
 int netcam_next_rtsp(unsigned char *image , netcam_context_ptr netcam){
 #ifdef HAVE_FFMPEG
 
-    if ((netcam->width  != netcam->rtsp->codec_context->width) ||
-        (netcam->height != netcam->rtsp->codec_context->height) ||
+    if ((netcam->width  != (unsigned)netcam->rtsp->codec_context->width) ||
+        (netcam->height != (unsigned)netcam->rtsp->codec_context->height) ||
         (netcam_check_pixfmt(netcam) != 0) ){
         netcam_rtsp_resize(image ,netcam);
     } else {
@@ -930,6 +934,8 @@ int netcam_next_rtsp(unsigned char *image , netcam_context_ptr netcam){
 
     return 0;
 #else  /* No FFmpeg/Libav */
+    /* Stop compiler warnings */
+    if (image == image) netcam->rtsp->status = RTSP_NOTCONNECTED;
     MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: FFmpeg/Libav not found on computer.  No RTSP support");
     return -1;
 #endif /* End #ifdef HAVE_FFMPEG */

--- a/netcam_rtsp.c
+++ b/netcam_rtsp.c
@@ -133,10 +133,10 @@ static void netcam_buffsize_rtsp(netcam_buff_ptr buff, size_t numbytes){
 static int decode_packet(AVPacket *packet, netcam_buff_ptr buffer, AVFrame *frame, AVCodecContext *cc){
     int check = 0;
     int frame_size = 0;
-    int ret = 0;
+    int retcd = 0;
 
-    ret = avcodec_decode_video2(cc, frame, &check, packet);
-    if (ret < 0) {
+    retcd = avcodec_decode_video2(cc, frame, &check, packet);
+    if (retcd < 0) {
         MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: Error decoding video packet");
         return 0;
     }
@@ -145,12 +145,15 @@ static int decode_packet(AVPacket *packet, netcam_buff_ptr buffer, AVFrame *fram
         return 0;
     }
 
-    frame_size = avpicture_get_size(cc->pix_fmt, cc->width, cc->height);
+    frame_size = my_image_get_buffer_size(cc->pix_fmt, cc->width, cc->height);
 
     netcam_buffsize_rtsp(buffer, frame_size);
 
-    avpicture_layout((const AVPicture*)frame,cc->pix_fmt,cc->width,cc->height
-                    ,(unsigned char *)buffer->ptr,frame_size );
+    retcd = my_image_copy_to_buffer(frame, (uint8_t *)buffer->ptr,cc->pix_fmt,cc->width,cc->height, frame_size);
+    if (retcd < 0) {
+        MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: Error decoding video packet: Copying to buffer");
+        return 0;
+    }
 
     buffer->used = frame_size;
 
@@ -313,7 +316,7 @@ int netcam_read_rtsp_image(netcam_context_ptr netcam){
     netcam->rtsp->readingframe = 1;
     while (size_decoded == 0 && av_read_frame(netcam->rtsp->format_context, &packet) >= 0) {
         if(packet.stream_index != netcam->rtsp->video_stream_index) {
-            av_free_packet(&packet);
+            my_packet_unref(packet);
             av_init_packet(&packet);
             packet.data = NULL;
             packet.size = 0;
@@ -322,7 +325,7 @@ int netcam_read_rtsp_image(netcam_context_ptr netcam){
         }
         size_decoded = decode_packet(&packet, buffer, netcam->rtsp->frame, netcam->rtsp->codec_context);
 
-        av_free_packet(&packet);
+        my_packet_unref(packet);
         av_init_packet(&packet);
         packet.data = NULL;
         packet.size = 0;
@@ -330,7 +333,7 @@ int netcam_read_rtsp_image(netcam_context_ptr netcam){
     netcam->rtsp->readingframe = 0;
 
     // at this point, we are finished with the packet
-    av_free_packet(&packet);
+    my_packet_unref(packet);
 
     if (size_decoded == 0) {
         // something went wrong, end of stream? Interupted?
@@ -575,17 +578,17 @@ int netcam_rtsp_open_sws(netcam_context_ptr netcam){
         return -1;
     }
 
-    netcam->rtsp->swsframe_size = avpicture_get_size(
+    netcam->rtsp->swsframe_size = my_image_get_buffer_size(
             MY_PIX_FMT_YUV420P
             ,netcam->width
             ,netcam->height);
-        if (netcam->rtsp->swsframe_size <= 0) {
-            if (netcam->rtsp->status == RTSP_NOTCONNECTED){
-                MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: Error determining size of frame out");
-            }
-            netcam_rtsp_close_context(netcam);
-            return -1;
+    if (netcam->rtsp->swsframe_size <= 0) {
+        if (netcam->rtsp->status == RTSP_NOTCONNECTED){
+            MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: Error determining size of frame out");
         }
+        netcam_rtsp_close_context(netcam);
+        return -1;
+    }
 
     return 0;
 
@@ -611,8 +614,8 @@ int netcam_rtsp_resize(unsigned char *image , netcam_context_ptr netcam){
     char     errstr[128];
     uint8_t *buffer_out;
 
-    retcd = avpicture_fill(
-        (AVPicture*)netcam->rtsp->swsframe_in
+    retcd=my_image_fill_arrays(
+        netcam->rtsp->swsframe_in
         ,(uint8_t*)netcam->latest->ptr
         ,netcam->rtsp->codec_context->pix_fmt
         ,netcam->rtsp->codec_context->width
@@ -629,8 +632,8 @@ int netcam_rtsp_resize(unsigned char *image , netcam_context_ptr netcam){
 
     buffer_out=(uint8_t *)av_malloc(netcam->rtsp->swsframe_size*sizeof(uint8_t));
 
-    retcd = avpicture_fill(
-        (AVPicture*)netcam->rtsp->swsframe_out
+    retcd=my_image_fill_arrays(
+        netcam->rtsp->swsframe_out
         ,buffer_out
         ,MY_PIX_FMT_YUV420P
         ,netcam->width
@@ -661,13 +664,13 @@ int netcam_rtsp_resize(unsigned char *image , netcam_context_ptr netcam){
         return -1;
     }
 
-    retcd = avpicture_layout(
-        (const AVPicture*)netcam->rtsp->swsframe_out
+    retcd=my_image_copy_to_buffer(
+         netcam->rtsp->swsframe_out
+        ,(uint8_t *)image
         ,MY_PIX_FMT_YUV420P
         ,netcam->width
         ,netcam->height
-        ,(unsigned char *)image
-        ,netcam->rtsp->swsframe_size );
+        ,netcam->rtsp->swsframe_size);
     if (retcd < 0) {
         if (netcam->rtsp->status == RTSP_NOTCONNECTED){
             av_strerror(retcd, errstr, sizeof(errstr));
@@ -874,7 +877,7 @@ int netcam_setup_rtsp(netcam_context_ptr netcam, struct url_t *url){
         av_register_all();
         avcodec_register_all();
     pthread_mutex_unlock(&global_lock);
-    
+
     /*
      * The RTSP context should be all ready to attempt a connection with
      * the server, so we try ....

--- a/netcam_rtsp.c
+++ b/netcam_rtsp.c
@@ -750,7 +750,9 @@ void netcam_shutdown_rtsp(netcam_context_ptr netcam){
         netcam_rtsp_close_context(netcam);
         MOTION_LOG(NTC, TYPE_NETCAM, NO_ERRNO,"%s: netcam shut down");
     }
-
+    
+    avformat_network_deinit();
+    
     free(netcam->rtsp->path);
     free(netcam->rtsp->user);
     free(netcam->rtsp->pass);
@@ -878,6 +880,7 @@ int netcam_setup_rtsp(netcam_context_ptr netcam, struct url_t *url){
     pthread_mutex_lock(&global_lock);
         av_register_all();
         avcodec_register_all();
+        avformat_network_init();
     pthread_mutex_unlock(&global_lock);
 
     /*

--- a/netcam_rtsp.h
+++ b/netcam_rtsp.h
@@ -9,10 +9,7 @@
 #include <libavutil/imgutils.h>
 #include <libswscale/swscale.h>
 
-#endif /* end HAVE_FFMPEG  */
-
 struct rtsp_context {
-#ifdef HAVE_FFMPEG
     AVFormatContext*      format_context;
     AVCodecContext*       codec_context;
     AVFrame*              frame;
@@ -27,12 +24,6 @@ struct rtsp_context {
     int                   status;
     struct timeval        startreadtime;
     struct SwsContext*   swsctx;
-
-#else /* Do not have FFmpeg */
-    int*                  format_context;
-    int                   readingframe;
-    int                   status;
-#endif /* end HAVE_FFMPEG  */
 };
 
 struct rtsp_context *rtsp_new_context(void);
@@ -41,3 +32,29 @@ int netcam_connect_rtsp(netcam_context_ptr netcam);
 int netcam_read_rtsp_image(netcam_context_ptr netcam);
 int netcam_setup_rtsp(netcam_context_ptr netcam, struct url_t *url);
 int netcam_next_rtsp(unsigned char *image , netcam_context_ptr netcam);
+int netcam_check_pixfmt(netcam_context_ptr netcam);
+void netcam_rtsp_null_context(netcam_context_ptr netcam);
+void netcam_rtsp_close_context(netcam_context_ptr netcam);
+int netcam_rtsp_resize_ntc(netcam_context_ptr netcam);
+int netcam_rtsp_open_context(netcam_context_ptr netcam);
+int netcam_rtsp_open_sws(netcam_context_ptr netcam);
+int netcam_rtsp_resize(unsigned char *image , netcam_context_ptr netcam);
+
+#else /* Do not have FFmpeg */
+
+struct rtsp_context {
+    int*                  format_context;
+    int                   readingframe;
+    int                   status;
+};
+
+struct rtsp_context *rtsp_new_context(void);
+void netcam_shutdown_rtsp(netcam_context_ptr netcam);
+int netcam_connect_rtsp(netcam_context_ptr netcam);
+int netcam_read_rtsp_image(netcam_context_ptr netcam);
+int netcam_setup_rtsp(netcam_context_ptr netcam, struct url_t *url);
+int netcam_next_rtsp(unsigned char *image , netcam_context_ptr netcam);
+
+#endif /* end HAVE_FFMPEG  */
+
+


### PR DESCRIPTION
These commits address multiple issues with the ffmpeg processing.  

1. The variable bit rate parameter will control quality for all the codec/container options and will close #113.  
2. The presentation time stamps (pts) were not being set right for all the different containers which closes #56 and #132.  
3. Fixed the truncated images which closes #131.  
4. The ogg container was not able to be successfully implemented and was removed as a available option.  Specification of this container will result in Motion falling back to the default.   
5. Revisions have been included to handle the ffmpeg 3.0 changes and remove the depreciation warnings.  Closes #136 
6. The swf container for the timelapse needed to be changed to mpg.  Using a codec of mpeg2 with a swf container is not permitted.  Other container options for timelapse not permitted so this container change closes #44      