### PR TITLE
Fix for whitespace only lines in config file

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -1750,7 +1750,7 @@ static struct context **conf_process(struct context **cnt, FILE *fp)
 
             /* Trim white space and any CR or LF at the end of the line. */
             end = line + strlen(line) - 1; /* Point to the last non-null character in the string. */
-            while (*end == ' ' || *end == '\t' || *end == '\n' || *end == '\r')
+            while (end >= line && (*end == ' ' || *end == '\t' || *end == '\n' || *end == '\r'))
                 end--;
 
             *(end+1) = '\0';


### PR DESCRIPTION
The while loop was missing a condition to stop at the start of the line,
so we'd carry on beyond the start of the buffer.

Closes #88