### PR TITLE
Fix hostname determination for IPv6 addresses in web server.

### DIFF
--- a/webhttpd.c
+++ b/webhttpd.c
@@ -2455,12 +2455,13 @@ static unsigned int read_client(int client_socket, void *userdata, char *auth)
                  * work that the result of gethostname(), which is reliant on
                  * the machine we're running on having it's hostname setup
                  * correctly and corresponding DNS in place. */
-                char *end_host = NULL;
                 hostname += strlen("Host:");
-                while (isspace(*hostname))
-                    hostname++;
-
-                if ((end_host = strstr(hostname,"\r\n"))) {
+                char *end_host = strstr(hostname,"\r\n");
+                if (end_host) {
+                    while (hostname < end_host && isspace(hostname[0]))
+                        hostname++;
+                    while (hostname < end_host && isspace(end_host[-1]))
+                        end_host--;
                     /* we have a string that is the hostname followed by
                      * optionally a colon and a port number - strip off any
                      * port number & colon */
@@ -2475,8 +2476,6 @@ static unsigned int read_client(int client_socket, void *userdata, char *auth)
                     }
                     if (colon)
                       end_host = colon;
-                    while (isspace(end_host[-1]))
-                        end_host--;
                     hostname = strndup(hostname, end_host-hostname);
                 } else {
                     hostname = NULL;

--- a/webhttpd.c
+++ b/webhttpd.c
@@ -2467,17 +2467,17 @@ static unsigned int read_client(int client_socket, void *userdata, char *auth)
                     char *colon = NULL;
                     if (hostname[0] == '[') {
                         // hostname is a IPv6 address like "[::1]"
-                        char *endbracket = memchr(hostname, ']', hostname-end_host);
+                        char *end_bracket = memchr(hostname, ']', end_host-hostname);
                         // look for the colon after the "]"
-                        colon = memchr(endbracket, ':', hostname-end_host);
+                        colon = memchr(end_bracket, ':', end_host-end_bracket);
                     } else {
-                        colon = memchr(hostname, ':', hostname-end_host);
+                        colon = memchr(hostname, ':', end_host-hostname);
                     }
                     if (colon)
                       end_host = colon;
                     while (isspace(end_host[-1]))
                         end_host--;
-                    hostname = strndup(hostname, end_host - hostname);
+                    hostname = strndup(hostname, end_host-hostname);
                 } else {
                     hostname = NULL;
                 }

--- a/webhttpd.c
+++ b/webhttpd.c
@@ -2464,7 +2464,15 @@ static unsigned int read_client(int client_socket, void *userdata, char *auth)
                     /* we have a string that is the hostname followed by
                      * optionally a colon and a port number - strip off any
                      * port number & colon */
-                    char *colon = memchr(hostname, ':', hostname-end_host);
+                    char *colon = NULL;
+                    if (hostname[0] == '[') {
+                        // hostname is a IPv6 address like "[::1]"
+                        char *endbracket = memchr(hostname, ']', hostname-end_host);
+                        // look for the colon after the "]"
+                        colon = memchr(endbracket, ':', hostname-end_host);
+                    } else {
+                        colon = memchr(hostname, ':', hostname-end_host);
+                    }
                     if (colon)
                       end_host = colon;
                     while (isspace(end_host[-1]))


### PR DESCRIPTION
When the web control is accessed via a IPv6 address, e.g. `http://[::1]:8080/`, the links displayed in the web control page were incorrect. This is because the hostname function simply looked for the first colon in the address, and cut off everything after that, assuming that that is the port number.

This checks if the hostname starts with an `[`, meaning it is an IPv6 address (according to [RFC 3986#3.2.2](https://tools.ietf.org/html/rfc3986#section-3.2.2)), and properly finds the colon after the closing `]`.