### PR TITLE
Rename base64_encode

### DIFF
--- a/netcam.c
+++ b/netcam.c
@@ -2019,7 +2019,7 @@ static int netcam_http_build_url(netcam_context_ptr netcam, struct url_t *url)
     else
         ptr = url->userpass;
 
-    /* base64_encode needs up to 3 additional chars. */
+    /* motion_base64_encode needs up to 3 additional chars. */
     if (ptr) {
         userpass = mymalloc(strlen(ptr) + 3);
         strcpy(userpass, ptr);
@@ -2045,7 +2045,7 @@ static int netcam_http_build_url(netcam_context_ptr netcam, struct url_t *url)
         /* Allocate space for the base64-encoded string. */
         encuserpass = mymalloc(BASE64_LENGTH(strlen(userpass)) + 1);
         /* Fill in the value. */
-        base64_encode(userpass, encuserpass, strlen(userpass));
+        motion_base64_encode(userpass, encuserpass, strlen(userpass));
         /* Now create the last part (authorization) of the request. */
         request_pass = mymalloc(strlen(connect_auth_req) +
                                 strlen(encuserpass) + 1);

--- a/netcam_wget.c
+++ b/netcam_wget.c
@@ -210,13 +210,13 @@ int skip_lws(const char *string)
 
 
 /**
- * base64_encode
+ * motion_base64_encode
  *
  *   Encode the string S of length LENGTH to base64 format and place it
  *   to STORE.  STORE will be 0-terminated, and must point to a writable
  *   buffer of at least 1+BASE64_LENGTH(length) bytes.  
  */
-void base64_encode(const char *s, char *store, int length)
+void motion_base64_encode(const char *s, char *store, int length)
 {
     /* Conversion table.  */
     static const char tbl[64] = {

--- a/netcam_wget.h
+++ b/netcam_wget.h
@@ -72,7 +72,7 @@ int rbuf_read_bufferful(netcam_context_ptr);
 /* How many bytes it will take to store LEN bytes in base64.  */
 #define BASE64_LENGTH(len) (4 * (((len) + 2) / 3))
 
-void base64_encode(const char *, char *, int);
+void motion_base64_encode(const char *, char *, int);
 char *strdupdelim(const char *, const char *);
 int http_process_type(const char *, void *);
 

--- a/stream.c
+++ b/stream.c
@@ -211,10 +211,10 @@ static void* handle_basic_auth(void* param)
 
         authentication = mymalloc(BASE64_LENGTH(auth_size) + 1);
         userpass = mymalloc(auth_size + 4);
-        /* base64_encode can read 3 bytes after the end of the string, initialize it. */
+        /* motion_base64_encode can read 3 bytes after the end of the string, initialize it. */
         memset(userpass, 0, auth_size + 4);
         strcpy(userpass, p->conf->stream_authentication);
-        base64_encode(userpass, authentication, auth_size);
+        motion_base64_encode(userpass, authentication, auth_size);
         free(userpass);
 
         if (strcmp(auth, authentication)) {

--- a/webhttpd.c
+++ b/webhttpd.c
@@ -2616,10 +2616,10 @@ void httpd_run(struct context **cnt)
 
         authentication = mymalloc(BASE64_LENGTH(auth_size) + 1);
         userpass = mymalloc(auth_size + 4);
-        /* base64_encode can read 3 bytes after the end of the string, initialize it */
+        /* motion_base64_encode can read 3 bytes after the end of the string, initialize it */
         memset(userpass, 0, auth_size + 4);
         strcpy(userpass, cnt[0]->conf.webcontrol_authentication);
-        base64_encode(userpass, authentication, auth_size);
+        motion_base64_encode(userpass, authentication, auth_size);
         free(userpass);
     }
 


### PR DESCRIPTION
base64_encode is already defined in gnutls so rename it as
motion_base64_encode to prevent a definition clash when linking
statically with gnutls

Fixes:
  - http://autobuild.buildroot.org/results/592672b8826f4c731c50d29725da964d876573c4

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>