### PR TITLE
Stop "make clean" deleting documentation jpgs

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -259,7 +259,7 @@ uninstall remove: pre-build-info
 ################################################################################
 clean: pre-build-info
 	@echo "Removing compiled files and binaries..."
-	@rm -f *~ *.jpg *.o $(PROGS) combine $(DEPEND_FILE)
+	@rm -f *~ *.o $(PROGS) combine $(DEPEND_FILE)
 
 ################################################################################
 # DIST restores the directory to distribution state.                           #


### PR DESCRIPTION
make clean currently removes all jpgs, which means it deletes the jpgs
used in the documentation (outputnormal1.jpg etc). This seems like it
wasn't intended.

I can't figure out why it deletes jpgs at all, it seems to date back
to the initial import of version 3.2.5 into svn in 2005 - seems safe
to remove it.