### PR TITLE
Revise the netcam_interupt

### DIFF
--- a/netcam.c
+++ b/netcam.c
@@ -2007,7 +2007,8 @@ static void *netcam_handler_loop(void *arg)
 
         if (netcam->caps.streaming == NCS_RTSP) {
             if (netcam->rtsp->format_context == NULL) {      // We must have disconnected.  Try to reconnect
-                if (netcam->rtsp->status == RTSP_CONNECTED){
+                if ((netcam->rtsp->status == RTSP_CONNECTED) ||
+                    (netcam->rtsp->status == RTSP_READINGIMAGE)){
                     MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: Reconnecting with camera....");
                 }
                 netcam->rtsp->status = RTSP_RECONNECTING;
@@ -2016,7 +2017,8 @@ static void *netcam_handler_loop(void *arg)
             } else {
                 // We think we are connected...
                 if (netcam->get_image(netcam) < 0) {
-                    if (netcam->rtsp->status == RTSP_CONNECTED){
+                    if ((netcam->rtsp->status == RTSP_CONNECTED) ||
+                        (netcam->rtsp->status == RTSP_READINGIMAGE)){
                         MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: Bad image.  Reconnecting with camera....");
                     }
                     //Nope.  We are not or got bad image.  Reconnect

--- a/netcam.h
+++ b/netcam.h
@@ -107,10 +107,12 @@ typedef struct file_context {
 #define NCS_BLOCK               2  /* streaming is done via MJPG-block */
 #define NCS_RTSP                3  /* streaming is done via RTSP */
 
-
-#define RTSP_NOTCONNECTED  0  /* The camera has never connected */
-#define RTSP_CONNECTED     1  /* The camera is currently connected */
-#define RTSP_RECONNECTING  2  /* The camera is trying to reconnect*/
+enum RTSP_STATUS {
+    RTSP_NOTCONNECTED,   /* The camera has never connected */
+    RTSP_CONNECTED,      /* The camera is currently connected */
+    RTSP_RECONNECTING,   /* Motion is trying to reconnect to camera */
+    RTSP_READINGIMAGE    /* Motion is reading a image from camera */
+};
 
 /*
  * struct netcam_context contains all the structures and other data

--- a/netcam_rtsp.c
+++ b/netcam_rtsp.c
@@ -258,15 +258,31 @@ struct rtsp_context *rtsp_new_context(void){
 static int netcam_interrupt_rtsp(void *ctx){
     struct rtsp_context *rtsp = (struct rtsp_context *)ctx;
 
-    if (rtsp->readingframe != 1) {
+    if (rtsp->status == RTSP_CONNECTED) {
         return 0;
-    } else {
+    } else if (rtsp->status == RTSP_READINGIMAGE) {
         struct timeval interrupttime;
         if (gettimeofday(&interrupttime, NULL) < 0) {
             MOTION_LOG(WRN, TYPE_NETCAM, SHOW_ERRNO, "%s: get interrupt time failed");
         }
         if ((interrupttime.tv_sec - rtsp->startreadtime.tv_sec ) > 10){
-            MOTION_LOG(WRN, TYPE_NETCAM, NO_ERRNO, "%s: Reading picture timed out for %s",rtsp->path);
+            MOTION_LOG(WRN, TYPE_NETCAM, NO_ERRNO, "%s: Camera timed out for %s",rtsp->path);
+            return 1;
+        } else{
+            return 0;
+        }
+    } else {
+        /* This is for NOTCONNECTED and RECONNECTING status.  We give these
+         * options more time because all the ffmpeg calls that are inside the
+         * rtsp_connect function will use the same start time.  Otherwise we
+         * would need to reset the time before each call to a ffmpeg function.
+        */
+        struct timeval interrupttime;
+        if (gettimeofday(&interrupttime, NULL) < 0) {
+            MOTION_LOG(WRN, TYPE_NETCAM, SHOW_ERRNO, "%s: get interrupt time failed");
+        }
+        if ((interrupttime.tv_sec - rtsp->startreadtime.tv_sec ) > 30){
+            MOTION_LOG(WRN, TYPE_NETCAM, NO_ERRNO, "%s: Camera timed out for %s",rtsp->path);
             return 1;
         } else{
             return 0;
@@ -313,7 +329,7 @@ int netcam_read_rtsp_image(netcam_context_ptr netcam){
     }
     netcam->rtsp->startreadtime = curtime;
 
-    netcam->rtsp->readingframe = 1;
+    netcam->rtsp->status = RTSP_READINGIMAGE;
     while (size_decoded == 0 && av_read_frame(netcam->rtsp->format_context, &packet) >= 0) {
         if(packet.stream_index != netcam->rtsp->video_stream_index) {
             my_packet_unref(packet);
@@ -330,7 +346,7 @@ int netcam_read_rtsp_image(netcam_context_ptr netcam){
         packet.data = NULL;
         packet.size = 0;
     }
-    netcam->rtsp->readingframe = 0;
+    netcam->rtsp->status = RTSP_CONNECTED;
 
     // at this point, we are finished with the packet
     my_packet_unref(packet);
@@ -445,6 +461,10 @@ static int netcam_rtsp_open_context(netcam_context_ptr netcam){
     netcam->rtsp->format_context = avformat_alloc_context();
     netcam->rtsp->format_context->interrupt_callback.callback = netcam_interrupt_rtsp;
     netcam->rtsp->format_context->interrupt_callback.opaque = netcam->rtsp;
+
+    if (gettimeofday(&netcam->rtsp->startreadtime, NULL) < 0) {
+        MOTION_LOG(ERR, TYPE_NETCAM, SHOW_ERRNO, "%s: gettimeofday");
+    }
 
     if (strncmp(netcam->rtsp->path, "http", 4) == 0 ){
         netcam->rtsp->format_context->iformat = av_find_input_format("mjpeg");
@@ -877,7 +897,6 @@ int netcam_setup_rtsp(netcam_context_ptr netcam, struct url_t *url){
     /*
      * Now we need to set some flags
      */
-    netcam->rtsp->readingframe = 0;
     netcam->rtsp->status = RTSP_NOTCONNECTED;
 
     /*

--- a/netcam_rtsp.h
+++ b/netcam_rtsp.h
@@ -20,7 +20,6 @@ struct rtsp_context {
     char*                 path;
     char*                 user;
     char*                 pass;
-    int                   readingframe;
     int                   status;
     struct timeval        startreadtime;
     struct SwsContext*   swsctx;
@@ -37,7 +36,6 @@ int netcam_next_rtsp(unsigned char *image , netcam_context_ptr netcam);
 
 struct rtsp_context {
     int*                  format_context;
-    int                   readingframe;
     int                   status;
 };
 

--- a/netcam_rtsp.h
+++ b/netcam_rtsp.h
@@ -20,7 +20,7 @@ struct rtsp_context {
     char*                 path;
     char*                 user;
     char*                 pass;
-    int                   status;
+    enum RTSP_STATUS      status;
     struct timeval        startreadtime;
     struct SwsContext*   swsctx;
 };
@@ -36,7 +36,7 @@ int netcam_next_rtsp(unsigned char *image , netcam_context_ptr netcam);
 
 struct rtsp_context {
     int*                  format_context;
-    int                   status;
+    enum RTSP_STATUS      status;
 };
 
 struct rtsp_context *rtsp_new_context(void);


### PR DESCRIPTION
The original netcam_interupt disregarded interupts from the
connection routines which occasionally caused problems with
camera reconnections.

Also included is a change to use a enum and consolidation to
only use the status instead of two separate variables.