### PR TITLE
automatically resize mask image if size differs from that of the captured image

### DIFF
--- a/motion_guide.html
+++ b/motion_guide.html
@@ -2559,8 +2559,8 @@ Areas are numbered like
 </ul> 
 <p></p>
 The full path and filename for the masking pgm file.  
-This picture MUST have the same width and height as the frames being 
-captured and be in binary format.
+If needed, the mask will be resized to match the width and height of the frames being 
+captured.
 If you have one or more areas of the camera image in which you do NOT want motion detected (e.g. a tree that 
 moves in the wind or a corner of the picture where you can see cars/pedestrians passing by) you need a mask file. 
 This file is a picture that you create in your favorite photo editing program. The areas that you want detected must 


### PR DESCRIPTION
While trying to add mask support to motionEye, I found out that the mask file image must match that of the captured image.

This is acceptable for local V4L(2) cameras whose resolution is normally explicitly specified using `width` and `height` directives. But when it comes to (M)JPEG netcams, where **the image size is not known beforehand**, it makes it impossible for a frontend to **automatically generate a suitable mask** (which is what I'm trying to achieve with motionEye these days).

I thought that resizing the PGM mask file as soon as it is requested and loaded is the easiest solution to my problem and the best thing to do in general, when sizes don't match. This pull request implements a very simple resize method applied on the PGM mask file when required.