### PR TITLE
Force motion to run in non-daemon mode in systemd service

### DIFF
--- a/motion.service.in
+++ b/motion.service.in
@@ -4,7 +4,7 @@ After=local-fs.target network.target
 
 [Service]
 PIDFile=/var/run/motion.pid
-ExecStart=@BIN_PATH@/motion
+ExecStart=@BIN_PATH@/motion -n
 Type=simple
 StandardError=null
 


### PR DESCRIPTION
The systemd service file, with `Type=simple`, expects motion to run in non-daemon mode, and not fork. If `daemon on` is set in `motion.conf`, the service will fail to run. Better to force the right mode from the service file to prevent misconfiguration.