### PR TITLE
Fix for older libavutil + add travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: c
+compiler: gcc
+before_script: autoreconf -fiv
+addons:
+  apt:
+    packages:
+      - libavformat-dev
+      - libavcodec-dev
+      - libav-tools
+      - libavutil-dev
+      - libswscale-dev 
+      - ffmpeg
+      - libjpeg8-dev
+      - libv4l-dev 
+      - libzip-dev
+script: ./configure && make

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -81,7 +81,7 @@ void my_frame_free(AVFrame *frame){
 #endif
 }
 /*********************************************/
-int my_image_get_buffer_size(enum AVPixelFormat pix_fmt, int width, int height){
+int my_image_get_buffer_size(enum MyPixelFormat pix_fmt, int width, int height){
     int retcd = 0;
 #if (LIBAVFORMAT_VERSION_MAJOR >= 57)
     int align = 1;
@@ -92,7 +92,7 @@ int my_image_get_buffer_size(enum AVPixelFormat pix_fmt, int width, int height){
     return retcd;
 }
 /*********************************************/
-int my_image_copy_to_buffer(AVFrame *frame, uint8_t *buffer_ptr, enum AVPixelFormat pix_fmt,int width, int height,int dest_size){
+int my_image_copy_to_buffer(AVFrame *frame, uint8_t *buffer_ptr, enum MyPixelFormat pix_fmt,int width, int height,int dest_size){
     int retcd = 0;
 #if (LIBAVFORMAT_VERSION_MAJOR >= 57)
     int align = 1;
@@ -105,7 +105,7 @@ int my_image_copy_to_buffer(AVFrame *frame, uint8_t *buffer_ptr, enum AVPixelFor
 	return retcd;
 }
 /*********************************************/
-int my_image_fill_arrays(AVFrame *frame,uint8_t *buffer_ptr,enum AVPixelFormat pix_fmt,int width,int height){
+int my_image_fill_arrays(AVFrame *frame,uint8_t *buffer_ptr,enum MyPixelFormat pix_fmt,int width,int height){
     int retcd = 0;
 #if (LIBAVFORMAT_VERSION_MAJOR >= 57)
     int align = 1;

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -25,6 +25,15 @@
 
 #endif
 
+/**
+ * libavutil changed the name from PixelFormat to AVPixelFormat in 51.42.0
+ * Add compatibility with older versions.
+ */
+#ifdef FF_API_PIX_FMT
+#define MyPixelFormat AVPixelFormat 
+#else
+#define MyPixelFormat PixelFormat
+#endif
 
 #endif /* HAVE_FFMPEG */
 
@@ -95,9 +104,9 @@ int ffmpeg_put_frame(struct ffmpeg *, AVFrame *);
 void ffmpeg_cleanups(struct ffmpeg *);
 AVFrame *ffmpeg_prepare_frame(struct ffmpeg *, unsigned char *,
                               unsigned char *, unsigned char *);
-int my_image_get_buffer_size(enum AVPixelFormat pix_fmt, int width, int height);
-int my_image_copy_to_buffer(AVFrame *frame,uint8_t *buffer_ptr,enum AVPixelFormat pix_fmt,int width,int height,int dest_size);
-int my_image_fill_arrays(AVFrame *frame,uint8_t *buffer_ptr,enum AVPixelFormat pix_fmt,int width,int height);
+int my_image_get_buffer_size(enum MyPixelFormat pix_fmt, int width, int height);
+int my_image_copy_to_buffer(AVFrame *frame,uint8_t *buffer_ptr,enum MyPixelFormat pix_fmt,int width,int height,int dest_size);
+int my_image_fill_arrays(AVFrame *frame,uint8_t *buffer_ptr,enum MyPixelFormat pix_fmt,int width,int height);
 void my_packet_unref(AVPacket pkt);
 
 #endif


### PR DESCRIPTION
I've tested this with the debian stable libavutil, plus the older one on travis, both work fine.

The travis config means we can setup travis to check that pull requests compile - I'll do that once this pull request is merged.