### PR TITLE
Cleanup old defines, FreeBSD CMake fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ else(${WITH_V4L})
 	set(WITHOUT_V4L ON)
 endif(${WITH_V4L})
 set(MOTION_V4L2 ${HAVE_LINUX_VIDEODEV2_H})
-set(MOTION_V4L2_OLD ${HAVE_LINUX_VIDEODEV2_H})
 
 configure_file(config.h.in "${CMAKE_CURRENT_SOURCE_DIR}/config.h")
 configure_file(motion-dist.conf.in motion-dist.conf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ option(WITH_MYSQL "enable MySQL database support" ${MYSQL_FOUND})
 option(WITH_PGSQL "enable PostgreSQL database support" ${PostgreSQL_FOUND})
 option(WITH_SQLITE3 "enable SQLite database support" ${SQLITE3_FOUND})
 option(WITH_V4L "enable Video 4 Linux (2) webcam support" ON)
+option(WITH_PWCBSD "enable PWC webcam support (BSD only)" OFF)
 
 set(HAVE_FFMPEG ${WITH_FFMPEG})
 set(HAVE_MMAL ${WITH_MMAL})
@@ -40,6 +41,7 @@ else(${WITH_V4L})
 	set(WITHOUT_V4L ON)
 endif(${WITH_V4L})
 set(MOTION_V4L2 ${HAVE_LINUX_VIDEODEV2_H})
+set(PWCBSD WITH_PWCBSD)
 
 configure_file(config.h.in "${CMAKE_CURRENT_SOURCE_DIR}/config.h")
 configure_file(motion-dist.conf.in motion-dist.conf)
@@ -56,11 +58,12 @@ configure_file(motion.init-FreeBSD.sh.in motion.init-FreeBSD.sh)
 list(APPEND SRC_FILES
      conf.c motion.c alg.c draw.c event.c ffmpeg.c jpegutils.c logger.c md5.c
      netcam.c netcam_ftp.c netcam_jpeg.c netcam_rtsp.c netcam_wget.c
-     picture.c rotate.c stream.c track.c video2.c video.c video_common.c
-     vloopback_motion.c webhttpd.c)
-if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+     picture.c rotate.c stream.c track.c vloopback_motion.c webhttpd.c)
+if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD" AND NOT(WITH_PWCBSD))
 	list(APPEND SRC_FILES video_freebsd.c)
-endif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+else()
+	list(APPEND SRC_FILES video2.c video.c video_common.c)
+endif()
 
 include_directories(${JPEG_INCLUDE_DIR})
 list(APPEND LINK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT} ${JPEG_LIBRARIES})

--- a/config.h.in
+++ b/config.h.in
@@ -18,5 +18,4 @@
 #undef PWCBSD
 #undef OLD_BKTR
 #cmakedefine MOTION_V4L2
-#cmakedefine MOTION_V4L2_OLD
 #cmakedefine WITHOUT_V4L

--- a/config.h.in
+++ b/config.h.in
@@ -8,13 +8,11 @@
 #cmakedefine HAVE_MYSQL
 #cmakedefine HAVE_PGSQL
 #cmakedefine HAVE_SQLITE3
+#cmakedefine PWCBSD
+#cmakedefine MOTION_V4L2
+#cmakedefine WITHOUT_V4L
 
 /* Optional headers */
 #cmakedefine HAVE_LINUX_VIDEODEV_H
 #cmakedefine HAVE_LINUX_VIDEODEV2_H
 #cmakedefine HAVE_SYS_VIDEOIO_H
-
-/* TODO: look at these */
-#undef PWCBSD
-#cmakedefine MOTION_V4L2
-#cmakedefine WITHOUT_V4L

--- a/config.h.in
+++ b/config.h.in
@@ -16,6 +16,5 @@
 
 /* TODO: look at these */
 #undef PWCBSD
-#undef OLD_BKTR
 #cmakedefine MOTION_V4L2
 #cmakedefine WITHOUT_V4L

--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,6 @@ if test "${FreeBSD}" != "" && test "${PWCBSD}" = "no"; then
 		AC_MSG_RESULT(yes)
 	else
 		AC_MSG_RESULT(no)
-		TEMP_CFLAGS="${TEMP_CFLAGS} -DOLD_BKTR"
 	fi
 #
 # Check to Exclude BKTR

--- a/configure.ac
+++ b/configure.ac
@@ -745,7 +745,6 @@ AC_CHECK_HEADERS(stdio.h unistd.h stdint.h fcntl.h time.h signal.h sys/ioctl.h s
 
 # Check if v4l2 is available
 SUPPORTED_V4L2=false
-SUPPORTED_V4L2_old=false
 
 if test "${V4L}" = "no"; then
 	AC_MSG_CHECKING(for V42L support)
@@ -755,7 +754,9 @@ else
 		[SUPPORTED_V4L2=true],
 		[SUPPORTED_V4L2=false],
 		[#include <sys/time.h>
-			#ifdef HAVE_LINUX_VIDEODEV_H
+			#ifdef HAVE_LINUX_VIDEODEV2_H
+			#include <linux/videodev2.h>
+			#elif HAVE_LINUX_VIDEODEV_H
 			#include <linux/videodev.h>
 			#elif HAVE_SYS_VIDEOIO_H
 			#include <sys/videoio.h>
@@ -767,20 +768,6 @@ else
 	else
 		AC_MSG_RESULT(no)
 	fi
-
-	# linux/videodev.h doesn't include videodev2.h
-	if test x$SUPPORTED_V4L2 = xfalse; then
-		AC_MSG_CHECKING(for V42L *old* support)
-		AC_MSG_RESULT(testing)
-		AC_CHECK_HEADERS(linux/videodev2.h,[SUPPORTED_V4L2_old=true],[], [#include <asm/types.h>])
-	fi
-
-
-	if test x$SUPPORTED_V4L2_old = xtrue; then
-		TEMP_CFLAGS="${TEMP_CFLAGS} -DMOTION_V4L2 -DMOTION_V4L2_OLD"
-		SUPPORTED_V4L2=true
-	fi
-
 fi
 
 

--- a/motion.h
+++ b/motion.h
@@ -49,12 +49,6 @@
 #include <sys/ioctl.h>
 #include <sys/param.h>
 #include <stdint.h>
-
-#define _LINUX_TIME_H 1
-#if defined(HAVE_LINUX_VIDEODEV_H) && (!defined(WITHOUT_V4L)) && (!defined(BSD))
-#include <linux/videodev.h>
-#endif
-
 #include <pthread.h>
 
 #include "logger.h"

--- a/pwc-ioctl.h
+++ b/pwc-ioctl.h
@@ -55,13 +55,7 @@
 #if defined(__linux__)
 #include <linux/types.h>
 #include <linux/version.h>
-
-#if LINUX_VERSION_CODE <= KERNEL_VERSION(2, 6, 10)
-/* Compatibility for older kernel */
-typedef __u16 __le16;
 #endif
-
-#endif /* ( !BSD ) */
 
  /* Enumeration of image sizes */
 #define PSZ_SQCIF   0x00

--- a/video.h
+++ b/video.h
@@ -10,12 +10,12 @@
 #ifndef _INCLUDE_VIDEO_H
 #define _INCLUDE_VIDEO_H
 
-#define _LINUX_TIME_H 1
 #include <sys/mman.h>
 
-
 #if !defined(WITHOUT_V4L)
-#if defined(HAVE_LINUX_VIDEODEV_H)
+#if defined(HAVE_LINUX_VIDEODEV2_H)
+#include <linux/videodev2.h>
+#elif defined(HAVE_LINUX_VIDEODEV_H)
 #include <linux/videodev.h>
 #elif defined(HAVE_SYS_VIDEOIO_H)
 #include <sys/videoio.h>

--- a/video2.c
+++ b/video2.c
@@ -73,12 +73,6 @@
 
 #if !defined(WITHOUT_V4L) && defined(MOTION_V4L2)
 
-#ifdef MOTION_V4L2_OLD
-// Seems that is needed for some system
-#include <linux/time.h>
-#include <linux/videodev2.h>
-#endif
-
 #define u8 unsigned char
 #define u16 unsigned short
 #define u32 unsigned int

--- a/video_freebsd.h
+++ b/video_freebsd.h
@@ -13,13 +13,8 @@
 
 #ifndef WITHOUT_V4L
 
-#ifdef __NetBSD__
+#if defined(__NetBSD__) || defined(__OpenBSD__)
 #include <dev/ic/bt8xx.h>
-#elif __OpenBSD__
-#include <dev/ic/bt8xx.h>
-#elif defined(OLD_BKTR)
-#include <machine/ioctl_meteor.h>
-#include <machine/ioctl_bt848.h>
 #else
 #include <dev/bktr/ioctl_meteor.h>
 #include <dev/bktr/ioctl_bt848.h>


### PR DESCRIPTION
Should be pretty self-explanatory, with maybe one exception:
`MOTION_V4L2_OLD` was only used to do `#include <linux/time.h>` and  `#include <linux/videodev2.h>`.
* `time.h` is already correctly included in `motion.h`, which is included at the top of `video2.c`
* I moved `#include <linux/videodev2.h>` together with the other video headers in `video.h`