### PR TITLE
Alternative sed option to not create bak files

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -155,12 +155,12 @@ svn:
 	svn update
 
 autotools:
-	@sed -i.bak 's/.\/commit-version.sh/.\/version.sh/g' configure.ac
+	@sed -e 's/.\/commit-version.sh/.\/version.sh/g' configure.ac > configure.ac.tmp && mv configure.ac.tmp configure.ac
 	autoconf
 	./configure --with-developer-flags 
 
 autotools-git:
-	@sed -i.bak 's/.\/git-commit-version.sh/.\/version.sh/g' configure.ac
+	@sed -e 's/.\/git-commit-version.sh/.\/version.sh/g' configure.ac > configure.ac.tmp && mv configure.ac.tmp configure.ac
 	autoconf
 	./configure --with-developer-flags 
 
@@ -168,15 +168,15 @@ autotools-git:
 build-commit: distclean svn set-version all
 
 set-version:
-	@sed -i.bak 's/.\/version.sh/.\/commit-version.sh/g' configure.ac
+	@sed -e 's/.\/version.sh/.\/commit-version.sh/g' configure.ac > configure.ac.tmp && mv configure.ac.tmp configure.ac
 	autoconf
-	@sed -i.bak 's/.\/commit-version.sh/.\/version.sh/g' configure.ac
+	@sed -e 's/.\/commit-version.sh/.\/version.sh/g' configure.ac > configure.ac.tmp && mv configure.ac.tmp configure.ac
 	./configure --with-developer-flags
 
 set-version-git:
-	@sed -i.bak 's/.\/version.sh/.\/git-commit-version.sh/g' configure.ac
+	@sed -e 's/.\/version.sh/.\/git-commit-version.sh/g' configure.ac > configure.ac.tmp && mv configure.ac.tmp configure.ac
 	autoconf
-	@sed -i.bak 's/.\/git-commit-version.sh/.\/version.sh/g' configure.ac
+	@sed -e 's/.\/git-commit-version.sh/.\/version.sh/g' configure.ac > configure.ac.tmp && mv configure.ac.tmp configure.ac
 	./configure --with-developer-flags
 
 
@@ -207,11 +207,11 @@ install:
 	mkdir -p $(DESTDIR)$(sysconfdir)/motion
 	mkdir -p $(DESTDIR)$(docdir)
 	mkdir -p $(DESTDIR)$(examplesdir)
-	@sed -i.bak 's|$${prefix}|$(prefix)|' motion-dist.conf
-	@sed -i.bak 's|$${prefix}|$(prefix)|' camera1-dist.conf
-	@sed -i.bak 's|$${prefix}|$(prefix)|' camera2-dist.conf
-	@sed -i.bak 's|$${prefix}|$(prefix)|' camera3-dist.conf
-	@sed -i.bak 's|$${prefix}|$(prefix)|' camera4-dist.conf
+	@sed -e 's|$${prefix}|$(prefix)|' motion-dist.conf > motion-dist.conf.tmp && mv motion-dist.conf.tmp motion-dist.conf
+	@sed -e 's|$${prefix}|$(prefix)|' camera1-dist.conf > camera1-dist.conf.tmp && mv camera1-dist.conf.tmp camera1-dist.conf
+	@sed -e 's|$${prefix}|$(prefix)|' camera2-dist.conf > camera2-dist.conf.tmp && mv camera2-dist.conf.tmp camera2-dist.conf
+	@sed -e 's|$${prefix}|$(prefix)|' camera3-dist.conf > camera3-dist.conf.tmp && mv camera3-dist.conf.tmp camera3-dist.conf
+	@sed -e 's|$${prefix}|$(prefix)|' camera4-dist.conf > camera4-dist.conf.tmp && mv camera4-dist.conf.tmp camera4-dist.conf
 	$(INSTALL_DATA) motion.1 $(DESTDIR)$(mandir)/man1
 	$(INSTALL_DATA) $(DOC) $(DESTDIR)$(docdir)
 	$(INSTALL_DATA) $(EXAMPLES) $(DESTDIR)$(examplesdir)

--- a/Makefile.in
+++ b/Makefile.in
@@ -155,12 +155,12 @@ svn:
 	svn update
 
 autotools:
-	@sed -e 's/.\/commit-version.sh/.\/version.sh/g' configure.ac > configure.ac.tmp && mv configure.ac.tmp configure.ac
+	@sed -e 's/.\/commit-version.sh/.\/version.sh/g' configure.ac > configure.ac.tmp && mv -f configure.ac.tmp configure.ac
 	autoconf
 	./configure --with-developer-flags 
 
 autotools-git:
-	@sed -e 's/.\/git-commit-version.sh/.\/version.sh/g' configure.ac > configure.ac.tmp && mv configure.ac.tmp configure.ac
+	@sed -e 's/.\/git-commit-version.sh/.\/version.sh/g' configure.ac > configure.ac.tmp && mv -f configure.ac.tmp configure.ac
 	autoconf
 	./configure --with-developer-flags 
 
@@ -168,15 +168,15 @@ autotools-git:
 build-commit: distclean svn set-version all
 
 set-version:
-	@sed -e 's/.\/version.sh/.\/commit-version.sh/g' configure.ac > configure.ac.tmp && mv configure.ac.tmp configure.ac
+	@sed -e 's/.\/version.sh/.\/commit-version.sh/g' configure.ac > configure.ac.tmp && mv -f configure.ac.tmp configure.ac
 	autoconf
-	@sed -e 's/.\/commit-version.sh/.\/version.sh/g' configure.ac > configure.ac.tmp && mv configure.ac.tmp configure.ac
+	@sed -e 's/.\/commit-version.sh/.\/version.sh/g' configure.ac > configure.ac.tmp && mv -f configure.ac.tmp configure.ac
 	./configure --with-developer-flags
 
 set-version-git:
-	@sed -e 's/.\/version.sh/.\/git-commit-version.sh/g' configure.ac > configure.ac.tmp && mv configure.ac.tmp configure.ac
+	@sed -e 's/.\/version.sh/.\/git-commit-version.sh/g' configure.ac > configure.ac.tmp && mv -f configure.ac.tmp configure.ac
 	autoconf
-	@sed -e 's/.\/git-commit-version.sh/.\/version.sh/g' configure.ac > configure.ac.tmp && mv configure.ac.tmp configure.ac
+	@sed -e 's/.\/git-commit-version.sh/.\/version.sh/g' configure.ac > configure.ac.tmp && mv -f configure.ac.tmp configure.ac
 	./configure --with-developer-flags
 
 
@@ -207,11 +207,11 @@ install:
 	mkdir -p $(DESTDIR)$(sysconfdir)/motion
 	mkdir -p $(DESTDIR)$(docdir)
 	mkdir -p $(DESTDIR)$(examplesdir)
-	@sed -e 's|$${prefix}|$(prefix)|' motion-dist.conf > motion-dist.conf.tmp && mv motion-dist.conf.tmp motion-dist.conf
-	@sed -e 's|$${prefix}|$(prefix)|' camera1-dist.conf > camera1-dist.conf.tmp && mv camera1-dist.conf.tmp camera1-dist.conf
-	@sed -e 's|$${prefix}|$(prefix)|' camera2-dist.conf > camera2-dist.conf.tmp && mv camera2-dist.conf.tmp camera2-dist.conf
-	@sed -e 's|$${prefix}|$(prefix)|' camera3-dist.conf > camera3-dist.conf.tmp && mv camera3-dist.conf.tmp camera3-dist.conf
-	@sed -e 's|$${prefix}|$(prefix)|' camera4-dist.conf > camera4-dist.conf.tmp && mv camera4-dist.conf.tmp camera4-dist.conf
+	@sed -e 's|$${prefix}|$(prefix)|' motion-dist.conf > motion-dist.conf.tmp && mv -f motion-dist.conf.tmp motion-dist.conf
+	@sed -e 's|$${prefix}|$(prefix)|' camera1-dist.conf > camera1-dist.conf.tmp && mv -f camera1-dist.conf.tmp camera1-dist.conf
+	@sed -e 's|$${prefix}|$(prefix)|' camera2-dist.conf > camera2-dist.conf.tmp && mv -f camera2-dist.conf.tmp camera2-dist.conf
+	@sed -e 's|$${prefix}|$(prefix)|' camera3-dist.conf > camera3-dist.conf.tmp && mv -f camera3-dist.conf.tmp camera3-dist.conf
+	@sed -e 's|$${prefix}|$(prefix)|' camera4-dist.conf > camera4-dist.conf.tmp && mv -f camera4-dist.conf.tmp camera4-dist.conf
 	$(INSTALL_DATA) motion.1 $(DESTDIR)$(mandir)/man1
 	$(INSTALL_DATA) $(DOC) $(DESTDIR)$(docdir)
 	$(INSTALL_DATA) $(EXAMPLES) $(DESTDIR)$(examplesdir)


### PR DESCRIPTION
The bsd compile pull revised the sed option to use -i.bak but this leaves behind bak files.  This alternative was found that was indicated to also be compatible without leaving bak files. 