### PR TITLE
Add camera_name setting to allow each camera to be given a name

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -43,6 +43,7 @@ char *get_current_dir_name(void)
 #define stripnewline(x) {if ((x)[strlen(x)-1]=='\n') (x)[strlen(x) - 1] = 0; }
 
 struct config conf_template = {
+    camera_name:                    NULL,
     width:                          DEF_WIDTH,
     height:                         DEF_HEIGHT,
     quality:                        DEF_QUALITY,
@@ -211,6 +212,15 @@ config_param config_params[] = {
     CONF_OFFSET(setup_mode),
     copy_bool,
     print_bool
+    },
+    {
+    "camera_name",
+    "# Name given to a camera/thread. Shown in web interface and may be used with the specifier %$ for filenames and such.\n"
+    "# Default: not defined",
+    0,
+    CONF_OFFSET(camera_name),
+    copy_string,
+    print_string
     },
     {
     "logfile",

--- a/conf.h
+++ b/conf.h
@@ -19,6 +19,7 @@
  * More parameters may be added later.
  */
 struct config {
+    const char *camera_name;
     unsigned int log_level;
     char *log_type_str;
     char *log_file;

--- a/configure.ac
+++ b/configure.ac
@@ -208,6 +208,17 @@ else
 fi
 
 
+if test "x$PTHREAD_SUPPORT" = "xyes"; then
+    AC_MSG_CHECKING([[for pthread_setname_np]])
+    CFLAGS="$TEMP_CFLAGS"
+    LIBS="$TEMP_LIBS"
+    AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM([[#include <pthread.h>]], [[  pthread_setname_np(pthread_self(), "name")]])],
+    [AC_DEFINE([[HAVE_PTHREAD_SETNAME_NP]], [[1]], [Define if you have pthread_setname_np function.])
+     AC_MSG_RESULT([[yes]])],
+    [AC_MSG_RESULT([[no]])] )
+fi
+
 #
 # Check for sdl library
 #

--- a/motion.c
+++ b/motion.c
@@ -1101,6 +1101,17 @@ static void *motion_loop(void *arg)
     unsigned int get_image = 1;    /* Flag used to signal that we capture new image when we run the loop */
     struct image_data *old_image;
 
+#ifdef HAVE_PTHREAD_SETNAME_NP
+    {
+        char tname[16];
+        snprintf(tname, sizeof(tname), "ml%d%s%s",
+                 cnt->threadnr,
+                 cnt->conf.camera_name ? ":" : "",
+                 cnt->conf.camera_name ? cnt->conf.camera_name : "");
+        pthread_setname_np(pthread_self(), tname);
+    }
+#endif
+
     /*
      * Next two variables are used for snapshot and timelapse feature
      * time_last_frame is set to 1 so that first coming timelapse or second = 0
@@ -3232,6 +3243,13 @@ size_t mystrftime(const struct context *cnt, char *s, size_t max, const char *us
             case 'n': // sqltype
                 if (sqltype)
                     sprintf(tempstr, "%*d", width, sqltype);
+                else
+                    ++pos_userformat;
+                break;
+
+            case '$': // thread name
+                if (cnt->conf.camera_name && cnt->conf.camera_name[0])
+                    snprintf(tempstr, PATH_MAX, "%s", cnt->conf.camera_name);
                 else
                     ++pos_userformat;
                 break;

--- a/netcam.c
+++ b/netcam.c
@@ -1893,6 +1893,17 @@ static void *netcam_handler_loop(void *arg)
     netcam_context_ptr netcam = arg;
     struct context *cnt = netcam->cnt; /* Needed for the SETUP macro :-( */
 
+#ifdef HAVE_PTHREAD_SETNAME_NP
+    {
+        char tname[16];
+        snprintf(tname, sizeof(tname), "nc%d%s%s",
+                 cnt->threadnr,
+                 cnt->conf.camera_name ? ":" : "",
+                 cnt->conf.camera_name ? cnt->conf.camera_name : "");
+        pthread_setname_np(pthread_self(), tname);
+    }
+#endif
+
     /* Store the corresponding motion thread number in TLS also for this
      * thread (necessary for 'MOTION_LOG' to function properly).
      */

--- a/stream.c
+++ b/stream.c
@@ -179,6 +179,10 @@ static void* handle_basic_auth(void* param)
         "Pragma: no-cache\r\n"
         "WWW-Authenticate: Basic realm=\""STREAM_REALM"\"\r\n\r\n";
 
+#ifdef HAVE_PTHREAD_SETNAME_NP
+    pthread_setname_np(pthread_self(), "handle_basic_auth");
+#endif
+
     pthread_mutex_lock(&stream_auth_mutex);
     p->thread_count++;
     pthread_mutex_unlock(&stream_auth_mutex);
@@ -429,6 +433,10 @@ static void* handle_md5_digest(void* param)
         "</HEAD><BODY>\r\n"
         "<H1>500 Internal Server Error</H1>\r\n"
         "</BODY></HTML>\r\n";
+
+#ifdef HAVE_PTHREAD_SETNAME_NP
+    pthread_setname_np(pthread_self(), "handle_md5_digest");
+#endif
 
     pthread_mutex_lock(&stream_auth_mutex);
     p->thread_count++;

--- a/webhttpd.c
+++ b/webhttpd.c
@@ -418,8 +418,11 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
             /*call list*/
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Thread %hu</b>\n<ul>",
-                        thread, thread);
+                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>\n<ul>",
+                        thread, thread,
+                        cnt[thread]->conf.camera_name ? " -- " : "",
+                        cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
+
                 send_template(client_socket, res);
 
                 for (i=0; config_params[i].param_name != NULL; i++) {
@@ -548,10 +551,13 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 sprintf(res,
                                     "<a href=/%hu/config/list>&lt;&ndash; back</a>"
-                                    "<br><br>\n<b>Thread %hu</b>\n"
+                                    "<br><br>\n<b>Thread %hu%s%s</b>\n"
                                     "<ul><li><a href=/%hu/config/set?%s>%s</a> = %s"
                                     "</li></ul><b>Done</b>",
-                                        thread, thread, thread, config_params[i].param_name,
+                                        thread, thread,
+                                        cnt[thread]->conf.camera_name ? " -- " : "",
+                                        cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                        thread, config_params[i].param_name,
                                         config_params[i].param_name, Value);
 
                                 send_template_ini_client(client_socket, ini_template);
@@ -594,8 +600,11 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             sprintf(res,
                                 "<a href=/%hu/config/list>&lt;&ndash; back</a><br><br>\n"
-                                    "<b>Thread %hu</b>\n<ul><li><a href=/%hu/config/set?%s>%s</a>"
-                                    "= %s</li></ul><br><b>Done</b>", thread, thread, thread,
+                                    "<b>Thread %hu%s%s</b>\n<ul><li><a href=/%hu/config/set?%s>%s</a>"
+                                    "= %s</li></ul><br><b>Done</b>", thread, thread,
+                                    cnt[thread]->conf.camera_name ? " -- " : "",
+                                    cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                    thread,
                                     config_params[i].param_name, config_params[i].param_name, type);
 
                             send_template_ini_client(client_socket, ini_template);
@@ -661,7 +670,7 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                                                 "<option value='off' selected>off</option>\n");
 
                             sprintf(res, "<a href=/%hu/config/list>&lt;&ndash; back</a><br><br>\n"
-                                         "<b>Thread %hu</b>\n"
+                                         "<b>Thread %hu%s%s</b>\n"
                                          "<form action=set?>\n"
                                          "<b>%s</b>&nbsp;<select name='%s'>\n"
                                          "%s"
@@ -669,6 +678,8 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                                          "&nbsp;&nbsp;&nbsp;&nbsp;"
                                          "<a href='%s#%s' target=_blank>[help]</a>"
                                          "</form>\n<hr><i>%s</i>", thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                          config_params[i].param_name, config_params[i].param_name,
                                          option, TWIKI_URL, config_params[i].param_name, text_help);
                         } else {
@@ -680,12 +691,14 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                                 if (value == NULL) value = "";
                             }
                             sprintf(res, "<a href=/%hu/config/list>&lt;&ndash; back</a><br><br>\n"
-                                         "<b>Thread %hu</b>\n<form action=set?>\n"
+                                         "<b>Thread %hu%s%s</b>\n<form action=set?>\n"
                                          "<b>%s</b>&nbsp;<input type=text name='%s' value='%s' size=80>\n"
                                          "<input type='submit' value='set'>\n"
                                          "&nbsp;&nbsp;&nbsp;&nbsp;"
                                          "<a href='%s#%s' target=_blank>[help]</a>"
                                          "</form>\n<hr><i>%s</i>", thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                          config_params[i].param_name, config_params[i].param_name,
                                          value, TWIKI_URL, config_params[i].param_name, text_help);
                         }
@@ -709,8 +722,10 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
         } else if (length_uri == 0) {
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, set_template);
-                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Thread %hu</b>\n"
-                             "<form name='n'>\n<select name='onames'>\n", thread, thread);
+                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>\n"
+                             "<form name='n'>\n<select name='onames'>\n", thread, thread,
+                             cnt[thread]->conf.camera_name ? " -- " : "",
+                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
 
                 send_template(client_socket, res);
                 for (i=0; config_params[i].param_name != NULL; i++) {
@@ -803,10 +818,13 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 send_template_ini_client(client_socket, ini_template);
                                 sprintf(res, "<a href=/%hu/config/get>&lt;&ndash; back</a><br><br>\n"
-                                             "<b>Thread %hu</b><br>\n<ul><li>%s = %s &nbsp;&nbsp;"
+                                             "<b>Thread %hu%s%s</b><br>\n<ul><li>%s = %s &nbsp;&nbsp;"
                                              "&nbsp;&nbsp;<a href='%s#%s' target=_blank>"
                                              "[help]</a></li></ul><hr><i>%s</i>",
-                                             thread, thread, config_params[i].param_name, value,
+                                             thread, thread,
+                                             cnt[thread]->conf.camera_name ? " -- " : "",
+                                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                             config_params[i].param_name, value,
                                              TWIKI_URL, config_params[i].param_name, text_help);
 
                                 send_template(client_socket, res);
@@ -837,9 +855,11 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
         } else if (length_uri == 0) {
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Thread %hu</b><br>\n"
+                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b><br>\n"
                              "<form action=get>\n"
-                             "<select name='query'>\n", thread, thread);
+                             "<select name='query'>\n", thread, thread,
+                        cnt[thread]->conf.camera_name ? " -- " : "",
+                        cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
                 for (i=0; config_params[i].param_name != NULL; i++) {
                     if ((thread != 0) && (config_params[i].main_thread))
@@ -896,8 +916,10 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
             conf_print(cnt);
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Thread %hu</b>  write done !\n",
-                             thread, thread);
+                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>  write done !\n",
+                             thread, thread,
+                             cnt[thread]->conf.camera_name ? " -- " : "",
+                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
             } else {
@@ -1131,8 +1153,10 @@ static unsigned int detection(char *pointer, char *res, unsigned int length_uri,
 
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/detection>&lt;&ndash; back</a><br><br><b>Thread %hu</b>"
+                sprintf(res, "<a href=/%hu/detection>&lt;&ndash; back</a><br><br><b>Thread %hu%s%s</b>"
                              " Detection status %s\n", thread, thread,
+                             cnt[thread]->conf.camera_name ? " -- " : "",
+                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                              (!cnt[thread]->running)? "NOT RUNNING": (cnt[thread]->pause)? "PAUSE":"ACTIVE");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
@@ -1165,8 +1189,10 @@ static unsigned int detection(char *pointer, char *res, unsigned int length_uri,
 
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/detection>&lt;&ndash; back</a><br><br>\n<b>Thread %hu</b>"
-                             " Detection resumed\n", thread, thread);
+                sprintf(res, "<a href=/%hu/detection>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>"
+                             " Detection resumed\n", thread, thread,
+                             cnt[thread]->conf.camera_name ? " -- " : "",
+                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
             } else {
@@ -1197,13 +1223,17 @@ static unsigned int detection(char *pointer, char *res, unsigned int length_uri,
 
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/detection>&lt;&ndash; back</a><br><br>\n<b>Thread %hu</b>"
-                             " Detection paused\n", thread, thread);
+                sprintf(res, "<a href=/%hu/detection>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>"
+                             " Detection paused\n", thread, thread,
+                             cnt[thread]->conf.camera_name ? " -- " : "",
+                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
             } else {
                 send_template_ini_client_raw(client_socket);
-                sprintf(res, "<b>Thread %hu</b> Detection paused\nDone\n", thread);
+                sprintf(res, "<b>Thread %hu%s%s</b> Detection paused\nDone\n", thread,
+                        cnt[thread]->conf.camera_name ? " -- " : "",
+                        cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template_raw(client_socket, res);
             }
         } else {
@@ -1225,13 +1255,17 @@ static unsigned int detection(char *pointer, char *res, unsigned int length_uri,
                 send_template(client_socket, res);
                 if (thread == 0) {
                     do{
-                        sprintf(res, "<b>Thread %hu</b> %s<br>\n", i,
+                        sprintf(res, "<b>Thread %hu%s%s</b> %s<br>\n", i,
+                                     cnt[thread]->conf.camera_name ? " -- " : "",
+                                     cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                      (!cnt[i]->running)? "NOT RUNNING" :
                                      (cnt[i]->lost_connection)?CONNECTION_KO:CONNECTION_OK);
                         send_template(client_socket, res);
                     } while (cnt[++i]);
                 } else {
-                    sprintf(res, "<b>Thread %hu</b> %s\n", thread,
+                    sprintf(res, "<b>Thread %hu%s%s</b> %s\n", thread,
+                                 cnt[thread]->conf.camera_name ? " -- " : "",
+                                 cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                  (!cnt[thread]->running)? "NOT RUNNING" :
                                  (cnt[thread]->lost_connection)? CONNECTION_KO: CONNECTION_OK);
                     send_template(client_socket, res);
@@ -1403,9 +1437,12 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             send_template_ini_client(client_socket, ini_template);
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu</b><br>\n"
+                                         "<b>Thread %hu%s%s</b><br>\n"
                                          "track set relative pan=%s<br>\n",
-                                         thread, thread, panvalue);
+                                         thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                         panvalue);
                             send_template(client_socket, res);
                             send_template_end_client(client_socket);
                         } else {
@@ -1417,7 +1454,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                     /* error in track action */
                         if (cnt[0]->conf.webcontrol_html_output) {
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu</b>\n", thread, thread);
+                                         "<b>Thread %hu%s%s</b>\n", thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                             response_client(client_socket, track_error, res);
                         } else {
                             response_client(client_socket, track_error_raw, NULL);
@@ -1440,9 +1479,12 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             send_template_ini_client(client_socket, ini_template);
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu</b><br>\n"
+                                         "<b>Thread %hu%s%s</b><br>\n"
                                          "track set relative tilt=%s\n",
-                                         thread, thread, tiltvalue);
+                                         thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                         tiltvalue);
                             send_template(client_socket, res);
                             send_template_end_client(client_socket);
                         } else {
@@ -1454,7 +1496,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         /* error in track action */
                         if (cnt[0]->conf.webcontrol_html_output) {
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu</b>\n", thread, thread);
+                                         "<b>Thread %hu%s%s</b>\n", thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                             response_client(client_socket, track_error, res);
                         } else {
                             response_client(client_socket, track_error_raw, NULL);
@@ -1469,9 +1513,12 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             send_template_ini_client(client_socket, ini_template);
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu</b><br>\n"
-                                     "track set absolute x=%s\n",
-                                         thread, thread, x_value);
+                                         "<b>Thread %hu%s%s</b><br>\n"
+                                         "track set absolute x=%s\n",
+                                         thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                         x_value);
                             send_template(client_socket, res);
                             send_template_end_client(client_socket);
                         } else {
@@ -1483,7 +1530,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         /* error in track action */
                         if (cnt[0]->conf.webcontrol_html_output) {
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu</b>\n", thread, thread);
+                                         "<b>Thread %hu%s%s</b>\n", thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                             response_client(client_socket, track_error, res);
                         } else {
                             response_client(client_socket, track_error_raw, NULL);
@@ -1499,9 +1548,12 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             send_template_ini_client(client_socket, ini_template);
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu</b><br>\n"
+                                         "<b>Thread %hu%s%s</b><br>\n"
                                          "track set absolute y=%s<br>\n",
-                                         thread, thread, y_value);
+                                         thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                         y_value);
                             send_template(client_socket, res);
                             send_template_end_client(client_socket);
                         } else {
@@ -1513,7 +1565,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         /* error in track action */
                         if (cnt[0]->conf.webcontrol_html_output) {
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu</b>\n", thread, thread);
+                                         "<b>Thread %hu%s%s</b>\n", thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                             response_client(client_socket, track_error, res);
                         } else {
                             response_client(client_socket, track_error_raw, NULL);
@@ -1671,9 +1725,12 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                     if (cnt[0]->conf.webcontrol_html_output) {
                         send_template_ini_client(client_socket, ini_template);
                         sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                     "<b>Thread %hu</b><br>\n"
+                                     "<b>Thread %hu%s%s</b><br>\n"
                                      "track absolute set x=%s y=%s<br>\n",
-                                     thread, thread, x_value, y_value);
+                                     thread, thread,
+                                     cnt[thread]->conf.camera_name ? " -- " : "",
+                                     cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                     x_value, y_value);
                         send_template(client_socket, res);
                         send_template_end_client(client_socket);
                     } else {
@@ -1685,7 +1742,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                     /* error in track action */
                     if (cnt[0]->conf.webcontrol_html_output) {
                         sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                     "<b>Thread %hu</b>\n", thread, thread);
+                                     "<b>Thread %hu%s%s</b>\n", thread, thread,
+                                     cnt[thread]->conf.camera_name ? " -- " : "",
+                                     cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                         response_client(client_socket, track_error, res);
                     } else {
                         response_client(client_socket, track_error_raw, NULL);
@@ -1721,9 +1780,12 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             send_template_ini_client(client_socket, ini_template);
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu</b><br>\n"
+                                         "<b>Thread %hu%s%s</b><br>\n"
                                          "track relative pan=%s tilt=%s\n",
-                                         thread, thread, panvalue, tiltvalue);
+                                         thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                         panvalue, tiltvalue);
                             send_template(client_socket, res);
                             send_template_end_client(client_socket);
                         } else {
@@ -1737,7 +1799,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         /* error in track tilt */
                         if (cnt[0]->conf.webcontrol_html_output) {
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu</b>\n", thread, thread);
+                                         "<b>Thread %hu%s%s</b>\n", thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                             response_client(client_socket, track_error, res);
                         } else {
                             response_client(client_socket, track_error_raw, NULL);
@@ -1747,8 +1811,10 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
 
                 /* error in track pan */
                 if (cnt[0]->conf.webcontrol_html_output) {
-                    sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br><b>Thread %hu</b>\n",
-                                 thread, thread);
+                    sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br><b>Thread %hu%s%s</b>\n",
+                                 thread, thread,
+                                 cnt[thread]->conf.camera_name ? " -- " : "",
+                                 cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                     response_client(client_socket, track_error, res);
                 } else {
                     response_client(client_socket, track_error_raw, NULL);
@@ -1757,7 +1823,7 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
         } else if (length_uri == 0) {
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Thread %hu</b><br>\n"
+                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b><br>\n"
                              "<form action='set'>\n"
                              "Pan<input type=text name='pan' value=''>\n"
                              "Tilt<input type=text name='tilt' value=''>\n"
@@ -1767,7 +1833,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                              "X<input type=text name='x' value=''>\n"
                              "Y<input type=text name='y' value=''>\n"
                              "<input type=submit value='set absolute'>\n"
-                             "</form>\n", thread, thread);
+                             "</form>\n", thread, thread,
+                             cnt[thread]->conf.camera_name ? " -- " : "",
+                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
             } else {
@@ -1793,8 +1861,10 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
 
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Thread %hu</b>"
-                              "<br>track set center", thread, thread);
+                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>"
+                             "<br>track set center", thread, thread,
+                             cnt[thread]->conf.camera_name ? " -- " : "",
+                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
             } else {
@@ -1815,8 +1885,10 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
         if (length_uri==0) {
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Thread %hu</b>"
+                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>"
                              "<br>track auto %s", thread, thread,
+                             cnt[thread]->conf.camera_name ? " -- " : "",
+                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                              (cnt[thread]->track.active)? "enabled":"disabled");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
@@ -1856,9 +1928,11 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             send_template_ini_client(client_socket, ini_template);
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu</b><br>"
-                                     "track auto %s", thread, thread,
-                                    (cnt[thread]->track.active)? "enabled":"disabled");
+                                         "<b>Thread %hu%s%s</b><br>"
+                                         "track auto %s", thread, thread,
+                                         cnt[thread]->conf.camera_name ? " -- " : "",
+                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                         (cnt[thread]->track.active)? "enabled":"disabled");
                             send_template(client_socket, res);
                             send_template_end_client(client_socket);
                         } else {
@@ -1877,8 +1951,10 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 send_template_ini_client(client_socket, ini_template);
                                 sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                             "<b>Thread %hu</b>"
+                                             "<b>Thread %hu%s%s</b>"
                                              "<br>track auto %s<br>", thread, thread,
+                                             cnt[thread]->conf.camera_name ? " -- " : "",
+                                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                              active ? "enabled":"disabled");
                                 send_template(client_socket, res);
                                 send_template_end_client(client_socket);
@@ -1910,12 +1986,15 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
 
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Thread %hu</b>\n"
+                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>\n"
                              "<form action='auto'><select name='value'>\n"
                              "<option value='0' %s>Disable</option><option value='1' %s>Enable</option>\n"
                              "<option value='status'>status</option>\n"
                              "</select><input type=submit value='set'>\n"
-                             "</form>\n", thread, thread, (cnt[thread]->track.active) ? "selected":"",
+                             "</form>\n", thread, thread,
+                             cnt[thread]->conf.camera_name ? " -- " : "",
+                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                        (cnt[thread]->track.active) ? "selected":"",
                              (cnt[thread]->track.active) ? "selected":"");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
@@ -1974,7 +2053,7 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                 sprintf(res, "<b>Motion "VERSION" Running [%hu] Threads</b><br>\n"
                              "<a href='/0/'>All</a>\n", i);
                 send_template(client_socket, res);
-                
+
                 counter = 0;
                 for (y = 1; y < i; y++) {
                     counter++;
@@ -1983,7 +2062,9 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                         send_template(client_socket, res);
                         counter = 0;
                     }
-                    sprintf(res, "<a href='/%hu/'>Thread %hu</a>\n", y, y);
+                    sprintf(res, "<a href='/%hu/'>Thread %hu%s%s</a>\n", y, y,
+                                 cnt[y]->conf.camera_name ? " -- " : "",
+                                 cnt[y]->conf.camera_name ? cnt[y]->conf.camera_name : "");
                     send_template(client_socket, res);
                 }
                 sprintf(res, "<br>");
@@ -2056,12 +2137,15 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 send_template_ini_client(client_socket, ini_template);
                                 sprintf(res, "<a href=/%hd/>&lt;&ndash; back</a><br><br>\n"
-                                             "<b>Thread %hd</b><br>\n"
+                                             "<b>Thread %hd%s%s</b><br>\n"
                                              "<a href=/%hd/config/list>list</a><br>\n"
                                              "<a href=/%hd/config/write>write</a><br>\n"
                                              "<a href=/%hd/config/set>set</a><br>\n"
                                              "<a href=/%hd/config/get>get</a><br>\n",
-                                             thread, thread, thread, thread, thread, thread);
+                                             thread, thread,
+                                             cnt[thread]->conf.camera_name ? " -- " : "",
+                                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                        thread, thread, thread, thread);
                                 send_template(client_socket, res);
                                 send_template_end_client(client_socket);
                             } else {
@@ -2089,12 +2173,15 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 send_template_ini_client(client_socket, ini_template);
                                 sprintf(res, "<a href=/%hd/>&lt;&ndash; back</a><br><br>\n"
-                                             "<b>Thread %hd</b><br>\n"
+                                             "<b>Thread %hd%s%s</b><br>\n"
                                              "<a href=/%hd/action/makemovie>makemovie</a><br>\n"
                                              "<a href=/%hd/action/snapshot>snapshot</a><br>\n"
                                              "<a href=/%hd/action/restart>restart</a><br>\n"
                                              "<a href=/%hd/action/quit>quit</a><br>\n",
-                                             thread, thread, thread, thread, thread, thread);
+                                             thread, thread,
+                                             cnt[thread]->conf.camera_name ? " -- " : "",
+                                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                        thread, thread, thread, thread);
                                 send_template(client_socket, res);
                                 send_template_end_client(client_socket);
                             } else {
@@ -2123,12 +2210,15 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 send_template_ini_client(client_socket, ini_template);
                                 sprintf(res, "<a href=/%hd/>&lt;&ndash; back</a><br><br>\n"
-                                             "<b>Thread %hd</b><br>\n"
+                                             "<b>Thread %hd%s%s</b><br>\n"
                                              "<a href=/%hd/detection/status>status</a><br>\n"
                                              "<a href=/%hd/detection/start>start</a><br>\n"
                                              "<a href=/%hd/detection/pause>pause</a><br>\n"
                                              "<a href=/%hd/detection/connection>connection</a><br>\n",
-                                             thread, thread, thread, thread, thread, thread);
+                                             thread, thread,
+                                             cnt[thread]->conf.camera_name ? " -- " : "",
+                                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                             thread, thread, thread, thread);
                                 send_template(client_socket, res);
                                 send_template_end_client(client_socket);
                             } else {
@@ -2154,12 +2244,15 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 send_template_ini_client(client_socket, ini_template);
                                 sprintf(res, "<a href=/%hd/>&lt;&ndash; back</a><br><br>\n"
-                                             "<b>Thread %hd</b><br>\n"
+                                             "<b>Thread %hd%s%s</b><br>\n"
                                              "<a href=/%hd/track/set>track set pan/tilt</a><br>\n"
                                              "<a href=/%hd/track/center>track center</a><br>\n"
                                              "<a href=/%hd/track/auto>track auto</a><br>\n"
                                              "<a href=/%hd/track/status>track status</a><br>\n",
-                                             thread, thread, thread, thread, thread, thread);
+                                             thread, thread,
+                                             cnt[thread]->conf.camera_name ? " -- " : "",
+                                             cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                             thread, thread, thread, thread);
                                 send_template(client_socket, res);
                                 send_template_end_client(client_socket);
                             } else {
@@ -2203,12 +2296,15 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                     /* /thread_number/ requested */
                     if (cnt[0]->conf.webcontrol_html_output) {
                         send_template_ini_client(client_socket, ini_template);
-                        sprintf(res, "<a href=/>&lt;&ndash; back</a><br><br>\n<b>Thread %hd</b><br>\n"
+                        sprintf(res, "<a href=/>&lt;&ndash; back</a><br><br>\n<b>Thread %hd%s%s</b><br>\n"
                                      "<a href='/%hd/config'>config</a><br>\n"
                                      "<a href='/%hd/action'>action</a><br>\n"
                                      "<a href='/%hd/detection'>detection</a><br>\n"
                                      "<a href='/%hd/track'>track</a><br>\n",
-                                     thread, thread, thread, thread, thread);
+                                     thread,
+                                     cnt[thread]->conf.camera_name ? " -- " : "",
+                                     cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                                     thread, thread, thread, thread);
                         send_template(client_socket, res);
                         send_template_end_client(client_socket);
                     } else {
@@ -2577,6 +2673,11 @@ void httpd_run(struct context **cnt)
 void *motion_web_control(void *arg)
 {
     struct context **cnt = arg;
+
+#ifdef HAVE_PTHREAD_SETNAME_NP
+    pthread_setname_np(pthread_self(), "web_control");
+#endif
+
     httpd_run(cnt);
 
     /* 


### PR DESCRIPTION
I've been finding this really useful; it gives me a meaningful way to remember which camera is which in the web configuration interface and also makes it really easy to find the right thread for a camera in gdb (the camera name shows up in "info threads"). I've fixed a couple of minor issues since this was last commented on and renamed the option to camera_name as that seems a better name (and is consistent with the camera_id integer settings that's been suggested in another pull request).

Based on a commit originally by Chris Roberts <86montecarlo@gmail.com>

camera_name allows naming of threads, is displayed in the motion control
webpage, and a new specifier (%$) added enabling it to be used for
filenames and such.

The changes I have made since Chris's commit:

1. Change format specifier for threadname from %E to %$

This avoids clashing with any known strftime format specifiers.
(According to the Debian stable strftime man page - it seems we've
already used all spare letters to mean other things.)

2. Behaviour if camera_name is not set is now unchanged

(Previous it would display "thread 1 -- NULL" if the thread name was
unset, and I don't believe how printf deals with NULL values for %s
specifiers is guaranteed.)

3. Thread name is reflected into the system thread name

Uses pthread_setname_np. There's a autoconf test for it, which looks
for the version that takes the thread id and thread name. I believe
this should work on all recent linux, and maybe other platforms too.

(It won't work on macOS; autoconf will disable it - but I deliberately
always use the pthread_setname_np(pthread_self(), name) form so that
it could easily be adapted for macOS in the future.)

4. The parameter has been renamed from thread_name to camera_name, as
that seems to better reflect how the user will see it.