### PR TITLE
Fix jpeg-turbo detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -273,7 +273,7 @@ if test "${JPEG_TURBO}" = "no"; then
     AC_MSG_RESULT(skipping)
 else
     AC_MSG_CHECKING(for libjpeg-turbo in -> [${JPEG_TURBO}] <-)
-    if test -f ${JPEG_TURBO}/lib/libjpeg.a -o ${JPEG_TURBO}/lib/libjpeg.so; then
+    if test -f ${JPEG_TURBO}/lib/libjpeg.a -o -f ${JPEG_TURBO}/lib/libjpeg.so; then
         AC_MSG_RESULT(found)
         JPEG_TURBO_OK="found"
     else


### PR DESCRIPTION
Commit number 4998d465f7837a01c02d88e6d213e5f881e62122 added the detection of jpeg-turbo dynamic library through -o but -f argument was missing so test was always true

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>