### PR TITLE
Rewrite sockets to be much simpler and properly support IPv6.

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -95,7 +95,7 @@ struct config conf_template = {
 #ifdef HAVE_SDL
     sdl_threadnr:                   0,
 #endif
-    localhost_ipv4:                 1,
+    ipv6_enabled:                   0,
     stream_port:                    0,
     stream_quality:                 50,
     stream_motion:                  0,
@@ -1076,13 +1076,13 @@ config_param config_params[] = {
     },
 #endif /* HAVE_FFMPEG */
     {
-    "localhost_ipv4",
+    "ipv6_enabled",
     "\n############################################################\n"
     "# Global Network Options\n"
     "############################################################\n\n"
-    "# Listen to IPv4 localhost instead of IPv6 (default: on)",
+    "# Listen to IPv6 localhost instead of IPv4 (default: off)",
     0,
-    CONF_OFFSET(localhost_ipv4),
+    CONF_OFFSET(ipv6_enabled),
     copy_bool,
     print_bool
     },

--- a/conf.c
+++ b/conf.c
@@ -95,7 +95,7 @@ struct config conf_template = {
 #ifdef HAVE_SDL
     sdl_threadnr:                   0,
 #endif
-    ipv6_enabled:                   0,
+    localhost_ipv4:                 1,
     stream_port:                    0,
     stream_quality:                 50,
     stream_motion:                  0,
@@ -1076,13 +1076,13 @@ config_param config_params[] = {
     },
 #endif /* HAVE_FFMPEG */
     {
-    "ipv6_enabled",
+    "localhost_ipv4",
     "\n############################################################\n"
     "# Global Network Options\n"
     "############################################################\n\n"
-    "# Enable or disable IPV6 for http control and stream (default: off)",
+    "# Listen to IPv4 localhost instead of IPv6 (default: on)",
     0,
-    CONF_OFFSET(ipv6_enabled),
+    CONF_OFFSET(localhost_ipv4),
     copy_bool,
     print_bool
     },

--- a/conf.h
+++ b/conf.h
@@ -70,7 +70,7 @@ struct config {
 #ifdef HAVE_SDL
     int sdl_threadnr;
 #endif
-    int ipv6_enabled;
+    int localhost_ipv4;
     int stream_port;
     int stream_quality;
     int stream_motion;

--- a/conf.h
+++ b/conf.h
@@ -70,7 +70,7 @@ struct config {
 #ifdef HAVE_SDL
     int sdl_threadnr;
 #endif
-    int localhost_ipv4;
+    int ipv6_enabled;
     int stream_port;
     int stream_quality;
     int stream_motion;

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -480,8 +480,8 @@ timelapse_filename %Y%m%d-timelapse
 ############################################################
 # Global Network Options
 ############################################################
-# Enable or disable IPV6 for http control and stream (default: off )
-ipv6_enabled off
+# Listen to IPv4 localhost instead of IPv6 (default: on)
+localhost_ipv4 on
 
 ############################################################
 # Live Stream Server

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -480,8 +480,8 @@ timelapse_filename %Y%m%d-timelapse
 ############################################################
 # Global Network Options
 ############################################################
-# Listen to IPv4 localhost instead of IPv6 (default: on)
-localhost_ipv4 on
+# Listen to IPv6 localhost instead of IPv4 (default: off)
+ipv6_enabled off
 
 ############################################################
 # Live Stream Server

--- a/motion.1
+++ b/motion.1
@@ -1261,15 +1261,15 @@ This option accepts the conversion specifiers included at the end of this manual
 .RE
 
 .TP
-.B ipv6_enabled
+.B localhost_ipv4
 .RS 
 .nf 
 Values: on/off
-Default: off 
+Default: on 
 Description: 
 .fi
 .RS
-Enable or disable IPV6 for http control and stream
+Listen to IPv4 localhost instead of IPv6
 .RE
 .RE
 

--- a/motion.1
+++ b/motion.1
@@ -1261,15 +1261,15 @@ This option accepts the conversion specifiers included at the end of this manual
 .RE
 
 .TP
-.B localhost_ipv4
+.B ipv6_enabled
 .RS 
 .nf 
 Values: on/off
-Default: on 
+Default: off 
 Description: 
 .fi
 .RS
-Listen to IPv4 localhost instead of IPv6
+Listen to IPv6 localhost instead of IPv4
 .RE
 .RE
 

--- a/motion.c
+++ b/motion.c
@@ -951,7 +951,7 @@ static int motion_init(struct context *cnt)
                        cnt->conf.stream_port);
             cnt->finish = 1;
         } else {
-            MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO, "%s: Started motion-stream server in port %d auth %s",
+            MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO, "%s: Started motion-stream server on port %d (auth %s)",
                        cnt->conf.stream_port, cnt->conf.stream_auth_method ? "Enabled":"Disabled");
         }
     }

--- a/motion_guide.html
+++ b/motion_guide.html
@@ -1350,7 +1350,7 @@ Some configuration options are only used if Motion is built on a system that has
   </colgroup>
  	<tbody>
   	  <tr>
-       <td bgcolor="#edf4f9" ><a href="#localhost_ipv4" >localhost_ipv4</a> </td>
+       <td bgcolor="#edf4f9" ><a href="#ipv6_enabled" >ipv6_enabled</a> </td>
        <td bgcolor="#edf4f9" ><a href="#stream_port" >stream_port</a> </td>
        <td bgcolor="#edf4f9" ><a href="#stream_quality" >stream_quality</a> </td>
        <td bgcolor="#edf4f9" ><a href="#stream_motion" >stream_motion</a> </td>       
@@ -3681,7 +3681,7 @@ to the following.
 <p></p>
 <p></p>
 
-<h3><a name="localhost_ipv4"></a> localhost_ipv4 </h3>
+<h3><a name="ipv6_enabled"></a> ipv6_enabled </h3>
 <p></p> 
 <ul>
   <li> Type: String</li>
@@ -3689,7 +3689,7 @@ to the following.
   <li> Default: </li>
 </ul> 
 <p></p>
-# Listen to IPv4 localhost instead of IPv6 (default: on)
+# Listen to IPv6 localhost instead of IPv4 (default: off)
 <p></p>
 
 <h3><a name="stream_port"></a> stream_port </h3>

--- a/motion_guide.html
+++ b/motion_guide.html
@@ -1350,13 +1350,13 @@ Some configuration options are only used if Motion is built on a system that has
   </colgroup>
  	<tbody>
   	  <tr>
-       <td bgcolor="#edf4f9" ><a href="#ipv6_enabled" >ipv6_enabled</a> </td>
+       <td bgcolor="#edf4f9" ><a href="#localhost_ipv4" >localhost_ipv4</a> </td>
        <td bgcolor="#edf4f9" ><a href="#stream_port" >stream_port</a> </td>
        <td bgcolor="#edf4f9" ><a href="#stream_quality" >stream_quality</a> </td>
        <td bgcolor="#edf4f9" ><a href="#stream_motion" >stream_motion</a> </td>       
      </tr>
   	  <tr>
-  	    <td bgcolor="#edf4f9" ><a href="#stream_maxrate" >stream_maxrate</a> </td>
+  	   <td bgcolor="#edf4f9" ><a href="#stream_maxrate" >stream_maxrate</a> </td>
        <td bgcolor="#edf4f9" ><a href="#stream_localhost" >stream_localhost</a> </td>
        <td bgcolor="#edf4f9" ><a href="#stream_limit" >stream_limit</a> </td>
        <td bgcolor="#edf4f9" ><a href="#stream_auth_method" >stream_auth_method</a> </td>       
@@ -3681,7 +3681,7 @@ to the following.
 <p></p>
 <p></p>
 
-<h3><a name="ipv6_enabled"></a> ipv6_enabled </h3>
+<h3><a name="localhost_ipv4"></a> localhost_ipv4 </h3>
 <p></p> 
 <ul>
   <li> Type: String</li>
@@ -3689,7 +3689,7 @@ to the following.
   <li> Default: </li>
 </ul> 
 <p></p>
-# Enable or disable IPV6 for http control and stream (default: off )
+# Listen to IPv4 localhost instead of IPv6 (default: on)
 <p></p>
 
 <h3><a name="stream_port"></a> stream_port </h3>

--- a/stream.c
+++ b/stream.c
@@ -720,7 +720,7 @@ Error:
  *
  * Returns: socket descriptor or -1 if any error happens
  */
-int http_bindsock(int port, int local, int local_ipv4)
+int http_bindsock(int port, int local, int ipv6_localhost)
 {
     int sd = socket(AF_INET6, SOCK_STREAM, 0);
 
@@ -730,12 +730,12 @@ int http_bindsock(int port, int local, int local_ipv4)
     sin6.sin6_family = AF_INET6;
     sin6.sin6_port = htons(port);
     if(local) {
-        if(local_ipv4) {
-            addr_str = "127.0.0.1";
-            sin6.sin6_addr = in6addr_loopback4;
-        } else {
+        if(ipv6_localhost) {
             addr_str = "::1";
             sin6.sin6_addr = in6addr_loopback;
+        } else {
+            addr_str = "127.0.0.1";
+            sin6.sin6_addr = in6addr_loopback4;
         }
     } else {
         addr_str = "any address";
@@ -1010,7 +1010,7 @@ static int stream_check_write(struct stream *list)
 int stream_init(struct context *cnt)
 {
     cnt->stream.socket = http_bindsock(cnt->conf.stream_port, cnt->conf.stream_localhost,
-                                       cnt->conf.localhost_ipv4);
+                                       cnt->conf.ipv6_enabled);
     cnt->stream.next = NULL;
     cnt->stream.prev = NULL;
     return cnt->stream.socket;

--- a/stream.c
+++ b/stream.c
@@ -39,6 +39,11 @@ struct auth_param {
     struct config *conf;
 };
 
+// IPv4 localhost mapped in IPv6 address
+// ::ffff:127.0.0.1
+#define IN6ADDR_LOOPBACK4_INIT { { { 0,0,0,0,0,0,0,0,0,0,0xff,0xff,0x7f,0,0,1 } } }
+const struct in6_addr in6addr_loopback4 = IN6ADDR_LOOPBACK4_INIT;
+
 pthread_mutex_t stream_auth_mutex;
 
 /**
@@ -715,84 +720,38 @@ Error:
  *
  * Returns: socket descriptor or -1 if any error happens
  */
-int http_bindsock(int port, int local, int ipv6_enabled)
+int http_bindsock(int port, int local, int local_ipv4)
 {
-    int sl = -1, optval;
-    struct addrinfo hints, *res = NULL, *ressave = NULL;
-    char portnumber[10], hbuf[NI_MAXHOST], sbuf[NI_MAXSERV];
+    int sd = socket(AF_INET6, SOCK_STREAM, 0);
 
-    snprintf(portnumber, sizeof(portnumber), "%u", port);
-    memset(&hints, 0, sizeof(struct addrinfo));
+    struct sockaddr_in6 sin6;
+    bzero(&sin6, sizeof(struct sockaddr_in6));
+    sin6.sin6_family = AF_INET6;
+    sin6.sin6_port = htons(port);
+    if(local) {
+        if(local_ipv4) //listen only on 127.0.0.1
+            sin6.sin6_addr = in6addr_loopback4;
+        else //listen only on ::1
+            sin6.sin6_addr = in6addr_loopback;
+    } else {
+        sin6.sin6_addr = in6addr_any;
+    }
+    int no = 0;
+    setsockopt(sd, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&no, sizeof(no));
 
-    /* Use the AI_PASSIVE flag, which indicates we are using this address for a listen() */
-    hints.ai_flags = AI_PASSIVE;
-#if defined(BSD)
-    hints.ai_family = AF_INET;
-#else
-    if (!ipv6_enabled)
-        hints.ai_family = AF_INET;
-    else
-        hints.ai_family = AF_UNSPEC;
-#endif
-    hints.ai_socktype = SOCK_STREAM;
-
-    optval = getaddrinfo(local ? "localhost" : NULL, portnumber, &hints, &res);
-
-    if (optval != 0) {
-        MOTION_LOG(CRT, TYPE_STREAM, SHOW_ERRNO, "%s: getaddrinfo() for motion-stream socket failed: %s",
-                   gai_strerror(optval));
-
-        if (res != NULL)
-            freeaddrinfo(res);
+    if (bind(sd, &sin6, sizeof(sin6)) != 0) {
+        MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "%s: error binding on port: %d", port);
         return -1;
     }
 
-    ressave = res;
-
-    while (res) {
-        /* Create socket */
-        sl = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
-
-        getnameinfo(res->ai_addr, res->ai_addrlen, hbuf,
-                    sizeof(hbuf), sbuf, sizeof(sbuf), NI_NUMERICHOST | NI_NUMERICSERV);
-
-        if (sl >= 0) {
-            optval = 1;
-            /* Reuse Address */
-            setsockopt(sl, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(int));
-
-            MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "%s: motion-stream testing : %s addr: %s port: %s",
-                       res->ai_family == AF_INET ? "IPV4":"IPV6", hbuf, sbuf);
-
-            if (bind(sl, res->ai_addr, res->ai_addrlen) == 0) {
-                MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "%s: motion-stream Bound : %s addr: %s port: %s",
-                           res->ai_family == AF_INET ? "IPV4":"IPV6", hbuf, sbuf);
-                break;
-            }
-
-            MOTION_LOG(CRT, TYPE_STREAM, SHOW_ERRNO, "%s: motion-stream bind() failed, retrying");
-            close(sl);
-            sl = -1;
-        }
-        MOTION_LOG(ERR, TYPE_STREAM, SHOW_ERRNO, "%s: motion-stream socket failed, retrying");
-        res = res->ai_next;
-    }
-
-    freeaddrinfo(ressave);
-
-    if (sl < 0) {
-        MOTION_LOG(CRT, TYPE_STREAM, SHOW_ERRNO, "%s: motion-stream creating socket/bind ERROR");
+    if (listen(sd, DEF_MAXWEBQUEUE) != 0) {
+        MOTION_LOG(CRT, TYPE_STREAM, SHOW_ERRNO, "%s: error listening");
         return -1;
     }
 
+    MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "%s: listening on port: %d", port);
 
-    if (listen(sl, DEF_MAXWEBQUEUE) == -1) {
-        MOTION_LOG(CRT, TYPE_STREAM, SHOW_ERRNO, "%s: motion-stream listen() ERROR");
-        close(sl);
-        sl = -1;
-    }
-
-    return sl;
+    return sd;
 }
 
 /**
@@ -1046,7 +1005,7 @@ static int stream_check_write(struct stream *list)
 int stream_init(struct context *cnt)
 {
     cnt->stream.socket = http_bindsock(cnt->conf.stream_port, cnt->conf.stream_localhost,
-                                       cnt->conf.ipv6_enabled);
+                                       cnt->conf.localhost_ipv4);
     cnt->stream.next = NULL;
     cnt->stream.prev = NULL;
     return cnt->stream.socket;

--- a/stream.c
+++ b/stream.c
@@ -724,23 +724,28 @@ int http_bindsock(int port, int local, int local_ipv4)
 {
     int sd = socket(AF_INET6, SOCK_STREAM, 0);
 
+    char *addr_str;
     struct sockaddr_in6 sin6;
     bzero(&sin6, sizeof(struct sockaddr_in6));
     sin6.sin6_family = AF_INET6;
     sin6.sin6_port = htons(port);
     if(local) {
-        if(local_ipv4) //listen only on 127.0.0.1
+        if(local_ipv4) {
+            addr_str = "127.0.0.1";
             sin6.sin6_addr = in6addr_loopback4;
-        else //listen only on ::1
+        } else {
+            addr_str = "::1";
             sin6.sin6_addr = in6addr_loopback;
+        }
     } else {
+        addr_str = "any address";
         sin6.sin6_addr = in6addr_any;
     }
     int no = 0;
     setsockopt(sd, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&no, sizeof(no));
 
     if (bind(sd, &sin6, sizeof(sin6)) != 0) {
-        MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "%s: error binding on port: %d", port);
+        MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "%s: error binding on %s port %d", addr_str, port);
         return -1;
     }
 
@@ -749,7 +754,7 @@ int http_bindsock(int port, int local, int local_ipv4)
         return -1;
     }
 
-    MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "%s: listening on port: %d", port);
+    MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "%s: listening on %s port %d", addr_str, port);
 
     return sd;
 }

--- a/stream.c
+++ b/stream.c
@@ -725,26 +725,26 @@ int http_bindsock(int port, int local, int ipv6_localhost)
     int sd = socket(AF_INET6, SOCK_STREAM, 0);
 
     char *addr_str;
-    struct sockaddr_in6 sin6;
-    bzero(&sin6, sizeof(struct sockaddr_in6));
-    sin6.sin6_family = AF_INET6;
-    sin6.sin6_port = htons(port);
+    struct sockaddr_in6 sin;
+    bzero(&sin, sizeof(struct sockaddr_in6));
+    sin.sin6_family = AF_INET6;
+    sin.sin6_port = htons(port);
     if(local) {
         if(ipv6_localhost) {
             addr_str = "::1";
-            sin6.sin6_addr = in6addr_loopback;
+            sin.sin6_addr = in6addr_loopback;
         } else {
             addr_str = "127.0.0.1";
-            sin6.sin6_addr = in6addr_loopback4;
+            sin.sin6_addr = in6addr_loopback4;
         }
     } else {
         addr_str = "any address";
-        sin6.sin6_addr = in6addr_any;
+        sin.sin6_addr = in6addr_any;
     }
     int no = 0;
     setsockopt(sd, IPPROTO_IPV6, IPV6_V6ONLY, (void *)&no, sizeof(no));
 
-    if (bind(sd, &sin6, sizeof(sin6)) != 0) {
+    if (bind(sd, &sin, sizeof(sin)) != 0) {
         MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "%s: error binding on %s port %d", addr_str, port);
         return -1;
     }
@@ -769,10 +769,10 @@ static int http_acceptsock(int sl)
 {
     int sc;
     unsigned long i;
-    struct sockaddr_storage sin;
-    socklen_t addrlen = sizeof(sin);
+    struct sockaddr_in6 sin;
+    socklen_t sin_len = sizeof(sin);
 
-    if ((sc = accept(sl, (struct sockaddr *)&sin, &addrlen)) >= 0) {
+    if ((sc = accept(sl, &sin, &sin_len)) >= 0) {
         i = 1;
         ioctl(sc, FIONBIO, &i);
         return sc;

--- a/webhttpd.c
+++ b/webhttpd.c
@@ -2607,8 +2607,8 @@ void httpd_run(struct context **cnt)
         return;
     }
 
-    MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO,
-        "%s: motion-httpd/"VERSION" running, accepting connections");
+    MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO,"%s: Started motion-httpd server on port %d (auth %s)",
+        cnt[0]->conf.webcontrol_port, cnt[0]->conf.webcontrol_authentication ? "Enabled":"Disabled");
 
     if (cnt[0]->conf.webcontrol_authentication != NULL) {
         char *userpass = NULL;

--- a/webhttpd.c
+++ b/webhttpd.c
@@ -2601,7 +2601,7 @@ void httpd_run(struct context **cnt)
     sigaction(SIGCHLD, &act, NULL);
 
     int sd = http_bindsock(cnt[0]->conf.webcontrol_port,
-        cnt[0]->conf.webcontrol_localhost, cnt[0]->conf.localhost_ipv4);
+        cnt[0]->conf.webcontrol_localhost, cnt[0]->conf.ipv6_enabled);
     if (sd < 0) {
         pthread_mutex_destroy(&httpd_mutex);
         return;

--- a/webhttpd.c
+++ b/webhttpd.c
@@ -2558,8 +2558,8 @@ static unsigned int read_client(int client_socket, void *userdata, char *auth)
 static int acceptnonblocking(int serverfd, int timeout)
 {
     int curfd;
-    struct sockaddr_storage client;
-    socklen_t namelen = sizeof(client);
+    struct sockaddr_in6 client;
+    socklen_t client_len = sizeof(client);
 
     struct timeval tm;
     fd_set fds;
@@ -2571,7 +2571,7 @@ static int acceptnonblocking(int serverfd, int timeout)
 
     if (select(serverfd + 1, &fds, NULL, NULL, &tm) > 0) {
         if (FD_ISSET(serverfd, &fds)) {
-            if ((curfd = accept(serverfd, (struct sockaddr*)&client, &namelen)) > 0)
+            if ((curfd = accept(serverfd, &client, &client_len)) > 0)
                 return curfd;
         }
     }


### PR DESCRIPTION
Remove option ipv6_enabled (IPv6 is always enabled)
Add option localhost_ipv4 (the user must choose to listen to IPv4 and IPv6 localhost, only relevant when the localhost option is set to on)

See #97 for more information