### PR TITLE
Fix OpenBSD and NetBSD compilation

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -102,7 +102,7 @@ struct config conf_template = {
     .tuner_number =                    0,
     .timelapse =                       0,
     .timelapse_mode =                  DEF_TIMELAPSE_MODE,
-#if (defined(__FreeBSD__))
+#ifdef __FreeBSD__
     tuner_device:                   NULL,
 #endif
     .video_device =                    VIDEO_DEVICE,
@@ -298,7 +298,7 @@ config_param config_params[] = {
     copy_int,
     print_int
     },
-#if (defined(__FreeBSD__))
+#ifdef __FreeBSD__
     {
     "tunerdevice",
     "# Tuner device to be used for capturing using tuner as source (default /dev/tuner0)\n"

--- a/conf.h
+++ b/conf.h
@@ -86,7 +86,7 @@ struct config {
     int tuner_number;
     int timelapse;
     const char *timelapse_mode;
-#if (defined(BSD) || defined(__FreeBSD_kernel__))
+#ifdef __FreeBSD__
     const char *tuner_device;
 #endif
     const char *video_device;

--- a/logger.c
+++ b/logger.c
@@ -192,7 +192,7 @@ void motion_log(int level, unsigned int type, int errno_flag, const char *fmt, .
     errno_save = errno;
 
     char threadname[32] = "unknown";
-#if (!defined(__FreeBSD__))
+#if (!defined(BSD) || defined(__APPLE__))
     pthread_getname_np(pthread_self(), threadname, sizeof(threadname));
 #endif
 

--- a/motion.c
+++ b/motion.c
@@ -13,7 +13,7 @@
 #include "video_freebsd.h"
 #else
 #include "video.h"
-#endif /* BSD */
+#endif
 
 #include "conf.h"
 #include "alg.h"
@@ -2311,11 +2311,11 @@ static void become_daemon(void)
         MOTION_LOG(ERR, TYPE_ALL, SHOW_ERRNO, "%s: Could not change directory");
 
 
-#if (defined(__FreeBSD__))
+#if (defined(BSD) && !defined(__APPLE__))
     setpgrp(0, getpid());
 #else
     setpgrp();
-#endif /* __FreeBSD__ */
+#endif
 
 
     if ((i = open("/dev/tty", O_RDWR)) >= 0) {

--- a/motion.h
+++ b/motion.h
@@ -12,10 +12,6 @@
 
 #include "config.h"
 
-#if defined(__FreeBSD__) || defined(__NetBSD__)
-#define BSD
-#endif
-
 /* Includes */
 #ifdef HAVE_MYSQL
 #include <mysql.h>
@@ -58,7 +54,7 @@
 
 #ifdef __APPLE__
 #define MOTION_PTHREAD_SETNAME(name)  pthread_setname_np(name)
-#elif defined(__FreeBSD__)
+#elif defined(BSD)
 #define MOTION_PTHREAD_SETNAME(name)  pthread_set_name_np(pthread_self(), name)
 #else
 #define MOTION_PTHREAD_SETNAME(name)  pthread_setname_np(pthread_self(), name)
@@ -404,9 +400,6 @@ struct context {
     int missing_frame_counter;               /* counts failed attempts to fetch picture frame from camera */
     unsigned int lost_connection;    
 
-#if (defined(BSD))
-    int tuner_dev;
-#endif
     int video_dev;
     int pipe;
     int mpipe;

--- a/netcam_rtsp.c
+++ b/netcam_rtsp.c
@@ -463,10 +463,8 @@ static int netcam_rtsp_open_context(netcam_context_ptr netcam){
      * desired name */
     {
         char newtname[16];
-#if defined(__FreeBSD__)
         char curtname[16] = "unknown";
-#else
-        char curtname[16];
+#if (!defined(BSD) || defined(__APPLE__))
         pthread_getname_np(pthread_self(), curtname, sizeof(curtname));
 #endif
         snprintf(newtname, sizeof(newtname), "av%d%s%s",

--- a/pwc-ioctl.h
+++ b/pwc-ioctl.h
@@ -323,6 +323,6 @@ struct pwc_raw_frame {
    __u8   rawframe[0];    /* frame_size = H/4*vbandlength */
 } __attribute__ ((packed));
 
-#endif    /*  MOTION_V4L2 && (! BSD ) */
+#endif /*  MOTION_V4L2 && __linux__ */
 
 #endif

--- a/rotate.c
+++ b/rotate.c
@@ -34,8 +34,14 @@
 #if defined(__APPLE__)
 #include <libkern/OSByteOrder.h>
 #define bswap_32(x) OSSwapInt32(x)
-#elif defined(BSD)
+#elif defined(__FreeBSD__)
 #include <sys/endian.h>
+#define bswap_32(x) bswap32(x)
+#elif defined(__OpenBSD__)
+#include <sys/types.h>
+#define bswap_32(x) swap32(x)
+#elif defined(__NetBSD__)
+#include <sys/bswap.h>
 #define bswap_32(x) bswap32(x)
 #else
 #include <byteswap.h>


### PR DESCRIPTION
Note that the `#define BSD` is not needed, because `BSD` is already set in `<sys/param.h>`. See e.g. [here](http://nadeausoftware.com/articles/2012/01/c_c_tip_how_use_compiler_predefined_macros_detect_operating_system).

Verified compilation on FreeBSD, OpenBSD and macOS. NetBSD should also work although I couldn't get that working in a virtual machine.

Also, `context.tuner_dev` was never used, so I've removed that.