### PR TITLE
Privacy Mask

### DIFF
--- a/motion.1
+++ b/motion.1
@@ -732,6 +732,21 @@ This option specifies the full path and name for the mask file.
 .RE
 
 .TP
+.B mask_privacy
+.RS
+.nf
+Values: User specified string
+Default: Not defined
+Description:
+.fi
+.RS
+The PGM mask file is a specially constructed mask file that allows the user to indicate the areas
+to remove from all images.
+This option specifies the full path and name for the privacy mask file.
+.RE
+.RE
+
+.TP
 .B smart_mask_speed
 .RS
 .nf

--- a/motion_guide.html
+++ b/motion_guide.html
@@ -3531,13 +3531,12 @@ Mask file (converted to png format so it can be shown by your web browser)
 <p></p>
 The full path and filename for the privacy masking pgm file.  This file works like the mask_file as
 described above.  The difference with this parameter is that while the mask_file excludes the section from
-detecting motion, this file excludes the section of the image completely.  Excluded areas will appear as
-white on all images and movies.
+detecting motion, this file excludes the section of the image completely.  
 <p></p>
 mask_privacy is applied before detection so no motion will ever be detected in the excluded area.
 This parameter could however still be used with the mask_file.  e.g.  This file could exclude the
 neighbors yard and the mask_file would exclude the blowing tree from motion detection.  The resulting
-pictures/movies would show solid white in place of the neighbors yard but the tree would still be in
+pictures/movies would show solid black in place of the neighbors yard but the tree would still be in
 the pictures/movies.
 <p></p>
 

--- a/picture.c
+++ b/picture.c
@@ -1005,8 +1005,11 @@ unsigned char *get_pgm(FILE *picture, int width, int height)
     }
 
     /* Read data */
-
-    image = mymalloc(mask_width * mask_height);
+    /* We allocate the size for a 420P since we will use
+    ** this image for masking privacy which needs the space for
+    ** the cr / cb components
+    */
+    image = mymalloc((mask_width * mask_height * 3) / 2);
 
     for (y = 0; y < mask_height; y++) {
         if ((int)fread(&image[y * mask_width], 1, mask_width, picture) != mask_width)
@@ -1023,7 +1026,7 @@ unsigned char *get_pgm(FILE *picture, int width, int height)
         MOTION_LOG(WRN, TYPE_ALL, NO_ERRNO, "%s: Attempting to resize mask image from %dx%d to %dx%d",
                    mask_width, mask_height, width, height);
 
-        resized_image = mymalloc(width * height);
+        resized_image = mymalloc((width * height * 3) / 2);
 
         for (y = 0; y < height; y++) {
             for (x = 0; x < width; x++) {


### PR DESCRIPTION
This PR fixes a issue with the previous implementation of the privacy mask.  In the previous implementation, the mask was only applied to the y color space.  This allowed for changes to still be seen with the Cr and Cb color spaces.  This PR implements the mask in all the color spaces to completely mask the area and revises the masked space to be black.