### PR TITLE
Add in a 'on_camera_found' event

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -138,6 +138,7 @@ struct config conf_template = {
     .on_movie_start =                  NULL,
     .on_movie_end =                    NULL,
     .on_camera_lost =                  NULL,
+    .on_camera_found =                 NULL,
     .motionvidpipe =                   NULL,
     .netcam_url =                      NULL,
     .netcam_userpass =                 NULL,
@@ -1456,6 +1457,15 @@ config_param config_params[] = {
     "# Some hangs the motion thread. Some even hangs the PC! (default: none)",
     0,
     CONF_OFFSET(on_camera_lost),
+    copy_string,
+    print_string
+    },
+    {
+    "on_camera_found",
+    "# Command to be executed when a camera that was lost has been found (default: none)\n"
+    "# NOTE: If motion doesn't properly detect a lost camera, it also won't know it found one.\n",
+    0,
+    CONF_OFFSET(on_camera_found),
     copy_string,
     print_string
     },

--- a/conf.h
+++ b/conf.h
@@ -120,6 +120,7 @@ struct config {
     char *on_movie_start;
     char *on_movie_end;
     char *on_camera_lost;
+    char *on_camera_found;
     const char *motionvidpipe;
     const char *netcam_url;
     const char *netcam_userpass;

--- a/event.c
+++ b/event.c
@@ -37,6 +37,7 @@ const char *eventList[] = {
     "EVENT_CRITICAL",
     "EVENT_AREA_DETECTED",
     "EVENT_CAMERA_LOST",
+    "EVENT_CAMERA_FOUND",
     "EVENT_FFMPEG_PUT",
     "EVENT_LAST"
 };
@@ -446,6 +447,15 @@ static void event_camera_lost(struct context *cnt,
 {
     if (cnt->conf.on_camera_lost)
         exec_command(cnt, cnt->conf.on_camera_lost, NULL, 0);
+}
+
+static void event_camera_found(struct context *cnt,
+            motion_event type ATTRIBUTE_UNUSED,
+            unsigned char *img ATTRIBUTE_UNUSED, char *dummy1 ATTRIBUTE_UNUSED,
+            void *dummy2 ATTRIBUTE_UNUSED, struct timeval *tv1 ATTRIBUTE_UNUSED)
+{
+    if (cnt->conf.on_camera_found)
+        exec_command(cnt, cnt->conf.on_camera_found, NULL, 0);
 }
 
 static void on_movie_end_command(struct context *cnt,
@@ -1018,6 +1028,10 @@ struct event_handlers event_handlers[] = {
     {
     EVENT_CAMERA_LOST,
     event_camera_lost
+    },
+    {
+    EVENT_CAMERA_FOUND,
+    event_camera_found
     },
     {
     EVENT_STOP,

--- a/event.h
+++ b/event.h
@@ -30,6 +30,7 @@ typedef enum {
     EVENT_CRITICAL,
     EVENT_AREA_DETECTED,
     EVENT_CAMERA_LOST,
+    EVENT_CAMERA_FOUND,
     EVENT_FFMPEG_PUT,
     EVENT_LAST,
 } motion_event;

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -667,6 +667,10 @@ quiet on
 # Some hangs the motion thread. Some even hangs the PC! (default: none)
 ; on_camera_lost value
 
+# Command to be executed when a camera that was lost has been found (default: none)
+# NOTE: If motion doesn't properly detect a lost camera, it also won't know it found one.
+; on_camera_found value
+
 #####################################################################
 # Common Options for database features.
 # Options require database options to be active also.

--- a/motion.1
+++ b/motion.1
@@ -1606,7 +1606,7 @@ Do not sound beeps when detecting motion
 .nf
 on_event_start, on_event_end, on_picture_save
 on_motion_detected, on_area_detected, on_movie_start
-on_movie_end, on_camera_lost
+on_movie_end, on_camera_lost, on_camera_found
 
 .fi
 .RE

--- a/motion.c
+++ b/motion.c
@@ -1518,6 +1518,7 @@ static int mlp_capture(struct context *cnt){
             /* If we previously logged starting a grey image, now log video re-start */
             MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO, "%s: Video signal re-acquired");
             // event for re-acquired video signal can be called here
+            event(cnt, EVENT_CAMERA_FOUND, NULL, NULL, NULL, NULL);
         }
         cnt->missing_frame_counter = 0;
 

--- a/motion_guide.html
+++ b/motion_guide.html
@@ -1440,6 +1440,11 @@ Some configuration options are only used if Motion is built on a system that has
 		<td align="left"><a href="#on_camera_lost" >on_camera_lost</a></td>
 	</tr>
 	<tr>
+		<td height="17" align="left">on_camera_found</td>
+		<td align="left">on_camera_found</td>
+		<td align="left"><a href="#on_camera_found" >on_camera_found</a></td>
+	</tr>
+	<tr>
 		<td height="17" align="left">on_event_end</td>
 		<td align="left">on_event_end</td>
 		<td align="left"><a href="#on_event_end" >on_event_end</a></td>
@@ -2051,6 +2056,7 @@ Some configuration options are only used if Motion is built on a system that has
        <td bgcolor="#edf4f9" ><a href="#on_movie_start" >on_movie_start</a> </td>
        <td bgcolor="#edf4f9" ><a href="#on_movie_end" >on_movie_end</a> </td>
        <td bgcolor="#edf4f9" ><a href="#on_camera_lost" >on_camera_lost</a> </td>
+       <td bgcolor="#edf4f9" ><a href="#on_camera_found" >on_camera_found</a> </td>
      </tr>
    </tbody>
 </table>
@@ -3838,6 +3844,24 @@ dependent upon the camera and driver and it is advised that this option be teste
 for each configuration.  It has also been observed that there are also
 situations in which the disconnection of the camera even hangs the PC in which
 case this script will not be executed.
+<p></p>
+You can use <a href="#conversion_specifiers">Conversion Specifiers</a>
+and spaces as part of the command.  This can be any type of program or script.
+Remember to set the execution bit in the ACL and if it is a script type program such as perl or bash
+also remember the shebang line (e.g. #!/user/bin/perl) as the first line of the script.
+<p></p>
+<p></p>
+
+<h3><a name="on_camera_found"></a> on_camera_found </h3>
+<p></p>
+<ul>
+  <li> Type: String</li>
+  <li> Range / Valid values: Max 4095 characters</li>
+  <li> Default: </li>
+</ul>
+<p></p>
+The full path and file name of the command to be executed when a lost camera is found
+If motion fails to detect a lost camera, it will also fail to know it found one.
 <p></p>
 You can use <a href="#conversion_specifiers">Conversion Specifiers</a>
 and spaces as part of the command.  This can be any type of program or script.


### PR DESCRIPTION
## Function Addition
This adds the event "ON_CAMERA_FOUND" for when a proper image is re-acquired after a camera has been lost. The place to call this event was already commented in 'motion.c', without an actual call or event to call.
The code is essentially a copy of 'on_camera_lost' and therefore is placed just after it in each file.

### Testing
I've only briefly tested this with my setup of 5 net-cams and a notification script for lost/found. After disconnecting one camera, I received the 'lost notification' after motion detected it was gone. Quite quickly after re-connecting the camera, I received the 'found notification' as expected. No adverse side-effects were noted during the test.

### Documentation
I've updated the motion_guide.html and motion-dist.conf.in with this additon but have not modified the CHANGELOG.