### PR TITLE
Make some internal functions "static"

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -149,7 +149,7 @@ void my_packet_unref(AVPacket pkt){
  *      0:  File doesn't exist
  *      1:  File exists
  */
-int timelapse_exists(const char *fname){
+static int timelapse_exists(const char *fname){
     FILE *file;
     file = fopen(fname, "r");
     if (file)
@@ -159,7 +159,7 @@ int timelapse_exists(const char *fname){
     }
     return 0;
 }
-int timelapse_append(struct ffmpeg *ffmpeg, AVPacket pkt){
+static int timelapse_append(struct ffmpeg *ffmpeg, AVPacket pkt){
     FILE *file;
 
     file = fopen(ffmpeg->oc->filename, "a");

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -87,8 +87,6 @@ void ffmpeg_close(struct ffmpeg *);
 void ffmpeg_avcodec_log(void *, int, const char *, va_list);
 
 #ifdef HAVE_FFMPEG
-int timelapse_exists(const char *fname);
-int timelapse_append(struct ffmpeg *ffmpeg, AVPacket pkt);
 AVFrame *my_frame_alloc(void);
 void my_frame_free(AVFrame *frame);
 int ffmpeg_put_frame(struct ffmpeg *, AVFrame *);

--- a/netcam_rtsp.c
+++ b/netcam_rtsp.c
@@ -31,7 +31,7 @@
  *
  * Determine whether pix_format is YUV420P
  */
-int netcam_check_pixfmt(netcam_context_ptr netcam){
+static int netcam_check_pixfmt(netcam_context_ptr netcam){
     int retcd;
 
     retcd = -1;
@@ -47,7 +47,7 @@ int netcam_check_pixfmt(netcam_context_ptr netcam){
  *
  * Null all the context
  */
-void netcam_rtsp_null_context(netcam_context_ptr netcam){
+static void netcam_rtsp_null_context(netcam_context_ptr netcam){
 
     netcam->rtsp->swsctx         = NULL;
     netcam->rtsp->swsframe_in    = NULL;
@@ -62,7 +62,7 @@ void netcam_rtsp_null_context(netcam_context_ptr netcam){
  *
  * Close all the context that could be open
  */
-void netcam_rtsp_close_context(netcam_context_ptr netcam){
+static void netcam_rtsp_close_context(netcam_context_ptr netcam){
 
     if (netcam->rtsp->swsctx       != NULL) sws_freeContext(netcam->rtsp->swsctx);
     if (netcam->rtsp->swsframe_in  != NULL) my_frame_free(netcam->rtsp->swsframe_in);
@@ -375,7 +375,7 @@ int netcam_read_rtsp_image(netcam_context_ptr netcam){
 *       Success     0(zero)
 *
 */
-int netcam_rtsp_resize_ntc(netcam_context_ptr netcam){
+static int netcam_rtsp_resize_ntc(netcam_context_ptr netcam){
 
     if ((netcam->width  != (unsigned)netcam->rtsp->codec_context->width) ||
         (netcam->height != (unsigned)netcam->rtsp->codec_context->height) ||
@@ -428,7 +428,7 @@ int netcam_rtsp_resize_ntc(netcam_context_ptr netcam){
 *       Success     0(zero)
 *
 */
-int netcam_rtsp_open_context(netcam_context_ptr netcam){
+static int netcam_rtsp_open_context(netcam_context_ptr netcam){
 
     int  retcd;
     char errstr[128];
@@ -534,7 +534,7 @@ int netcam_rtsp_open_context(netcam_context_ptr netcam){
 *       Success     0(zero)
 *
 */
-int netcam_rtsp_open_sws(netcam_context_ptr netcam){
+static int netcam_rtsp_open_sws(netcam_context_ptr netcam){
 
     netcam->width  = ((netcam->cnt->conf.width / 8) * 8);
     netcam->height = ((netcam->cnt->conf.height / 8) * 8);
@@ -608,7 +608,7 @@ int netcam_rtsp_open_sws(netcam_context_ptr netcam){
 *       Success     0(zero)
 *
 */
-int netcam_rtsp_resize(unsigned char *image , netcam_context_ptr netcam){
+static int netcam_rtsp_resize(unsigned char *image , netcam_context_ptr netcam){
 
     int      retcd;
     char     errstr[128];

--- a/netcam_rtsp.h
+++ b/netcam_rtsp.h
@@ -32,13 +32,6 @@ int netcam_connect_rtsp(netcam_context_ptr netcam);
 int netcam_read_rtsp_image(netcam_context_ptr netcam);
 int netcam_setup_rtsp(netcam_context_ptr netcam, struct url_t *url);
 int netcam_next_rtsp(unsigned char *image , netcam_context_ptr netcam);
-int netcam_check_pixfmt(netcam_context_ptr netcam);
-void netcam_rtsp_null_context(netcam_context_ptr netcam);
-void netcam_rtsp_close_context(netcam_context_ptr netcam);
-int netcam_rtsp_resize_ntc(netcam_context_ptr netcam);
-int netcam_rtsp_open_context(netcam_context_ptr netcam);
-int netcam_rtsp_open_sws(netcam_context_ptr netcam);
-int netcam_rtsp_resize(unsigned char *image , netcam_context_ptr netcam);
 
 #else /* Do not have FFmpeg */
 


### PR DESCRIPTION
I've resurrected the pull request that I'd previously closed here:

https://github.com/Motion-Project/motion/pull/149

I think the way we have the code on the current master may not match with the original intention of whoever wrote the code (though it is always hard to tell). Given that the functions aren't called from outside their .c files and weren't originally in the .h files I think it's reasonable to surmise that they were intended to be local to the .c files, so make them so. (Keeping functions only exposed the minimum amount necessary aids in figuring out how the rest of the code calls into a particular piece of code.)