### PR TITLE
Fix detection of sqlite3 when cross-compiling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -460,16 +460,13 @@ else
 
     # first we check to see if the sqlite3 amalgamation (sqlite3.c), is in with our source
     # this is the prefered way to use sqlite
-    AC_CHECK_FILE([sqlite3.c],
-        [
+    if test -f sqlite3.c; then
         SQLITE3_SUPPORT="yes"
         VIDEO="$VIDEO sqlite3.o"
         TEMP_LIBS="$TEMP_LIBS -ldl"
         AC_DEFINE([HAVE_SQLITE3],1,[Define to 1 if you have SQLITE3])
         AC_DEFINE([HAVE_SQLITE3_EMBEDDED],1,[Define to 1 if you have SQLITE3 embedded support])
-        ]
-        ,
-        [
+    else
         # if sqlite3.c is not found then we look for the shared library
         AC_CHECK_LIB(sqlite3, sqlite3_open,
             [
@@ -478,8 +475,7 @@ else
             AC_DEFINE([HAVE_SQLITE3],1,[Define to 1 if you have SQLITE3 shared library support])
             ]
         )
-        ]
-    )
+    fi
 
     CFLAGS=$saved_CFLAGS
     LIBS=$saved_LIBS


### PR DESCRIPTION
Replace usage of AC_CHECK_FILE by test -f to check the existence of
sqlite3.c as AC_CHECK_FILE does not work when cross-compiling

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>