### PR TITLE
Initial support for conversion specifier words

### DIFF
--- a/motion_guide.html
+++ b/motion_guide.html
@@ -2390,6 +2390,15 @@ The following section provides detailed descriptions of each of the configuratio
        <td bgcolor="#edf4f9" >number indicating filetype</a> </td>
        <td bgcolor="#edf4f9" >%$</a> </td>
        <td bgcolor="#edf4f9" >camera name</a> </td>
+
+     </tr>
+     <tr>
+       <td bgcolor="#edf4f9" >%{host}</a> </td>
+       <td bgcolor="#edf4f9" >name of computer running Motion</a> </td>
+       <td bgcolor="#edf4f9" >%{fps}</a> </td>
+       <td bgcolor="#edf4f9" >current frames per second</a> </td>
+       <td bgcolor="#edf4f9" ></a> </td>
+       <td bgcolor="#edf4f9" ></a> </td>
      </tr>
     </tbody>
 </table>


### PR DESCRIPTION
This is a first draft of the proposed change related to issue #299.
Tested by streaming a grey image with various "text_left" variants.