### PR TITLE
Revert to standard os file buffering

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -1796,7 +1796,7 @@ void conf_print(struct context **cnt)
         MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO, "%s: Writing config file to %s",
                    cnt[thread]->conf_filename);
 
-        conffile = myfopen(cnt[thread]->conf_filename, "w", 0);
+        conffile = myfopen(cnt[thread]->conf_filename, "w");
 
         if (!conffile)
             continue;

--- a/event.c
+++ b/event.c
@@ -512,7 +512,7 @@ static void event_create_extpipe(struct context *cnt,
         snprintf(cnt->extpipefilename, PATH_MAX - 4, "%s/%s", cnt->conf.filepath, stamp);
 
         /* Open a dummy file to check if path is correct */
-        fd_dummy = myfopen(cnt->extpipefilename, "w", 0);
+        fd_dummy = myfopen(cnt->extpipefilename, "w");
 
         /* TODO: trigger some warning instead of only log an error message */
         if (fd_dummy == NULL) {

--- a/logger.c
+++ b/logger.c
@@ -110,7 +110,7 @@ void set_log_mode(int mode)
 FILE * set_logfile(const char *logfile_name)
 {
     log_mode = LOGMODE_SYSLOG;  /* Setup temporary to let log if myfopen fails */
-    logfile = myfopen(logfile_name, "a", 0);
+    logfile = myfopen(logfile_name, "a");
 
     /* If logfile was opened correctly */
     if (logfile)

--- a/motion.h
+++ b/motion.h
@@ -212,8 +212,6 @@
 #define UPDATE_REF_FRAME  1
 #define RESET_REF_FRAME   2
 
-#define BUFSIZE_1MEG      (1024 * 1024)
-
 /* Forward declaration, used in track.h */
 struct images;
 
@@ -457,7 +455,7 @@ extern pthread_key_t tls_key_threadnr; /* key for thread number */
 int http_bindsock(int, int, int);
 void * mymalloc(size_t);
 void * myrealloc(void *, size_t, const char *);
-FILE * myfopen(const char *, const char *, size_t);
+FILE * myfopen(const char *, const char *);
 int myfclose(FILE *);
 size_t mystrftime(const struct context *, char *, size_t, const char *, const struct tm *, const char *, int);
 int create_path(const char *);

--- a/picture.c
+++ b/picture.c
@@ -934,7 +934,7 @@ void put_picture(struct context *cnt, char *file, unsigned char *image, int ftyp
 {
     FILE *picture;
 
-    picture = myfopen(file, "w", BUFSIZE_1MEG);
+    picture = myfopen(file, "w");
     if (!picture) {
         /* Report to syslog - suggest solution if the problem is access rights to target dir. */
         if (errno ==  EACCES) {
@@ -1037,7 +1037,7 @@ void put_fixed_mask(struct context *cnt, const char *file)
 {
     FILE *picture;
 
-    picture = myfopen(file, "w", BUFSIZE_1MEG);
+    picture = myfopen(file, "w");
     if (!picture) {
         /* Report to syslog - suggest solution if the problem is access rights to target dir. */
         if (errno ==  EACCES) {


### PR DESCRIPTION
This pull request will close #102 

This commit reverts  back the change in 3.2.12 which implemented setvbuf and user defined file buffers to increase the throughput of writing the jpgs.  The implementation used a set of 32 global buffers that do not appear to be thread safe.  The implementation also did not reinitialize the buffers after use which could be a issue.  

Further analysis and profiling is required to determine whether the throughput remains a issue and whether it needs to be addressed by a future change.  