### PR TITLE
Adding ubuntu 14.04 to build along with 12.04 in travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,42 @@
-language: c
-compiler: gcc
-before_script: autoreconf -fiv
-addons:
-  apt:
-    packages:
-      - libavformat-dev
-      - libavcodec-dev
-      - libav-tools
-      - libavutil-dev
-      - libswscale-dev 
-      - ffmpeg
-      - libjpeg8-dev
-      - libv4l-dev 
-      - libzip-dev
+before_script:
+  - autoreconf -fiv
+  - avplay -version
 script: ./configure && make
+
+matrix:
+  include:
+  - os: linux
+    language: c
+    compiler: gcc
+    addons:
+      apt:
+        packages:
+        - libavformat-dev
+        - libavcodec-dev
+        - libav-tools
+        - libavutil-dev
+        - libswscale-dev
+        - ffmpeg
+        - libjpeg8-dev
+        - libv4l-dev
+        - libzip-dev
+  - os: linux
+    language: c
+    compiler: gcc
+    sudo: rquired
+    dist: trusty
+    addons:
+      apt:
+        sources:
+        - sourceline: 'ppa:mc3man/trusty-media'
+        packages:
+        - libavformat-dev
+        - libavcodec-dev
+        - libav-tools
+        - libavutil-dev
+        - libswscale-dev
+        - ffmpeg
+        - libjpeg8-dev
+        - libv4l-dev
+        - libzip-dev
+


### PR DESCRIPTION
Duplicated the addons section of travis so that I could add in the sourceline to apt for 14.04 so ffmpeg can be installed from the PPA (https://launchpad.net/~mc3man/+archive/ubuntu/trusty-media)

You can see the complete build output here: https://travis-ci.org/mterzo/motion/builds/160351676

12.04 lib versions:
```
$ avplay -version
avplay version 0.8.17-4:0.8.17-0ubuntu0.12.04.2, Copyright (c) 2003-2014 the Libav developers
  built on Apr  1 2016 14:24:20 with gcc 4.6.3
avplay 0.8.17-4:0.8.17-0ubuntu0.12.04.2
libavutil    51. 22. 3 / 51. 22. 3
libavcodec   53. 35. 0 / 53. 35. 0
libavformat  53. 21. 1 / 53. 21. 1
libavdevice  53.  2. 0 / 53.  2. 0
libavfilter   2. 15. 0 /  2. 15. 0
libswscale    2.  1. 0 /  2.  1. 0
libpostproc  52.  0. 0 / 52.  0. 0
```

14.04 lib versions:
```
avplay version 9.18-6:9.18-0ubuntu0.14.04.1+fdkaac, Copyright (c) 2003-2014 the Libav developers
  built on Apr 10 2015 23:18:58 with gcc 4.8 (Ubuntu 4.8.2-19ubuntu1)
avplay 9.18-6:9.18-0ubuntu0.14.04.1+fdkaac
libavutil     52.  3. 0 / 52.  3. 0
libavcodec    54. 35. 0 / 54. 35. 0
libavformat   54. 20. 4 / 54. 20. 4
libavdevice   53.  2. 0 / 53.  2. 0
libavfilter    3.  3. 0 /  3.  3. 0
libavresample  1.  0. 1 /  1.  0. 1
libswscale     2.  1. 1 /  2.  1. 1
```