### PR TITLE
MYPixelFormat Revision

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -10,7 +10,17 @@
  *
  * This file has been modified so that only major versions greater than
  * 53 are supported.
- */
+ * Note that while the conditions are based upon LIBAVFORMAT, not all of the changes are 
+ * specific to libavformat.h.  Some changes could be related to other components of ffmpeg.
+ * This is for simplicity.  The avformat version has historically changed at the same time
+ * as the other components so it is easier to have a single version number to track rather 
+ * than the particular version numbers which are associated with each component.
+ * The libav variant also has different apis with the same major/minor version numbers.  
+ * As such, it is occasionally necessary to look at the microversion number.  Numbers
+ * greater than 100 for micro version indicate ffmpeg whereas numbers less than 100
+ * indicate libav
+*/
+
 
 #include "config.h"
 

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -17,22 +17,14 @@
 
 #define MY_PIX_FMT_YUV420P   AV_PIX_FMT_YUV420P
 #define MY_PIX_FMT_YUVJ420P  AV_PIX_FMT_YUVJ420P
+#define MyPixelFormat AVPixelFormat 
 
 #else
 
 #define MY_PIX_FMT_YUV420P   PIX_FMT_YUV420P
 #define MY_PIX_FMT_YUVJ420P  PIX_FMT_YUVJ420P
-
-#endif
-
-/**
- * libavutil changed the name from PixelFormat to AVPixelFormat in 51.42.0
- * Add compatibility with older versions.
- */
-#ifdef FF_API_PIX_FMT
-#define MyPixelFormat AVPixelFormat 
-#else
 #define MyPixelFormat PixelFormat
+
 #endif
 
 #endif /* HAVE_FFMPEG */


### PR DESCRIPTION
Revise the condition used for testing older versions of ffmpeg to use the AVFormat version number instead of the FF_API_PIX_FMT.  Closes #165 