### PR TITLE
Replace "Thread x" with "Camera x" in the web ui

### DIFF
--- a/webhttpd.c
+++ b/webhttpd.c
@@ -435,8 +435,8 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
             /*call list*/
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>\n<ul>",
-                        thread, thread,
+                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Camera %d%s%s</b>\n<ul>",
+                        thread, cnt[thread]->conf.camera_id,
                         cnt[thread]->conf.camera_name ? " -- " : "",
                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
 
@@ -568,10 +568,10 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 sprintf(res,
                                     "<a href=/%hu/config/list>&lt;&ndash; back</a>"
-                                    "<br><br>\n<b>Thread %hu%s%s</b>\n"
+                                    "<br><br>\n<b>Camera %d%s%s</b>\n"
                                     "<ul><li><a href=/%hu/config/set?%s>%s</a> = %s"
                                     "</li></ul><b>Done</b>",
-                                        thread, thread,
+                                        thread, cnt[thread]->conf.camera_id,
                                         cnt[thread]->conf.camera_name ? " -- " : "",
                                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                         thread, config_params[i].param_name,
@@ -617,8 +617,8 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             sprintf(res,
                                 "<a href=/%hu/config/list>&lt;&ndash; back</a><br><br>\n"
-                                    "<b>Thread %hu%s%s</b>\n<ul><li><a href=/%hu/config/set?%s>%s</a>"
-                                    "= %s</li></ul><br><b>Done</b>", thread, thread,
+                                    "<b>Camera %d%s%s</b>\n<ul><li><a href=/%hu/config/set?%s>%s</a>"
+                                    "= %s</li></ul><br><b>Done</b>", thread, cnt[thread]->conf.camera_id,
                                     cnt[thread]->conf.camera_name ? " -- " : "",
                                     cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                     thread,
@@ -687,14 +687,14 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                                                 "<option value='off' selected>off</option>\n");
 
                             sprintf(res, "<a href=/%hu/config/list>&lt;&ndash; back</a><br><br>\n"
-                                         "<b>Thread %hu%s%s</b>\n"
+                                         "<b>Camera %d%s%s</b>\n"
                                          "<form action=set?>\n"
                                          "<b>%s</b>&nbsp;<select name='%s'>\n"
                                          "%s"
                                          "</select><input type='submit' value='set'>\n"
                                          "&nbsp;&nbsp;&nbsp;&nbsp;"
                                          "<a href='%s#%s' target=_blank>[help]</a>"
-                                         "</form>\n<hr><i>%s</i>", thread, thread,
+                                         "</form>\n<hr><i>%s</i>", thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                          config_params[i].param_name, config_params[i].param_name,
@@ -708,12 +708,12 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                                 if (value == NULL) value = "";
                             }
                             sprintf(res, "<a href=/%hu/config/list>&lt;&ndash; back</a><br><br>\n"
-                                         "<b>Thread %hu%s%s</b>\n<form action=set?>\n"
+                                         "<b>Camera %d%s%s</b>\n<form action=set?>\n"
                                          "<b>%s</b>&nbsp;<input type=text name='%s' value='%s' size=80>\n"
                                          "<input type='submit' value='set'>\n"
                                          "&nbsp;&nbsp;&nbsp;&nbsp;"
                                          "<a href='%s#%s' target=_blank>[help]</a>"
-                                         "</form>\n<hr><i>%s</i>", thread, thread,
+                                         "</form>\n<hr><i>%s</i>", thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                          config_params[i].param_name, config_params[i].param_name,
@@ -739,8 +739,8 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
         } else if (length_uri == 0) {
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, set_template);
-                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>\n"
-                             "<form name='n'>\n<select name='onames'>\n", thread, thread,
+                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Camera %d%s%s</b>\n"
+                             "<form name='n'>\n<select name='onames'>\n", thread, cnt[thread]->conf.camera_id,
                              cnt[thread]->conf.camera_name ? " -- " : "",
                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
 
@@ -835,10 +835,10 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 send_template_ini_client(client_socket, ini_template);
                                 sprintf(res, "<a href=/%hu/config/get>&lt;&ndash; back</a><br><br>\n"
-                                             "<b>Thread %hu%s%s</b><br>\n<ul><li>%s = %s &nbsp;&nbsp;"
+                                             "<b>Camera %d%s%s</b><br>\n<ul><li>%s = %s &nbsp;&nbsp;"
                                              "&nbsp;&nbsp;<a href='%s#%s' target=_blank>"
                                              "[help]</a></li></ul><hr><i>%s</i>",
-                                             thread, thread,
+                                             thread, cnt[thread]->conf.camera_id,
                                              cnt[thread]->conf.camera_name ? " -- " : "",
                                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                              config_params[i].param_name, value,
@@ -872,9 +872,9 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
         } else if (length_uri == 0) {
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b><br>\n"
+                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Camera %d%s%s</b><br>\n"
                              "<form action=get>\n"
-                             "<select name='query'>\n", thread, thread,
+                             "<select name='query'>\n", thread, cnt[thread]->conf.camera_id,
                         cnt[thread]->conf.camera_name ? " -- " : "",
                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
@@ -915,7 +915,7 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                 } else {
                     conf_print(cnt);
                     send_template_ini_client_raw(client_socket);
-                    sprintf(res, "Thread %hu write\nDone\n", thread);
+                    sprintf(res, "Camera %d write\nDone\n", cnt[thread]->conf.camera_id);
                     send_template_raw(client_socket, res);
                 }
             } else {
@@ -933,15 +933,15 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
             conf_print(cnt);
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>  write done !\n",
-                             thread, thread,
+                sprintf(res, "<a href=/%hu/config>&lt;&ndash; back</a><br><br>\n<b>Camera %d%s%s</b>  write done !\n",
+                             thread, cnt[thread]->conf.camera_id,
                              cnt[thread]->conf.camera_name ? " -- " : "",
                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
             } else {
                 send_template_ini_client_raw(client_socket);
-                sprintf(res, "Thread %hu write\nDone\n", thread);
+                sprintf(res, "Camera %d write\nDone\n", cnt[thread]->conf.camera_id);
                 send_template_raw(client_socket, res);
             }
         } else {
@@ -1170,15 +1170,15 @@ static unsigned int detection(char *pointer, char *res, unsigned int length_uri,
 
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/detection>&lt;&ndash; back</a><br><br><b>Thread %hu%s%s</b>"
-                             " Detection status %s\n", thread, thread,
+                sprintf(res, "<a href=/%hu/detection>&lt;&ndash; back</a><br><br><b>Camera %d%s%s</b>"
+                             " Detection status %s\n", thread, cnt[thread]->conf.camera_id,
                              cnt[thread]->conf.camera_name ? " -- " : "",
                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                              (!cnt[thread]->running)? "NOT RUNNING": (cnt[thread]->pause)? "PAUSE":"ACTIVE");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
             } else {
-                sprintf(res, "Thread %hu Detection status %s\n", thread,
+                sprintf(res, "Camera %d Detection status %s\n", cnt[thread]->conf.camera_id,
                              (!cnt[thread]->running)? "NOT RUNNING": (cnt[thread]->pause)? "PAUSE":"ACTIVE");
                 send_template_ini_client_raw(client_socket);
                 send_template_raw(client_socket, res);
@@ -1206,15 +1206,15 @@ static unsigned int detection(char *pointer, char *res, unsigned int length_uri,
 
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/detection>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>"
-                             " Detection resumed\n", thread, thread,
+                sprintf(res, "<a href=/%hu/detection>&lt;&ndash; back</a><br><br>\n<b>Camera %d%s%s</b>"
+                             " Detection resumed\n", thread, cnt[thread]->conf.camera_id,
                              cnt[thread]->conf.camera_name ? " -- " : "",
                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
             } else {
                 send_template_ini_client_raw(client_socket);
-                sprintf(res, "Thread %hu Detection resumed\nDone\n", thread);
+                sprintf(res, "Camera %d Detection resumed\nDone\n", cnt[thread]->conf.camera_id);
                 send_template_raw(client_socket, res);
             }
         } else {
@@ -1240,15 +1240,15 @@ static unsigned int detection(char *pointer, char *res, unsigned int length_uri,
 
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/detection>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>"
-                             " Detection paused\n", thread, thread,
+                sprintf(res, "<a href=/%hu/detection>&lt;&ndash; back</a><br><br>\n<b>Camera %d%s%s</b>"
+                             " Detection paused\n", thread, cnt[thread]->conf.camera_id,
                              cnt[thread]->conf.camera_name ? " -- " : "",
                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
             } else {
                 send_template_ini_client_raw(client_socket);
-                sprintf(res, "<b>Thread %hu%s%s</b> Detection paused\nDone\n", thread,
+                sprintf(res, "<b>Camera %d%s%s</b> Detection paused\nDone\n", cnt[thread]->conf.camera_id,
                         cnt[thread]->conf.camera_name ? " -- " : "",
                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template_raw(client_socket, res);
@@ -1272,15 +1272,15 @@ static unsigned int detection(char *pointer, char *res, unsigned int length_uri,
                 send_template(client_socket, res);
                 if (thread == 0) {
                     do{
-                        sprintf(res, "<b>Thread %hu%s%s</b> %s<br>\n", i,
-                                     cnt[thread]->conf.camera_name ? " -- " : "",
-                                     cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
+                        sprintf(res, "<b>Camera %d%s%s</b> %s<br>\n", cnt[i]->conf.camera_id,
+                                     cnt[i]->conf.camera_name ? " -- " : "",
+                                     cnt[i]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                      (!cnt[i]->running)? "NOT RUNNING" :
                                      (cnt[i]->lost_connection)?CONNECTION_KO:CONNECTION_OK);
                         send_template(client_socket, res);
                     } while (cnt[++i]);
                 } else {
-                    sprintf(res, "<b>Thread %hu%s%s</b> %s\n", thread,
+                    sprintf(res, "<b>Camera %d%s%s</b> %s\n", cnt[thread]->conf.camera_id,
                                  cnt[thread]->conf.camera_name ? " -- " : "",
                                  cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                  (!cnt[thread]->running)? "NOT RUNNING" :
@@ -1292,13 +1292,13 @@ static unsigned int detection(char *pointer, char *res, unsigned int length_uri,
                 send_template_ini_client_raw(client_socket);
                 if (thread == 0) {
                     do {
-                        sprintf(res, "Thread %hu %s\n", i,
+                        sprintf(res, "Camera %d %s\n", cnt[i]->conf.camera_id,
                                      (!cnt[i]->running)? "NOT RUNNING" :
                                                              (cnt[i]->lost_connection)? CONNECTION_KO: CONNECTION_OK);
                         send_template_raw(client_socket, res);
                     } while (cnt[++i]);
                 } else {
-                    sprintf(res, "Thread %hu %s\n", thread,
+                    sprintf(res, "Camera %d %s\n", cnt[thread]->conf.camera_id,
                                  (!cnt[thread]->running)? "NOT RUNNING" :
                                  (cnt[thread]->lost_connection)? CONNECTION_KO: CONNECTION_OK);
                     send_template_raw(client_socket, res);
@@ -1454,9 +1454,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             send_template_ini_client(client_socket, ini_template);
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu%s%s</b><br>\n"
+                                         "<b>Camera %d%s%s</b><br>\n"
                                          "track set relative pan=%s<br>\n",
-                                         thread, thread,
+                                         thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                          panvalue);
@@ -1471,7 +1471,7 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                     /* error in track action */
                         if (cnt[0]->conf.webcontrol_html_output) {
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu%s%s</b>\n", thread, thread,
+                                         "<b>Camera %d%s%s</b>\n", thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                             response_client(client_socket, track_error, res);
@@ -1496,9 +1496,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             send_template_ini_client(client_socket, ini_template);
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu%s%s</b><br>\n"
+                                         "<b>Camera %d%s%s</b><br>\n"
                                          "track set relative tilt=%s\n",
-                                         thread, thread,
+                                         thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                          tiltvalue);
@@ -1513,7 +1513,7 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         /* error in track action */
                         if (cnt[0]->conf.webcontrol_html_output) {
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu%s%s</b>\n", thread, thread,
+                                         "<b>Camera %d%s%s</b>\n", thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                             response_client(client_socket, track_error, res);
@@ -1530,9 +1530,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             send_template_ini_client(client_socket, ini_template);
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu%s%s</b><br>\n"
+                                         "<b>Camera %d%s%s</b><br>\n"
                                          "track set absolute x=%s\n",
-                                         thread, thread,
+                                         thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                          x_value);
@@ -1547,7 +1547,7 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         /* error in track action */
                         if (cnt[0]->conf.webcontrol_html_output) {
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu%s%s</b>\n", thread, thread,
+                                         "<b>Camera %d%s%s</b>\n", thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                             response_client(client_socket, track_error, res);
@@ -1565,9 +1565,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             send_template_ini_client(client_socket, ini_template);
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu%s%s</b><br>\n"
+                                         "<b>Camera %d%s%s</b><br>\n"
                                          "track set absolute y=%s<br>\n",
-                                         thread, thread,
+                                         thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                          y_value);
@@ -1582,7 +1582,7 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         /* error in track action */
                         if (cnt[0]->conf.webcontrol_html_output) {
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu%s%s</b>\n", thread, thread,
+                                         "<b>Camera %d%s%s</b>\n", thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                             response_client(client_socket, track_error, res);
@@ -1742,9 +1742,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                     if (cnt[0]->conf.webcontrol_html_output) {
                         send_template_ini_client(client_socket, ini_template);
                         sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                     "<b>Thread %hu%s%s</b><br>\n"
+                                     "<b>Camera %d%s%s</b><br>\n"
                                      "track absolute set x=%s y=%s<br>\n",
-                                     thread, thread,
+                                     thread, cnt[thread]->conf.camera_id,
                                      cnt[thread]->conf.camera_name ? " -- " : "",
                                      cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                      x_value, y_value);
@@ -1759,7 +1759,7 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                     /* error in track action */
                     if (cnt[0]->conf.webcontrol_html_output) {
                         sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                     "<b>Thread %hu%s%s</b>\n", thread, thread,
+                                     "<b>Camera %d%s%s</b>\n", thread, cnt[thread]->conf.camera_id,
                                      cnt[thread]->conf.camera_name ? " -- " : "",
                                      cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                         response_client(client_socket, track_error, res);
@@ -1797,9 +1797,9 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             send_template_ini_client(client_socket, ini_template);
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu%s%s</b><br>\n"
+                                         "<b>Camera %d%s%s</b><br>\n"
                                          "track relative pan=%s tilt=%s\n",
-                                         thread, thread,
+                                         thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                          panvalue, tiltvalue);
@@ -1816,7 +1816,7 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         /* error in track tilt */
                         if (cnt[0]->conf.webcontrol_html_output) {
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu%s%s</b>\n", thread, thread,
+                                         "<b>Camera %d%s%s</b>\n", thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                             response_client(client_socket, track_error, res);
@@ -1828,8 +1828,8 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
 
                 /* error in track pan */
                 if (cnt[0]->conf.webcontrol_html_output) {
-                    sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br><b>Thread %hu%s%s</b>\n",
-                                 thread, thread,
+                    sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br><b>Camera %d%s%s</b>\n",
+                                 thread, cnt[thread]->conf.camera_id,
                                  cnt[thread]->conf.camera_name ? " -- " : "",
                                  cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                     response_client(client_socket, track_error, res);
@@ -1840,7 +1840,7 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
         } else if (length_uri == 0) {
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b><br>\n"
+                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Camera %d%s%s</b><br>\n"
                              "<form action='set'>\n"
                              "Pan<input type=text name='pan' value=''>\n"
                              "Tilt<input type=text name='tilt' value=''>\n"
@@ -1850,7 +1850,7 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                              "X<input type=text name='x' value=''>\n"
                              "Y<input type=text name='y' value=''>\n"
                              "<input type=submit value='set absolute'>\n"
-                             "</form>\n", thread, thread,
+                             "</form>\n", thread, cnt[thread]->conf.camera_id,
                              cnt[thread]->conf.camera_name ? " -- " : "",
                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
@@ -1878,14 +1878,14 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
 
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>"
-                             "<br>track set center", thread, thread,
+                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Camera %d%s%s</b>"
+                             "<br>track set center", thread, cnt[thread]->conf.camera_id,
                              cnt[thread]->conf.camera_name ? " -- " : "",
                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
             } else {
-                sprintf(res, "Thread %hu\n track set center\nDone\n", thread);
+                sprintf(res, "Camera %d\n track set center\nDone\n", cnt[thread]->conf.camera_id);
                 send_template_ini_client_raw(client_socket);
                 send_template_raw(client_socket, res);
             }
@@ -1902,15 +1902,15 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
         if (length_uri==0) {
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>"
-                             "<br>track auto %s", thread, thread,
+                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Camera %d%s%s</b>"
+                             "<br>track auto %s", thread, cnt[thread]->conf.camera_id,
                              cnt[thread]->conf.camera_name ? " -- " : "",
                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                              (cnt[thread]->track.active)? "enabled":"disabled");
                 send_template(client_socket, res);
                 send_template_end_client(client_socket);
             } else {
-                sprintf(res, "Thread %hu\n track auto %s\nDone\n", thread,
+                sprintf(res, "Camera %d\n track auto %s\nDone\n", cnt[thread]->conf.camera_id,
                              (cnt[thread]->track.active)? "enabled":"disabled");
                 send_template_ini_client_raw(client_socket);
                 send_template_raw(client_socket, res);
@@ -1945,15 +1945,15 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                         if (cnt[0]->conf.webcontrol_html_output) {
                             send_template_ini_client(client_socket, ini_template);
                             sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                         "<b>Thread %hu%s%s</b><br>"
-                                         "track auto %s", thread, thread,
+                                         "<b>Camera %d%s%s</b><br>"
+                                         "track auto %s", thread, cnt[thread]->conf.camera_id,
                                          cnt[thread]->conf.camera_name ? " -- " : "",
                                          cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                          (cnt[thread]->track.active)? "enabled":"disabled");
                             send_template(client_socket, res);
                             send_template_end_client(client_socket);
                         } else {
-                            sprintf(res, "Thread %hu\n track auto %s\nDone\n", thread,
+                            sprintf(res, "Camera %d\n track auto %s\nDone\n", cnt[thread]->conf.camera_id,
                                      (cnt[thread]->track.active)? "enabled":"disabled");
                             send_template_ini_client_raw(client_socket);
                             send_template_raw(client_socket, res);
@@ -1968,8 +1968,8 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 send_template_ini_client(client_socket, ini_template);
                                 sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>"
-                                             "<b>Thread %hu%s%s</b>"
-                                             "<br>track auto %s<br>", thread, thread,
+                                             "<b>Camera %d%s%s</b>"
+                                             "<br>track auto %s<br>", thread, cnt[thread]->conf.camera_id,
                                              cnt[thread]->conf.camera_name ? " -- " : "",
                                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                              active ? "enabled":"disabled");
@@ -2003,12 +2003,12 @@ static unsigned int track(char *pointer, char *res, unsigned int length_uri,
 
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Thread %hu%s%s</b>\n"
+                sprintf(res, "<a href=/%hu/track>&lt;&ndash; back</a><br><br>\n<b>Camera %d%s%s</b>\n"
                              "<form action='auto'><select name='value'>\n"
                              "<option value='0' %s>Disable</option><option value='1' %s>Enable</option>\n"
                              "<option value='status'>status</option>\n"
                              "</select><input type=submit value='set'>\n"
-                             "</form>\n", thread, thread,
+                             "</form>\n", thread, cnt[thread]->conf.camera_id,
                              cnt[thread]->conf.camera_name ? " -- " : "",
                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                         (cnt[thread]->track.active) ? "selected":"",
@@ -2067,7 +2067,7 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
             //Send the webcontrol section if applicable
             if (cnt[0]->conf.webcontrol_html_output) {
                 send_template_ini_client(client_socket, ini_template);
-                sprintf(res, "<b>Motion "VERSION" Running [%hu] Threads</b><br>\n"
+                sprintf(res, "<b>Motion "VERSION" Running [%hu] Cameras</b><br>\n"
                              "<a href='/0/'>All</a>\n", i);
                 send_template(client_socket, res);
 
@@ -2079,7 +2079,7 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                         send_template(client_socket, res);
                         counter = 0;
                     }
-                    sprintf(res, "<a href='/%hu/'>Thread %hu%s%s</a>\n", y, y,
+                    sprintf(res, "<a href='/%hu/'>Camera %d%s%s</a>\n", y, cnt[y]->conf.camera_id,
                                  cnt[y]->conf.camera_name ? " -- " : "",
                                  cnt[y]->conf.camera_name ? cnt[y]->conf.camera_name : "");
                     send_template(client_socket, res);
@@ -2112,7 +2112,7 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                 send_template_end_client(client_socket);
             } else {
                 send_template_ini_client_raw(client_socket);
-                sprintf(res, "Motion "VERSION" Running [%hu] Threads\n0\n", i);
+                sprintf(res, "Motion "VERSION" Running [%hu] Cameras\n0\n", i);
                 send_template_raw(client_socket, res);
                 for (y = 1; y < i; y++) {
                     sprintf(res, "%hu\n", y);
@@ -2158,12 +2158,12 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 send_template_ini_client(client_socket, ini_template);
                                 sprintf(res, "<a href=/%hd/>&lt;&ndash; back</a><br><br>\n"
-                                             "<b>Thread %hd%s%s</b><br>\n"
+                                             "<b>Camera %d%s%s</b><br>\n"
                                              "<a href=/%hd/config/list>list</a><br>\n"
                                              "<a href=/%hd/config/write>write</a><br>\n"
                                              "<a href=/%hd/config/set>set</a><br>\n"
                                              "<a href=/%hd/config/get>get</a><br>\n",
-                                             thread, thread,
+                                             thread, cnt[thread]->conf.camera_id,
                                              cnt[thread]->conf.camera_name ? " -- " : "",
                                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                         thread, thread, thread, thread);
@@ -2171,7 +2171,7 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                                 send_template_end_client(client_socket);
                             } else {
                                 send_template_ini_client_raw(client_socket);
-                                sprintf(res, "Thread %hd\nlist\nwrite\nset\nget\n", thread);
+                                sprintf(res, "Camera %d\nlist\nwrite\nset\nget\n", cnt[thread]->conf.camera_id);
                                 send_template_raw(client_socket, res);
                             }
                         } else if ((slash == '/') && (length_uri >= 4)) {
@@ -2194,12 +2194,12 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 send_template_ini_client(client_socket, ini_template);
                                 sprintf(res, "<a href=/%hd/>&lt;&ndash; back</a><br><br>\n"
-                                             "<b>Thread %hd%s%s</b><br>\n"
+                                             "<b>Camera %d%s%s</b><br>\n"
                                              "<a href=/%hd/action/makemovie>makemovie</a><br>\n"
                                              "<a href=/%hd/action/snapshot>snapshot</a><br>\n"
                                              "<a href=/%hd/action/restart>restart</a><br>\n"
                                              "<a href=/%hd/action/quit>quit</a><br>\n",
-                                             thread, thread,
+                                             thread, cnt[thread]->conf.camera_id,
                                              cnt[thread]->conf.camera_name ? " -- " : "",
                                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                         thread, thread, thread, thread);
@@ -2207,7 +2207,7 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                                 send_template_end_client(client_socket);
                             } else {
                                 send_template_ini_client_raw(client_socket);
-                                sprintf(res, "Thread %hd\nmakemovie\nsnapshot\nrestart\nquit\n", thread);
+                                sprintf(res, "Camera %d\nmakemovie\nsnapshot\nrestart\nquit\n", cnt[thread]->conf.camera_id);
                                 send_template_raw(client_socket, res);
                             }
                         } else if ((slash == '/') && (length_uri > 4)) {
@@ -2231,12 +2231,12 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 send_template_ini_client(client_socket, ini_template);
                                 sprintf(res, "<a href=/%hd/>&lt;&ndash; back</a><br><br>\n"
-                                             "<b>Thread %hd%s%s</b><br>\n"
+                                             "<b>Camera %d%s%s</b><br>\n"
                                              "<a href=/%hd/detection/status>status</a><br>\n"
                                              "<a href=/%hd/detection/start>start</a><br>\n"
                                              "<a href=/%hd/detection/pause>pause</a><br>\n"
                                              "<a href=/%hd/detection/connection>connection</a><br>\n",
-                                             thread, thread,
+                                             thread, cnt[thread]->conf.camera_id,
                                              cnt[thread]->conf.camera_name ? " -- " : "",
                                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                              thread, thread, thread, thread);
@@ -2244,7 +2244,7 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                                 send_template_end_client(client_socket);
                             } else {
                                 send_template_ini_client_raw(client_socket);
-                                sprintf(res, "Thread %hd\nstatus\nstart\npause\nconnection\n", thread);
+                                sprintf(res, "Camera %d\nstatus\nstart\npause\nconnection\n", cnt[thread]->conf.camera_id);
                                 send_template_raw(client_socket, res);
                             }
                         } else if ((slash == '/') && (length_uri > 5)) {
@@ -2265,12 +2265,12 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                             if (cnt[0]->conf.webcontrol_html_output) {
                                 send_template_ini_client(client_socket, ini_template);
                                 sprintf(res, "<a href=/%hd/>&lt;&ndash; back</a><br><br>\n"
-                                             "<b>Thread %hd%s%s</b><br>\n"
+                                             "<b>Camera %d%s%s</b><br>\n"
                                              "<a href=/%hd/track/set>track set pan/tilt</a><br>\n"
                                              "<a href=/%hd/track/center>track center</a><br>\n"
                                              "<a href=/%hd/track/auto>track auto</a><br>\n"
                                              "<a href=/%hd/track/status>track status</a><br>\n",
-                                             thread, thread,
+                                             thread, cnt[thread]->conf.camera_id,
                                              cnt[thread]->conf.camera_name ? " -- " : "",
                                              cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                              thread, thread, thread, thread);
@@ -2278,7 +2278,7 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                                 send_template_end_client(client_socket);
                             } else {
                                 send_template_ini_client_raw(client_socket);
-                                sprintf(res, "Thread %hd\nset pan/tilt\ncenter\nauto\nstatus\n", thread);
+                                sprintf(res, "Camera %d\nset pan/tilt\ncenter\nauto\nstatus\n", cnt[thread]->conf.camera_id);
                                 send_template_raw(client_socket, res);
                             }
 
@@ -2317,12 +2317,12 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                     /* /thread_number/ requested */
                     if (cnt[0]->conf.webcontrol_html_output) {
                         send_template_ini_client(client_socket, ini_template);
-                        sprintf(res, "<a href=/>&lt;&ndash; back</a><br><br>\n<b>Thread %hd%s%s</b><br>\n"
+                        sprintf(res, "<a href=/>&lt;&ndash; back</a><br><br>\n<b>Camera %d -- Thread %hd%s%s</b><br>\n"
                                      "<a href='/%hd/config'>config</a><br>\n"
                                      "<a href='/%hd/action'>action</a><br>\n"
                                      "<a href='/%hd/detection'>detection</a><br>\n"
                                      "<a href='/%hd/track'>track</a><br>\n",
-                                     thread,
+                                     cnt[thread]->conf.camera_id, thread,
                                      cnt[thread]->conf.camera_name ? " -- " : "",
                                      cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "",
                                      thread, thread, thread, thread);
@@ -2330,7 +2330,7 @@ static unsigned int handle_get(int client_socket, const char *url, void *userdat
                         send_template_end_client(client_socket);
                     } else {
                         send_template_ini_client_raw(client_socket);
-                        sprintf(res, "Thread %hd\nconfig\naction\ndetection\ntrack\n", thread);
+                        sprintf(res, "Camera %d\nconfig\naction\ndetection\ntrack\n", cnt[thread]->conf.camera_id);
                         send_template_raw(client_socket, res);
                     }
                 }


### PR DESCRIPTION
In common with other recent changes, remove another place where
"Thread" is visible to the user.

We also now use the camera_id rather than the thread number. The
camera_id already defaults to the thread number, so this change
won't cause any difference for older config files that don't set
camera_id.