### PR TITLE
Fix commit version for non-git versions

### DIFF
--- a/commit-version.sh
+++ b/commit-version.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
-SNV_VERSION=`git show -s --format=%h`
-echo -n "4.0+git$SNV_VERSION"
+BASE_VERSION="4.0"
+if [ -d .git ]; then
+	GIT_COMMIT=`git show -s --format=%h`
+	echo -n "$BASE_VERSION+git$GIT_COMMIT"
+else
+	echo -n "$BASE_VERSION"
+fi

--- a/git-commit-version.sh
+++ b/git-commit-version.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
-SNV_VERSION=`git show -s --format=%h`
-echo -n "4.0+git$SNV_VERSION"
-
+BASE_VERSION="4.0"
+if [ -d .git ]; then
+	GIT_COMMIT=`git show -s --format=%h`
+	echo -n "$BASE_VERSION+git$GIT_COMMIT"
+else
+	echo -n "$BASE_VERSION"
+fi

--- a/version.sh
+++ b/version.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
-SNV_VERSION=`git show -s --format=%h`
-echo -n "4.0+git$SNV_VERSION"
+BASE_VERSION="4.0"
+if [ -d .git ]; then
+	GIT_COMMIT=`git show -s --format=%h`
+	echo -n "$BASE_VERSION+git$GIT_COMMIT"
+else
+	echo -n "$BASE_VERSION"
+fi


### PR DESCRIPTION
First of all: congrats on the 4.0 release!

When I download from https://github.com/Motion-Project/motion/archive/release-4.0.tar.gz and compile it the regular way, I get the following message:
````
fatal: Not a git repository (or any parent up to mount point /home)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
````

and the version number set in in the configuration files and the program itself is `4.0+git`.

This is because `version.sh` expects that it in in a git clone (that there is a `.git` directory).

This pull request fixes the version number for non-git releases.