### PR TITLE
Updated extpipe examples with ultrafast H264 (ffmpeg, mencoder and x264)

### DIFF
--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -352,8 +352,10 @@ use_extpipe off
 
 # External program (full path and opts) to pipe raw video to
 # Generally, use '-' for STDIN...
-;extpipe mencoder -demuxer rawvideo -rawvideo w=320:h=240:i420 -ovc x264 -x264encopts bframes=4:frameref=1:subq=1:scenecut=-1:nob_adapt:threads=1:keyint=1000:8x8dct:vbv_bufsize=4000:crf=24:partitions=i8x8,i4x4:vbv_maxrate=800:no-chroma-me -vf denoise3d=16:12:48:4,pp=lb -of   avi -o %f.avi - -fps %fps
-
+;extpipe mencoder -demuxer rawvideo -rawvideo w=%w:h=%h:i420 -ovc x264 -x264encopts bframes=4:frameref=1:subq=1:scenecut=-1:nob_adapt:threads=1:keyint=1000:8x8dct:vbv_bufsize=4000:crf=24:partitions=i8x8,i4x4:vbv_maxrate=800:no-chroma-me -vf denoise3d=16:12:48:4,pp=lb -of   avi -o %f.avi - -fps %fps
+;extpipe x264 - --input-res %wx%h --fps %fps --bitrate 2000 --preset ultrafast --quiet -o %f.mp4
+;extpipe mencoder -demuxer rawvideo -rawvideo w=%w:h=%h:fps=%fps -ovc x264 -x264encopts preset=ultrafast -of lavf -o %f.mp4 - -fps %fps
+;extpipe ffmpeg -y -f rawvideo -pix_fmt yuv420p -video_size %wx%h -framerate %fps -i pipe:0 -vcodec libx264 -preset ultrafast -f mp4 %f.mp4
 
 
 ############################################################

--- a/motion_guide.html
+++ b/motion_guide.html
@@ -3538,6 +3538,12 @@ if a dash '-' is given motion will use /proc/video/vloopback/vloopbacks to locat
 This option specifies whether to send the output to a 
 pipe for external encoding into a movie. 
 <p></p>
+Piping raw video to stdout has some advantages comparing to using built-in ffmpeg encoder.
+First, this way you can use any encoder that supports RAW frames from stdin so you are not limited to the formats
+that are currently implemented in motion. See examples in <a href="#extpipe">extpipe</a>
+Second, external encoder utilizes separate cpu core on a multi-core system so movie encoding is offloaded
+from main motion thread to a separate core(s) giving noticeable performance boost
+<p></p>
 Note that this option does not require the install or configure of the videoloop back
 <p></p>
 <p></p>
@@ -3558,8 +3564,13 @@ Note that this option does not require the install or configure of the videoloop
 <p></p>
 Sample:
 <p></p>
-extpipe mencoder -demuxer rawvideo -rawvideo w=320:h=240:i420 -ovc x264 -x264encopts bframes=4:frameref=1:subq=1:scenecut=-1:nob_adapt:threads=1:keyint=1000:8x8dct:vbv_bufsize=4000:crf=24:partitions=i8x8,i4x4:vbv_maxrate=800:no-chroma-me -vf denoise3d=16:12:48:4,pp=lb -of   avi -o %f.avi - -fps %fps
-
+extpipe mencoder -demuxer rawvideo -rawvideo w=%w:h=%h:i420 -ovc x264 -x264encopts bframes=4:frameref=1:subq=1:scenecut=-1:nob_adapt:threads=1:keyint=1000:8x8dct:vbv_bufsize=4000:crf=24:partitions=i8x8,i4x4:vbv_maxrate=800:no-chroma-me -vf denoise3d=16:12:48:4,pp=lb -of   avi -o %f.avi - -fps %fps
+<p></p>
+extpipe x264 - --input-res %wx%h --fps %fps --bitrate 2000 --preset ultrafast --quiet -o %f.mp4
+<p></p>
+extpipe mencoder -demuxer rawvideo -rawvideo w=%w:h=%h:fps=%fps -ovc x264 -x264encopts preset=ultrafast -of lavf -o %f.mp4 - -fps %fps
+<p></p>
+extpipe ffmpeg -y -f rawvideo -pix_fmt yuv420p -video_size %wx%h -framerate %fps -i pipe:0 -vcodec libx264 -preset ultrafast -f mp4 %f.mp4
 <p></p>
 <p></p>
 


### PR DESCRIPTION
Guys, what do you think about extending examples of `extpipe`? The existing one may be too scary for users, so I have added few more. They are simple and use different encoders to better demonstrate the approach.
```
Updated extpipe examples with ultrafast H264 (ffmpeg, mencoder and x264)
Also updated previous example to use %w and %h variables
```