### PR TITLE
Put back option to disable IPv6

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -1080,7 +1080,7 @@ config_param config_params[] = {
     "\n############################################################\n"
     "# Global Network Options\n"
     "############################################################\n\n"
-    "# Listen to IPv6 localhost instead of IPv4 (default: off)",
+    "# Enable IPv6 (default: off)",
     0,
     CONF_OFFSET(ipv6_enabled),
     copy_bool,

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -480,7 +480,7 @@ timelapse_filename %Y%m%d-timelapse
 ############################################################
 # Global Network Options
 ############################################################
-# Listen to IPv6 localhost instead of IPv4 (default: off)
+# Enable IPv6 (default: off)
 ipv6_enabled off
 
 ############################################################


### PR DESCRIPTION
`enable_ipv6 off` now (again) turns off IPv6 entirely.

I have set the default to `enable_ipv6 on`, since disabling it should only be necessary on a small set of systems.

Fixes #217