### PR TITLE
Adding support for conf.d style directory configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.log
 .svn/
 *.o
+*.sw*
 autom4te.cache
 aclocal.m4
 .depend

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: c
+compiler: gcc
+before_script: autoreconf -fiv
+addons:
+  apt:
+    packages:
+      - libavformat-dev
+      - libavcodec-dev
+      - libav-tools
+      - libavutil-dev
+      - libswscale-dev 
+      - ffmpeg
+      - libjpeg8-dev
+      - libv4l-dev 
+      - libzip-dev
+script: ./configure && make

--- a/INSTALL
+++ b/INSTALL
@@ -10,6 +10,7 @@ have associated dependencies which dictate the configuration options.
 Build Packages:
     autoconf 
     automake
+    git
     pkgconf
     libtool 
     libjpeg8-dev 

--- a/conf.h
+++ b/conf.h
@@ -15,7 +15,7 @@
 #ifndef _INCLUDE_CONF_H
 #define _INCLUDE_CONF_H
 
-/* 
+/*
  * More parameters may be added later.
  */
 struct config {
@@ -86,7 +86,7 @@ struct config {
     unsigned long frequency;
     int tuner_number;
     int timelapse;
-    const char *timelapse_mode; 
+    const char *timelapse_mode;
 #if (defined(BSD) || defined(__FreeBSD_kernel__))
     const char *tuner_device;
 #endif
@@ -134,15 +134,17 @@ struct config {
     int text_double;
     const char *despeckle_filter;
     const char *area_detect;
+    int camera_id;
     int minimum_motion_frames;
     const char *exif_text;
+    char *thread_dir;
     char *pid_file;
     int argc;
     char **argv;
 };
 
-/** 
- * typedef for a param copy function. 
+/**
+ * typedef for a param copy function.
  */
 typedef struct context ** (* conf_copy_func)(struct context **, const char *, int);
 typedef const char *(* conf_print_func)(struct context **, char **, int, unsigned int);
@@ -157,7 +159,7 @@ typedef struct {
     int conf_value;                   /* pointer to a field in struct context     */
     conf_copy_func  copy;             /* a function to set the value in 'config'  */
     conf_print_func print;            /* a function to output the value to a file */
-} config_param; 
+} config_param;
 
 extern config_param config_params[];
 

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -25,6 +25,12 @@
 
 #endif
 
+/*
+ * AVPixelFormat is a newer release of avutil PixelFormat is the old name
+ */
+#ifndef AVPixelFormat
+#define AVPixelFormat PixelFormat
+#endif
 
 #endif /* HAVE_FFMPEG */
 

--- a/motion.c
+++ b/motion.c
@@ -2764,7 +2764,7 @@ int main (int argc, char **argv)
                        cnt_list[i]->conf.stream_port);
 #ifdef HAVE_SQLITE
             /* this is done to share the seralized handle
-             * and supress creation of new handles in the threads */    
+             * and supress creation of new handles in the threads */
             cnt_list[i]->database_sqlite3=cnt_list[0]->database_sqlite3;
 #endif
             start_motion_thread(cnt_list[i], &thread_attr);
@@ -3036,7 +3036,7 @@ int create_path(const char *path)
  *   (which is: path does not exist), the path is created and then things are
  *   tried again. This is faster then trying to create that path over and over
  *   again. If someone removes the path after it was created, myfopen will
- *   recreate the path automatically. 
+ *   recreate the path automatically.
  *
  * Parameters:
  *
@@ -3173,6 +3173,9 @@ size_t mystrftime(const struct context *cnt, char *s, size_t max, const char *us
                     cnt->current_image->location.width);
                 break;
 
+            case 'I': // camera id
+                sprintf(tempstr, "%*d", width, cnt->conf.camera_id);
+                break;
             case 'J': // motion height
                 sprintf(tempstr, "%*d", width,
                     cnt->current_image->location.height);


### PR DESCRIPTION
Instead of having to modify the conf file for every new camera, allow for a similar conf.d directory based configuration.

Instead of
```
thread /etc/motion/thread1.conf
```
Use:
```
thread_dir /etc/motion/conf.d

where
 /etc/motion/conf.d/camera_file_1.conf
```

Camera_file contains the same information as thread1.conf, it also allows for a stick camera_id to be defined, this will prevent changing the thread_id when adding cameras, which will cause issues with the camera id used in the database.

camera_file_1.conf:
```
camera_id 1
stream_port 7000
netcam_url <url>
width 640
height 520
framerate 7
```

As I'm writing this pull request, I think I may need to break this up for you.

I'm adding Travis CI support, It runs on (ubuntu 12.04), which uses older version of libavutil, which is now broken with the the commit from: 1ffcbe2

I'm also adding vim temp from git.

I'm adding git to the list of packages needed.  When I was composing my u12.04 docker container I realized you needed during the build.  Good to know when building a container.


