### PR TITLE
Fix for crash accessing camera_id / corrupt config files

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -744,9 +744,9 @@ config_param config_params[] = {
     },
     {
     "camera_id",
-    "Id used to label the camera when inserting data into SQL or saving the\n"
-    "camera image to disk.  This is better than using thread ID so that there\n"
-    "always is a consistent label\n",
+    "# Id used to label the camera when inserting data into SQL or saving the\n"
+    "# camera image to disk.  This is better than using thread ID so that there\n"
+    "# always is a consistent label",
     0,
     CONF_OFFSET(camera_id),
     copy_int,


### PR DESCRIPTION
The help comment didn't contain the necessary #s at the beginning.

Fixes #200