### PR TITLE
Cleanup HTML.

### DIFF
--- a/stream.c
+++ b/stream.c
@@ -413,26 +413,28 @@ static void* handle_md5_digest(void* param)
         "Pragma: no-cache\r\n"
         "WWW-Authenticate: Digest";
     static const char *auth_failed_html_template=
-        "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\r\n"
-        "<HTML><HEAD>\r\n"
-        "<TITLE>401 Authorization Required</TITLE>\r\n"
-        "</HEAD><BODY>\r\n"
-        "<H1>Authorization Required</H1>\r\n"
-        "This server could not verify that you are authorized to access the document "
+        "<!DOCTYPE html>\n"
+        "<html>\n"
+        "<head><title>401 Authorization Required</title></head>\n"
+        "<body>\n"
+        "<h1>Authorization Required</h1>\n"
+        "<p>This server could not verify that you are authorized to access the document "
         "requested.  Either you supplied the wrong credentials (e.g., bad password), "
-        "or your browser doesn't understand how to supply the credentials required.\r\n"
-        "</BODY></HTML>\r\n";
+        "or your browser doesn't understand how to supply the credentials required.</p>\n"
+        "</body>\n"
+        "</html>\n";
     static const char *internal_error_template=
         "HTTP/1.0 500 Internal Server Error\r\n"
         "Server: Motion/"VERSION"\r\n"
         "Content-Type: text/html\r\n"
         "Connection: Close\r\n\r\n"
-        "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">\r\n"
-        "<HTML><HEAD>\r\n"
-        "<TITLE>500 Internal Server Error</TITLE>\r\n"
-        "</HEAD><BODY>\r\n"
-        "<H1>500 Internal Server Error</H1>\r\n"
-        "</BODY></HTML>\r\n";
+        "<!DOCTYPE html>\n"
+        "<html>\n"
+        "<head><title>500 Internal Server Error</title></head>\n"
+        "<body>\n"
+        "<h1>500 Internal Server Error</h1>\n"
+        "</body>\n"
+        "</html>\n";
 
 #ifdef HAVE_PTHREAD_SETNAME_NP
     pthread_setname_np(pthread_self(), "handle_md5_digest");

--- a/webhttpd.c
+++ b/webhttpd.c
@@ -26,16 +26,23 @@ pthread_mutex_t httpd_mutex;
 int warningkill;
 
 static const char *ini_template =
-    "<html><head><title>Motion "VERSION"</title></head>\n"
+    "<!DOCTYPE html>\n"
+    "<html>\n"
+    "<head><title>Motion "VERSION"</title></head>\n"
     "<body>\n";
 
 static const char *set_template =
-    "<html><head><script language='javascript'>"
+    "<!DOCTYPE html>\n"
+    "<html>\n"
+    "<head>\n"
+    "<title>Motion "VERSION"</title>\n"
+    "<script language='javascript'>"
     "function show() {top.location.href="
     "'set?'+document.n.onames.options[document.n.onames.selectedIndex].value"
     "+'='+document.s.valor.value;"
-    "}</script>\n<title>Motion "VERSION"</title>\n"
-    "</head><body>\n";
+    "}</script>\n"
+    "</head>\n"
+    "<body>\n";
 
 static const char *end_template =
     "</body>\n"
@@ -66,6 +73,7 @@ static const char *ok_response_raw =
 static const char *bad_request_response =
     "HTTP/1.0 400 Bad Request\r\n"
     "Content-type: text/html\r\n\r\n"
+    "<!DOCTYPE html>\n"
     "<html>\n"
     "<body>\n"
     "<h1>Bad Request</h1>\n"
@@ -81,6 +89,7 @@ static const char *bad_request_response_raw =
 static const char *not_found_response_template =
     "HTTP/1.0 404 Not Found\r\n"
     "Content-type: text/html\r\n\r\n"
+    "<!DOCTYPE html>\n"
     "<html>\n"
     "<body>\n"
     "<h1>Not Found</h1>\n"
@@ -96,6 +105,7 @@ static const char *not_found_response_template_raw =
 static const char *not_found_response_valid =
     "HTTP/1.0 404 Not Valid\r\n"
     "Content-type: text/html\r\n\r\n"
+    "<!DOCTYPE html>\n"
     "<html>\n"
     "<body>\n"
     "<h1>Not Valid</h1>\n"
@@ -111,6 +121,7 @@ static const char *not_found_response_valid_raw =
 static const char *not_valid_syntax =
     "HTTP/1.0 404 Not Valid Syntax\r\n"
     "Content-type: text/html\r\n\r\n"
+    "<!DOCTYPE html>\n"
     "<html>\n"
     "<body>\n"
     "<h1>Not Valid Syntax</h1>\n"
@@ -125,6 +136,7 @@ static const char *not_valid_syntax_raw =
 static const char *not_track =
     "HTTP/1.0 200 OK\r\n"
     "Content-type: text/html\r\n\r\n"
+    "<!DOCTYPE html>\n"
     "<html>\n"
     "<body>\n"
     "<h1>Tracking Not Enabled</h1>\n";
@@ -137,6 +149,7 @@ static const char *not_track_raw =
 static const char *track_error =
     "HTTP/1.0 200 OK\r\n"
     "Content-type: text/html\r\n\r\n"
+    "<!DOCTYPE html>\n"
     "<html>\n"
     "<body>\n"
     "<h1>Track Error</h1>\n";
@@ -149,6 +162,7 @@ static const char *track_error_raw =
 static const char *error_value =
     "HTTP/1.0 200 OK\r\n"
     "Content-type: text/html\r\n\r\n"
+    "<!DOCTYPE html>\n"
     "<html>\n"
     "<body>\n"
     "<h1>Value Error</h1>\n";
@@ -161,6 +175,7 @@ static const char *error_value_raw =
 static const char *not_found_response_valid_command =
     "HTTP/1.0 404 Not Valid Command\r\n"
     "Content-type: text/html\r\n\r\n"
+    "<!DOCTYPE html>\n"
     "<html>\n"
     "<body>\n"
     "<h1>Not Valid Command</h1>\n"
@@ -176,6 +191,7 @@ static const char *not_found_response_valid_command_raw =
 static const char *bad_method_response_template =
     "HTTP/1.0 501 Method Not Implemented\r\n"
     "Content-type: text/html\r\n\r\n"
+    "<!DOCTYPE html>\n"
     "<html>\n"
     "<body>\n"
     "<h1>Method Not Implemented</h1>\n"


### PR DESCRIPTION
Clean up HTML:
* Use the HTML5 doctype everywhere, as [recommended](https://www.w3.org/QA/Tips/Doctype) by the W3C. This shouldn't have any effect right now, but is good to have if we want more complex HTML in the future.
* Use lowercase HTML tags (more readable)
* Line breaks with `\n` instead of `\r\n` (`\r\n` is only needed in HTTP headers)
* Line breaks in more logical places in the HTML.