### PR TITLE
ffmpeg 3.1 Revisions

### DIFF
--- a/event.c
+++ b/event.c
@@ -691,7 +691,13 @@ static void event_ffmpeg_newfile(struct context *cnt,
         cnt->ffmpeg_output->start_time.tv_sec = currenttime_tv->tv_sec;
         cnt->ffmpeg_output->start_time.tv_usec = currenttime_tv->tv_usec;
         cnt->ffmpeg_output->last_pts = 0;
+        cnt->ffmpeg_output->gop_cnt = 0;
         cnt->ffmpeg_output->codec_name = codec;
+        if (strcmp(cnt->conf.ffmpeg_video_codec, "test") == 0) {
+            cnt->ffmpeg_output->test_mode = 1;
+        } else {
+            cnt->ffmpeg_output->test_mode = 0;
+        }
 
         retcd = ffmpeg_open(cnt->ffmpeg_output);
         if (retcd < 0){
@@ -715,7 +721,13 @@ static void event_ffmpeg_newfile(struct context *cnt,
         cnt->ffmpeg_output_debug->start_time.tv_sec = currenttime_tv->tv_sec;
         cnt->ffmpeg_output_debug->start_time.tv_usec = currenttime_tv->tv_usec;
         cnt->ffmpeg_output_debug->last_pts = 0;
+        cnt->ffmpeg_output_debug->gop_cnt = 0;
         cnt->ffmpeg_output_debug->codec_name = codec;
+        if (strcmp(cnt->conf.ffmpeg_video_codec, "test") == 0) {
+            cnt->ffmpeg_output_debug->test_mode = 1;
+        } else {
+            cnt->ffmpeg_output_debug->test_mode = 0;
+        }
 
         retcd = ffmpeg_open(cnt->ffmpeg_output_debug);
         if (retcd < 0){
@@ -764,7 +776,8 @@ static void event_ffmpeg_timelapse(struct context *cnt,
         cnt->ffmpeg_timelapse->start_time.tv_sec = currenttime_tv->tv_sec;
         cnt->ffmpeg_timelapse->start_time.tv_usec = currenttime_tv->tv_usec;
         cnt->ffmpeg_timelapse->last_pts = 0;
-
+        cnt->ffmpeg_timelapse->test_mode = 0;
+        cnt->ffmpeg_timelapse->gop_cnt = 0;
 
         if ((strcmp(cnt->conf.ffmpeg_video_codec,"mpg") == 0) ||
             (strcmp(cnt->conf.ffmpeg_video_codec,"swf") == 0) ){
@@ -798,8 +811,7 @@ static void event_ffmpeg_timelapse(struct context *cnt,
     }
 
     if (ffmpeg_put_image(cnt->ffmpeg_timelapse, img, currenttime_tv) == -1) {
-        cnt->finish = 1;
-        cnt->restart = 0;
+        MOTION_LOG(ERR, TYPE_EVENTS, NO_ERRNO, "%s: Error encoding image");
     }
 
 }
@@ -811,15 +823,13 @@ static void event_ffmpeg_put(struct context *cnt,
 {
     if (cnt->ffmpeg_output) {
         if (ffmpeg_put_image(cnt->ffmpeg_output, img, currenttime_tv) == -1) {
-            cnt->finish = 1;
-            cnt->restart = 0;
+            MOTION_LOG(ERR, TYPE_EVENTS, NO_ERRNO, "%s: Error encoding image");
         }
     }
 
     if (cnt->ffmpeg_output_debug) {
         if (ffmpeg_put_image(cnt->ffmpeg_output_debug, cnt->imgs.out, currenttime_tv) == -1) {
-            cnt->finish = 1;
-            cnt->restart = 0;
+            MOTION_LOG(ERR, TYPE_EVENTS, NO_ERRNO, "%s: Error encoding image");
         }
     }
 }

--- a/event.c
+++ b/event.c
@@ -587,21 +587,22 @@ static void event_new_video(struct context *cnt,
     MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s Source FPS %d", cnt->movie_fps);
 
     if (cnt->movie_fps < 2) cnt->movie_fps = 2;
+
 }
 
 
 static void event_ffmpeg_newfile(struct context *cnt,
             motion_event type ATTRIBUTE_UNUSED,
-            unsigned char *img, char *dummy1 ATTRIBUTE_UNUSED,
-            void *dummy2 ATTRIBUTE_UNUSED, struct timeval *currenttime_tv)
+            unsigned char *dummy0 ATTRIBUTE_UNUSED,
+            char *dummy1 ATTRIBUTE_UNUSED,
+            void *dummy2 ATTRIBUTE_UNUSED,
+            struct timeval *currenttime_tv)
 {
-    int width = cnt->imgs.width;
-    int height = cnt->imgs.height;
-    unsigned char *convbuf, *y, *u, *v;
     char stamp[PATH_MAX];
     const char *moviepath;
     const char *codec;
     long codenbr;
+    int retcd;
 
     if (!cnt->conf.ffmpeg_output && !cnt->conf.ffmpeg_output_debug)
         return;
@@ -679,43 +680,50 @@ static void event_ffmpeg_newfile(struct context *cnt,
     }
     if (cnt->conf.ffmpeg_output) {
 
-        convbuf = NULL;
-        y = img;
-        u = img + width * height;
-        v = u + (width * height) / 4;
+        cnt->ffmpeg_output = mymalloc(sizeof(struct ffmpeg));
+        cnt->ffmpeg_output->width  = cnt->imgs.width;
+        cnt->ffmpeg_output->height = cnt->imgs.height;
+        cnt->ffmpeg_output->tlapse = TIMELAPSE_NONE;
+        cnt->ffmpeg_output->fps = cnt->movie_fps;
+        cnt->ffmpeg_output->bps = cnt->conf.ffmpeg_bps;
+        cnt->ffmpeg_output->filename = cnt->newfilename;
+        cnt->ffmpeg_output->vbr = cnt->conf.ffmpeg_vbr;
+        cnt->ffmpeg_output->start_time.tv_sec = currenttime_tv->tv_sec;
+        cnt->ffmpeg_output->start_time.tv_usec = currenttime_tv->tv_usec;
+        cnt->ffmpeg_output->last_pts = 0;
+        cnt->ffmpeg_output->codec_name = codec;
 
-        if ((cnt->ffmpeg_output =
-            ffmpeg_open(codec, cnt->newfilename, y, u, v,
-                         cnt->imgs.width, cnt->imgs.height, cnt->movie_fps, cnt->conf.ffmpeg_bps,
-                         cnt->conf.ffmpeg_vbr,TIMELAPSE_NONE, currenttime_tv)) == NULL) {
-            MOTION_LOG(ERR, TYPE_EVENTS, SHOW_ERRNO, "%s: ffopen_open error creating (new) file [%s]",
-                       cnt->newfilename);
-            cnt->finish = 1;
+        retcd = ffmpeg_open(cnt->ffmpeg_output);
+        if (retcd < 0){
+            MOTION_LOG(ERR, TYPE_EVENTS, NO_ERRNO, "%s: ffopen_open error creating (new) file [%s]",cnt->newfilename);
+            free(cnt->ffmpeg_output);
+            cnt->ffmpeg_output=NULL;
             return;
         }
-
-        ((struct ffmpeg *)cnt->ffmpeg_output)->udata = convbuf;
         event(cnt, EVENT_FILECREATE, NULL, cnt->newfilename, (void *)FTYPE_MPEG, NULL);
     }
 
     if (cnt->conf.ffmpeg_output_debug) {
-        y = cnt->imgs.out;
-        u = cnt->imgs.out + width *height;
-        v = u + (width * height) / 4;
-        convbuf = NULL;
+        cnt->ffmpeg_output_debug = mymalloc(sizeof(struct ffmpeg));
+        cnt->ffmpeg_output_debug->width  = cnt->imgs.width;
+        cnt->ffmpeg_output_debug->height = cnt->imgs.height;
+        cnt->ffmpeg_output_debug->tlapse = TIMELAPSE_NONE;
+        cnt->ffmpeg_output_debug->fps = cnt->movie_fps;
+        cnt->ffmpeg_output_debug->bps = cnt->conf.ffmpeg_bps;
+        cnt->ffmpeg_output_debug->filename = cnt->newfilename;
+        cnt->ffmpeg_output_debug->vbr = cnt->conf.ffmpeg_vbr;
+        cnt->ffmpeg_output_debug->start_time.tv_sec = currenttime_tv->tv_sec;
+        cnt->ffmpeg_output_debug->start_time.tv_usec = currenttime_tv->tv_usec;
+        cnt->ffmpeg_output_debug->last_pts = 0;
+        cnt->ffmpeg_output_debug->codec_name = codec;
 
-        if ((cnt->ffmpeg_output_debug =
-            ffmpeg_open(codec, cnt->motionfilename, y, u, v,
-                        cnt->imgs.width, cnt->imgs.height, cnt->movie_fps, cnt->conf.ffmpeg_bps,
-                        cnt->conf.ffmpeg_vbr,TIMELAPSE_NONE,currenttime_tv)) == NULL) {
-            MOTION_LOG(ERR, TYPE_EVENTS, SHOW_ERRNO, "%s: ffopen_open error creating (motion) file [%s]",
-                       cnt->motionfilename);
-            cnt->finish = 1;
+        retcd = ffmpeg_open(cnt->ffmpeg_output_debug);
+        if (retcd < 0){
+            MOTION_LOG(ERR, TYPE_EVENTS, NO_ERRNO, "%s: ffopen_open error creating (motion) file [%s]", cnt->motionfilename);
+            free(cnt->ffmpeg_output_debug);
+            cnt->ffmpeg_output_debug = NULL;
             return;
         }
-
-        cnt->ffmpeg_output_debug->udata = convbuf;
-        event(cnt, EVENT_FILECREATE, NULL, cnt->motionfilename, (void *)FTYPE_MPEG_MOTION, NULL);
     }
 }
 
@@ -724,9 +732,7 @@ static void event_ffmpeg_timelapse(struct context *cnt,
             char *dummy1 ATTRIBUTE_UNUSED, void *dummy2 ATTRIBUTE_UNUSED,
             struct timeval *currenttime_tv)
 {
-    int width = cnt->imgs.width;
-    int height = cnt->imgs.height;
-    unsigned char *convbuf, *y, *u, *v;
+    int retcd;
 
     if (!cnt->ffmpeg_timelapse) {
         char tmp[PATH_MAX];
@@ -748,10 +754,16 @@ static void event_ffmpeg_timelapse(struct context *cnt,
         /* PATH_MAX - 4 to allow for .mpg to be appended without overflow */
         snprintf(cnt->timelapsefilename, PATH_MAX - 4, "%s/%s", cnt->conf.filepath, tmp);
 
-        convbuf = NULL;
-        y = img;
-        u = img + width * height;
-        v = u + (width * height) / 4;
+        cnt->ffmpeg_timelapse = mymalloc(sizeof(struct ffmpeg));
+        cnt->ffmpeg_timelapse->width  = cnt->imgs.width;
+        cnt->ffmpeg_timelapse->height = cnt->imgs.height;
+        cnt->ffmpeg_timelapse->fps = cnt->conf.frame_limit;
+        cnt->ffmpeg_timelapse->bps = cnt->conf.ffmpeg_bps;
+        cnt->ffmpeg_timelapse->filename = cnt->timelapsefilename;
+        cnt->ffmpeg_timelapse->vbr = cnt->conf.ffmpeg_vbr;
+        cnt->ffmpeg_timelapse->start_time.tv_sec = currenttime_tv->tv_sec;
+        cnt->ffmpeg_timelapse->start_time.tv_usec = currenttime_tv->tv_usec;
+        cnt->ffmpeg_timelapse->last_pts = 0;
 
 
         if ((strcmp(cnt->conf.ffmpeg_video_codec,"mpg") == 0) ||
@@ -763,35 +775,29 @@ static void event_ffmpeg_timelapse(struct context *cnt,
 
             MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s: Timelapse using mpg codec.");
             MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s: Events will be appended to file");
-            cnt->ffmpeg_timelapse =
-                ffmpeg_open(codec_mpg,cnt->timelapsefilename, y, u, v
-                        ,cnt->imgs.width, cnt->imgs.height, cnt->conf.frame_limit
-                        ,cnt->conf.ffmpeg_bps,cnt->conf.ffmpeg_vbr,TIMELAPSE_APPEND,currenttime_tv);
+
+            cnt->ffmpeg_timelapse->tlapse = TIMELAPSE_APPEND;
+            cnt->ffmpeg_timelapse->codec_name = codec_mpg;
+            retcd = ffmpeg_open(cnt->ffmpeg_timelapse);
         } else {
             MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s: Timelapse using mpeg4 codec.");
             MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "%s: Events will be trigger new files");
-            cnt->ffmpeg_timelapse =
-                ffmpeg_open(codec_mpeg ,cnt->timelapsefilename, y, u, v
-                        ,cnt->imgs.width, cnt->imgs.height, cnt->conf.frame_limit
-                        ,cnt->conf.ffmpeg_bps,cnt->conf.ffmpeg_vbr,TIMELAPSE_NEW,currenttime_tv);
+
+            cnt->ffmpeg_timelapse->tlapse = TIMELAPSE_NEW;
+            cnt->ffmpeg_timelapse->codec_name = codec_mpeg;
+            retcd = ffmpeg_open(cnt->ffmpeg_timelapse);
         }
 
-        if (cnt->ffmpeg_timelapse == NULL){
-            MOTION_LOG(ERR, TYPE_EVENTS, SHOW_ERRNO, "%s: ffopen_open error creating "
-                       "(timelapse) file [%s]", cnt->timelapsefilename);
-            cnt->finish = 1;
+        if (retcd < 0){
+            MOTION_LOG(ERR, TYPE_EVENTS, NO_ERRNO, "%s: ffopen_open error creating (timelapse) file [%s]", cnt->timelapsefilename);
+            free(cnt->ffmpeg_timelapse);
+            cnt->ffmpeg_timelapse = NULL;
             return;
         }
-
-        cnt->ffmpeg_timelapse->udata = convbuf;
         event(cnt, EVENT_FILECREATE, NULL, cnt->timelapsefilename, (void *)FTYPE_MPEG_TIMELAPSE, NULL);
     }
 
-    y = img;
-    u = img + width * height;
-    v = u + (width * height) / 4;
-
-    if (ffmpeg_put_other_image(cnt->ffmpeg_timelapse, y, u, v,currenttime_tv) == -1) {
+    if (ffmpeg_put_image(cnt->ffmpeg_timelapse, img, currenttime_tv) == -1) {
         cnt->finish = 1;
         cnt->restart = 0;
     }
@@ -804,22 +810,14 @@ static void event_ffmpeg_put(struct context *cnt,
             void *dummy2 ATTRIBUTE_UNUSED, struct timeval *currenttime_tv)
 {
     if (cnt->ffmpeg_output) {
-        int width = cnt->imgs.width;
-        int height = cnt->imgs.height;
-        unsigned char *y, *u, *v;
-
-        y = img;
-        u = y + (width * height);
-        v = u + (width * height) / 4;
-
-        if (ffmpeg_put_other_image(cnt->ffmpeg_output, y, u, v, currenttime_tv) == -1) {
+        if (ffmpeg_put_image(cnt->ffmpeg_output, img, currenttime_tv) == -1) {
             cnt->finish = 1;
             cnt->restart = 0;
         }
     }
 
     if (cnt->ffmpeg_output_debug) {
-        if (ffmpeg_put_image(cnt->ffmpeg_output_debug, currenttime_tv) == -1) {
+        if (ffmpeg_put_image(cnt->ffmpeg_output_debug, cnt->imgs.out, currenttime_tv) == -1) {
             cnt->finish = 1;
             cnt->restart = 0;
         }
@@ -834,22 +832,19 @@ static void event_ffmpeg_closefile(struct context *cnt,
 {
 
     if (cnt->ffmpeg_output) {
-        free(cnt->ffmpeg_output->udata);
-
         ffmpeg_close(cnt->ffmpeg_output);
+        free(cnt->ffmpeg_output);
         cnt->ffmpeg_output = NULL;
-
         event(cnt, EVENT_FILECLOSE, NULL, cnt->newfilename, (void *)FTYPE_MPEG, NULL);
     }
 
     if (cnt->ffmpeg_output_debug) {
-        free(cnt->ffmpeg_output_debug->udata);
-
         ffmpeg_close(cnt->ffmpeg_output_debug);
+        free(cnt->ffmpeg_output_debug);
         cnt->ffmpeg_output_debug = NULL;
-
         event(cnt, EVENT_FILECLOSE, NULL, cnt->motionfilename, (void *)FTYPE_MPEG_MOTION, NULL);
     }
+
 }
 
 static void event_ffmpeg_timelapseend(struct context *cnt,
@@ -859,11 +854,9 @@ static void event_ffmpeg_timelapseend(struct context *cnt,
             struct timeval *tv1 ATTRIBUTE_UNUSED)
 {
     if (cnt->ffmpeg_timelapse) {
-        free(cnt->ffmpeg_timelapse->udata);
-
         ffmpeg_close(cnt->ffmpeg_timelapse);
+        free(cnt->ffmpeg_timelapse);
         cnt->ffmpeg_timelapse = NULL;
-
         event(cnt, EVENT_FILECLOSE, NULL, cnt->timelapsefilename, (void *)FTYPE_MPEG_TIMELAPSE, NULL);
     }
 }

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -892,7 +892,7 @@ int ffmpeg_put_image(struct ffmpeg *ffmpeg, unsigned char *image, const struct t
             ffmpeg->picture->key_frame = 1;
             ffmpeg->gop_cnt = 0;
         } else {
-            ffmpeg->picture->pict_type = AV_PICTURE_TYPE_NONE;
+            ffmpeg->picture->pict_type = AV_PICTURE_TYPE_P;
             ffmpeg->picture->key_frame = 0;
         }
 

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -28,8 +28,6 @@
 
 #ifdef HAVE_FFMPEG
 
-#define AVSTREAM_CODEC_PTR(avs_ptr) (avs_ptr->codec)
-
 /****************************************************************************
  *  The section below is the "my" section of functions.
  *  These are designed to be extremely simple version specific
@@ -70,6 +68,7 @@
 #define MY_CODEC_ID_HEVC      CODEC_ID_H264
 
 #endif
+
 /*********************************************/
 AVFrame *my_frame_alloc(void){
     AVFrame *pic;
@@ -145,19 +144,19 @@ void my_packet_unref(AVPacket pkt){
 #endif
 }
 /*********************************************/
+void my_avcodec_close(AVCodecContext *codec_context){
+#if (LIBAVFORMAT_VERSION_MAJOR >= 58) || ((LIBAVFORMAT_VERSION_MAJOR == 57) && (LIBAVFORMAT_VERSION_MINOR >= 41))
+    avcodec_free_context(&codec_context);
+#else
+    avcodec_close(codec_context);
+#endif
+}
+/*********************************************/
 
 /****************************************************************************
  ****************************************************************************
  ****************************************************************************/
-/**
- * timelapse_exists
- *      Determines whether the timelapse file exists
- *
- * Returns
- *      0:  File doesn't exist
- *      1:  File exists
- */
-static int timelapse_exists(const char *fname){
+static int ffmpeg_timelapse_exists(const char *fname){
     FILE *file;
     file = fopen(fname, "r");
     if (file)
@@ -168,7 +167,7 @@ static int timelapse_exists(const char *fname){
     return 0;
 }
 
-static int timelapse_append(struct ffmpeg *ffmpeg, AVPacket pkt){
+static int ffmpeg_timelapse_append(struct ffmpeg *ffmpeg, AVPacket pkt){
     FILE *file;
 
     file = fopen(ffmpeg->oc->filename, "a");
@@ -181,9 +180,7 @@ static int timelapse_append(struct ffmpeg *ffmpeg, AVPacket pkt){
     return 0;
 }
 
-/** locking callback for use with ffmpeg's av_lockmgr_register */
-static int ffmpeg_lockmgr_cb(void **arg, enum AVLockOp op)
-{
+static int ffmpeg_lockmgr_cb(void **arg, enum AVLockOp op){
     pthread_mutex_t *mutex = *arg;
     int err;
 
@@ -218,281 +215,497 @@ static int ffmpeg_lockmgr_cb(void **arg, enum AVLockOp op)
     return 1;
 }
 
-/**
- * get_oformat
- *      Obtains the output format used for the specified codec. For mpeg4 codecs,
- *      the format is avi; for mpeg1 codec, the format is mpeg. The filename has
- *      to be passed, because it gets the appropriate extension appended onto it.
- *
- *  Returns
- *      AVOutputFormat pointer or NULL if any error happens.
- */
-static AVOutputFormat *get_oformat(const char *codec, char *filename){
-    const char *ext;
-    AVOutputFormat *of = NULL;
-    /*
-     * Here, we use guess_format to automatically setup the codec information.
-     * If we are using msmpeg4, manually set that codec here.
-     * We also dynamically add the file extension to the filename here.
-     */
-    if (strcmp(codec, "tlapse") == 0) {
-        ext = ".mpg";
-        of = av_guess_format ("mpeg2video", NULL, NULL);
-        if (of) of->video_codec = MY_CODEC_ID_MPEG2VIDEO;
-    } else if (strcmp(codec, "mpeg4") == 0) {
-        ext = ".avi";
-        of = av_guess_format("avi", NULL, NULL);
-    } else if (strcmp(codec, "msmpeg4") == 0) {
-        ext = ".avi";
-        of = av_guess_format("avi", NULL, NULL);
-        /* Manually override the codec id. */
-        if (of) of->video_codec = MY_CODEC_ID_MSMPEG4V2;
-    } else if (strcmp(codec, "swf") == 0) {
-        ext = ".swf";
-        of = av_guess_format("swf", NULL, NULL);
-    } else if (strcmp(codec, "flv") == 0) {
-        ext = ".flv";
-        of = av_guess_format("flv", NULL, NULL);
-        of->video_codec = MY_CODEC_ID_FLV1;
-    } else if (strcmp(codec, "ffv1") == 0) {
-        ext = ".avi";
-        of = av_guess_format("avi", NULL, NULL);
-        if (of) of->video_codec = MY_CODEC_ID_FFV1;
-    } else if (strcmp(codec, "mov") == 0) {
-        ext = ".mov";
-        of = av_guess_format("mov", NULL, NULL);
-    } else if (strcmp (codec, "mp4") == 0){
-      ext = ".mp4";
-      of = av_guess_format ("mp4", NULL, NULL);
-      of->video_codec = MY_CODEC_ID_H264;
-    } else if (strcmp (codec, "mkv") == 0){
-      ext = ".mkv";
-      of = av_guess_format ("matroska", NULL, NULL);
-      of->video_codec = MY_CODEC_ID_H264;
-    } else if (strcmp (codec, "hevc") == 0){
-      ext = ".mp4";
-      of = av_guess_format ("mp4", NULL, NULL);
-      of->video_codec = MY_CODEC_ID_HEVC;
-    } else {
-        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: ffmpeg_video_codec option value"
-                   " %s is not supported", codec);
-        return NULL;
-    }
+static void ffmpeg_free_context(struct ffmpeg *ffmpeg){
 
-    if (!of) {
-        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Could not guess format for %s", codec);
-        return NULL;
-    }
+        if (ffmpeg->picture != NULL){
+            my_frame_free(ffmpeg->picture);
+            ffmpeg->picture = NULL;
+        }
 
-    /* The 4 allows for ".avi" or ".mpg" to be appended. */
-    strncat(filename, ext, 4);
+        if (ffmpeg->ctx_codec != NULL){
+            my_avcodec_close(ffmpeg->ctx_codec);
+            ffmpeg->ctx_codec = NULL;
+        }
 
-    return of;
+        if (ffmpeg->oc != NULL){
+            avformat_free_context(ffmpeg->oc);
+            ffmpeg->oc = NULL;
+        }
+
 }
 
-/**
- * ffmpeg_cleanups
- *      Clean up ffmpeg struct if something was wrong.
- *
- * Returns
- *      Function returns nothing.
- */
-void ffmpeg_cleanups(struct ffmpeg *ffmpeg){
+static int ffmpeg_get_oformat(struct ffmpeg *ffmpeg){
 
-    /* Close each codec */
-    if (ffmpeg->video_st) {
-        avcodec_close(AVSTREAM_CODEC_PTR(ffmpeg->video_st));
+    /* Only the newer codec and containers can handle the really fast FPS */
+    if (((strcmp(ffmpeg->codec_name, "msmpeg4") == 0) ||
+        (strcmp(ffmpeg->codec_name, "mpeg4") == 0) ||
+        (strcmp(ffmpeg->codec_name, "swf") == 0) ) && (ffmpeg->fps >50)){
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s The frame rate specified is too high for the ffmpeg movie type specified. Choose a different ffmpeg container or lower framerate. ");
+        ffmpeg_free_context(ffmpeg);
+        return -1;
     }
-    free(ffmpeg->video_outbuf);
-    av_freep(&ffmpeg->picture);
-    avformat_free_context(ffmpeg->oc);
-    free(ffmpeg);
+
+    if (ffmpeg->tlapse == TIMELAPSE_APPEND){
+        ffmpeg->oc->oformat = av_guess_format ("mpeg2video", NULL, NULL);
+        if (ffmpeg->oc->oformat) ffmpeg->oc->oformat->video_codec = MY_CODEC_ID_MPEG2VIDEO;
+        strncat(ffmpeg->filename, ".mpg", 4);
+        if (!ffmpeg->oc->oformat) {
+            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: ffmpeg_video_codec option value %s is not supported", ffmpeg->codec_name);
+            ffmpeg_free_context(ffmpeg);
+            return -1;
+        }
+        return 0;
+    }
+
+    if (strcmp(ffmpeg->codec_name, "mpeg4") == 0) {
+        ffmpeg->oc->oformat = av_guess_format("avi", NULL, NULL);
+        strncat(ffmpeg->filename, ".avi", 4);
+    }
+
+    if (strcmp(ffmpeg->codec_name, "msmpeg4") == 0) {
+        ffmpeg->oc->oformat = av_guess_format("avi", NULL, NULL);
+        strncat(ffmpeg->filename, ".avi", 4);
+        if (ffmpeg->oc->oformat) ffmpeg->oc->oformat->video_codec = MY_CODEC_ID_MSMPEG4V2;
+    }
+
+    if (strcmp(ffmpeg->codec_name, "swf") == 0) {
+        ffmpeg->oc->oformat = av_guess_format("swf", NULL, NULL);
+        strncat(ffmpeg->filename, ".swf", 4);
+    }
+
+    if (strcmp(ffmpeg->codec_name, "flv") == 0) {
+        ffmpeg->oc->oformat = av_guess_format("flv", NULL, NULL);
+        strncat(ffmpeg->filename, ".flv", 4);
+        if (ffmpeg->oc->oformat) ffmpeg->oc->oformat->video_codec = MY_CODEC_ID_FLV1;
+    }
+
+    if (strcmp(ffmpeg->codec_name, "ffv1") == 0) {
+        ffmpeg->oc->oformat = av_guess_format("avi", NULL, NULL);
+        strncat(ffmpeg->filename, ".avi", 4);
+        if (ffmpeg->oc->oformat) ffmpeg->oc->oformat->video_codec = MY_CODEC_ID_FFV1;
+    }
+
+    if (strcmp(ffmpeg->codec_name, "mov") == 0) {
+        ffmpeg->oc->oformat = av_guess_format("mov", NULL, NULL);
+        strncat(ffmpeg->filename, ".mov", 4);
+    }
+
+    if (strcmp(ffmpeg->codec_name, "mp4") == 0) {
+        ffmpeg->oc->oformat = av_guess_format("mp4", NULL, NULL);
+        strncat(ffmpeg->filename, ".mp4", 4);
+        if (ffmpeg->oc->oformat) ffmpeg->oc->oformat->video_codec = MY_CODEC_ID_H264;
+    }
+
+    if (strcmp(ffmpeg->codec_name, "mkv") == 0) {
+        ffmpeg->oc->oformat = av_guess_format("matroska", NULL, NULL);
+        strncat(ffmpeg->filename, ".mkv", 4);
+        if (ffmpeg->oc->oformat) ffmpeg->oc->oformat->video_codec = MY_CODEC_ID_H264;
+    }
+
+    if (strcmp(ffmpeg->codec_name, "hevc") == 0) {
+        ffmpeg->oc->oformat = av_guess_format("mp4", NULL, NULL);
+        strncat(ffmpeg->filename, ".mp4", 4);
+        if (ffmpeg->oc->oformat) ffmpeg->oc->oformat->video_codec = MY_CODEC_ID_HEVC;
+    }
+
+    //Check for valid results
+    if (!ffmpeg->oc->oformat) {
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: codec option value %s is not supported", ffmpeg->codec_name);
+        ffmpeg_free_context(ffmpeg);
+        return -1;
+    }
+
+    if (ffmpeg->oc->oformat->video_codec == MY_CODEC_ID_NONE) {
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Could not get the codec");
+        ffmpeg_free_context(ffmpeg);
+        return -1;
+    }
+
+    return 0;
 }
 
-/**
- * ffmpeg_put_frame
- *      Encodes and writes a video frame using the av_write_frame API. This is
- *      a helper function for ffmpeg_put_image and ffmpeg_put_other_image.
- *
- *  Returns
- *      Number of bytes written or -1 if any error happens.
- */
-int ffmpeg_put_frame(struct ffmpeg *ffmpeg, AVFrame *pic, const struct timeval *tv1){
-/**
- * Since the logic,return values and conditions changed so
- * dramatically between versions, the encoding of the frame
- * is 100% blocked based upon Libav/FFMpeg version
- */
-#if (LIBAVFORMAT_VERSION_MAJOR >= 55) || ((LIBAVFORMAT_VERSION_MAJOR == 54) && (LIBAVFORMAT_VERSION_MINOR > 6))
-    int retcd;
-    int got_packet_ptr;
-    AVPacket pkt;
+static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
+
+#if (LIBAVFORMAT_VERSION_MAJOR >= 58) || ((LIBAVFORMAT_VERSION_MAJOR == 57) && (LIBAVFORMAT_VERSION_MINOR >= 41))
+    //ffmpeg version 3.1 and after
+    int retcd = 0;
     char errstr[128];
-    int64_t pts_interval;
 
-
-    av_init_packet(&pkt); /* Init static structure. */
-    if (ffmpeg->oc->oformat->flags & AVFMT_RAWPICTURE) {
-        pkt.stream_index = ffmpeg->video_st->index;
-        pkt.flags |= AV_PKT_FLAG_KEY;
-        pkt.data = (uint8_t *)pic;
-        pkt.size = sizeof(AVPicture);
-    } else {
-        pkt.data = NULL;
-        pkt.size = 0;
-        retcd = avcodec_encode_video2(AVSTREAM_CODEC_PTR(ffmpeg->video_st),
-                                        &pkt, pic, &got_packet_ptr);
-        if (retcd < 0 ){
-            av_strerror(retcd, errstr, sizeof(errstr));
-            MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: Error encoding video:%s",errstr);
-            //Packet is freed upon failure of encoding
-            return -1;
-        }
-        if (got_packet_ptr == 0){
-            //Buffered packet.  Throw special return code
-            my_packet_unref(pkt);
-            return -2;
-        }
-    }
-    if (ffmpeg->tlapse == TIMELAPSE_APPEND) {
-        retcd = timelapse_append(ffmpeg, pkt);
-    } else if (ffmpeg->tlapse == TIMELAPSE_NEW) {
-        retcd = av_write_frame(ffmpeg->oc, &pkt);
-    } else {
-        pts_interval = ((1000000L * (tv1->tv_sec - ffmpeg->start_time.tv_sec)) + tv1->tv_usec - ffmpeg->start_time.tv_usec) + 10000;
-
-//        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: interval:%d img_sec:%d img_usec:%d strt_sec:%d strt_usec:%d "
-//                   ,pts_interval,tv1->tv_sec,tv1->tv_usec,ffmpeg->start_time.tv_sec,ffmpeg->start_time.tv_usec);
-
-        if (pts_interval < 0){
-            /* This can occur when we have pre-capture frames.  Reset start time of video. */
-            ffmpeg->start_time.tv_sec = tv1->tv_sec ;
-            ffmpeg->start_time.tv_usec = tv1->tv_usec ;
-            pts_interval = 1;
-        }
-        pkt.pts = av_rescale_q(pts_interval,(AVRational){1, 1000000L},ffmpeg->video_st->time_base);
-        if (pkt.pts <= ffmpeg->last_pts) pkt.pts = ffmpeg->last_pts + 1;
-        pkt.dts = pkt.pts;
-        retcd = av_write_frame(ffmpeg->oc, &pkt);
-        ffmpeg->last_pts = pkt.pts;
-    }
-    //        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: pts:%d dts:%d stream:%d interval %d",pkt.pts,pkt.dts,ffmpeg->video_st->time_base.den,pts_interval);
-    my_packet_unref(pkt);
-
-    if (retcd != 0) {
-        MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: Error while writing video frame");
-        ffmpeg_cleanups(ffmpeg);
+    retcd = avcodec_send_frame(ffmpeg->ctx_codec, ffmpeg->picture);
+    if (retcd < 0 ){
+        av_strerror(retcd, errstr, sizeof(errstr));
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Error encoding video:%s",errstr);
         return -1;
     }
-
-    return retcd;
-
-#else  //  Old versions of Libav/FFmpeg
-    int retcd;
-    AVPacket pkt;
-
-    av_init_packet(&pkt); /* Init static structure. */
-    pkt.stream_index = ffmpeg->video_st->index;
-    if (ffmpeg->oc->oformat->flags & AVFMT_RAWPICTURE) {
-        // Raw video case.
-        pkt.size = sizeof(AVPicture);
-        pkt.data = (uint8_t *)pic;
-        pkt.flags |= AV_PKT_FLAG_KEY;
-    } else {
-        retcd = avcodec_encode_video(AVSTREAM_CODEC_PTR(ffmpeg->video_st),
-                                        ffmpeg->video_outbuf,
-                                        ffmpeg->video_outbuf_size, pic);
-        if (retcd < 0 ){
-            MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: Error encoding video");
-            my_packet_unref(pkt);
-            return -1;
-        }
-        if (retcd == 0 ){
-            // No bytes encoded => buffered=>special handling
-            my_packet_unref(pkt);
-            return -2;
-        }
-
-        pkt.size = retcd;
-        pkt.data = ffmpeg->video_outbuf;
-        pkt.pts = AVSTREAM_CODEC_PTR(ffmpeg->video_st)->coded_frame->pts;
-        if (AVSTREAM_CODEC_PTR(ffmpeg->video_st)->coded_frame->key_frame)
-            pkt.flags |= AV_PKT_FLAG_KEY;
-    }
-    if (ffmpeg->tlapse == TIMELAPSE_APPEND) {
-        retcd = timelapse_append(ffmpeg, pkt);
-    } else {
-        retcd = av_write_frame(ffmpeg->oc, &pkt);
-    }
-    my_packet_unref(pkt);
-
-    if (retcd != 0) {
-        MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: Error while writing video frame");
-        ffmpeg_cleanups(ffmpeg);
+    retcd = avcodec_receive_packet(ffmpeg->ctx_codec, &ffmpeg->pkt);
+    if (retcd < 0 ){
+        av_strerror(retcd, errstr, sizeof(errstr));
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Error encoding video:%s",errstr);
+        //Packet is freed upon failure of encoding
         return -1;
     }
+    if (retcd == AVERROR(EAGAIN)){
+        //Buffered packet.  Throw special return code
+        my_packet_unref(ffmpeg->pkt);
+        return -2;
+    }
+    return 0;
 
-    return retcd;
+#elif (LIBAVFORMAT_VERSION_MAJOR >= 55) || ((LIBAVFORMAT_VERSION_MAJOR == 54) && (LIBAVFORMAT_VERSION_MINOR > 6))
+
+    int retcd = 0;
+    char errstr[128];
+    int got_packet_ptr;
+
+    retcd = avcodec_encode_video2(ffmpeg->ctx_codec, &ffmpeg->pkt, ffmpeg->picture, &got_packet_ptr);
+    if (retcd < 0 ){
+        av_strerror(retcd, errstr, sizeof(errstr));
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Error encoding video:%s",errstr);
+        //Packet is freed upon failure of encoding
+        return -1;
+    }
+    if (got_packet_ptr == 0){
+        //Buffered packet.  Throw special return code
+        my_packet_unref(ffmpeg->pkt);
+        return -2;
+    }
+    return 0;
+
+#else
+
+    int retcd = 0;
+    uint8_t *video_outbuf;
+    int video_outbuf_size;
+
+    video_outbuf_size = (ffmpeg->ctx_codec->width +16) * (ffmpeg->ctx_codec->height +16) * 1;
+    video_outbuf = mymalloc(video_outbuf_size);
+
+    retcd = avcodec_encode_video(ffmpeg->video_st->codec, video_outbuf, video_outbuf_size, ffmpeg->picture);
+    if (retcd < 0 ){
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Error encoding video");
+        my_packet_unref(ffmpeg->pkt);
+        return -1;
+    }
+    if (retcd == 0 ){
+        // No bytes encoded => buffered=>special handling
+        my_packet_unref(ffmpeg->pkt);
+        return -2;
+    }
+
+    ffmpeg->pkt.size = retcd;
+    ffmpeg->pkt.data = video_outbuf;
+
+    free(video_outbuf);
+
+    return 0;
 
 #endif
+
 }
 
-/**
- * ffmpeg_prepare_frame
- *      Allocates and prepares a picture frame by setting up the U, Y and V pointers in
- *      the frame according to the passed pointers.
- *
- * Returns
- *      NULL If the allocation fails.
- *
- *      The returned AVFrame pointer must be freed after use.
- */
-AVFrame *ffmpeg_prepare_frame(struct ffmpeg *ffmpeg, unsigned char *y,
-                              unsigned char *u, unsigned char *v)
-{
-    AVFrame *picture;
+static int ffmpeg_set_pts(struct ffmpeg *ffmpeg, const struct timeval *tv1){
 
-    picture = my_frame_alloc();
+    int64_t pts_interval;
 
-    if (!picture) {
-        MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: Could not alloc frame");
-        return NULL;
+    pts_interval = ((1000000L * (tv1->tv_sec - ffmpeg->start_time.tv_sec)) + tv1->tv_usec - ffmpeg->start_time.tv_usec);
+    if (pts_interval < 0){
+        /* This can occur when we have pre-capture frames.  Reset start time of video. */
+        ffmpeg->start_time.tv_sec = tv1->tv_sec ;
+        ffmpeg->start_time.tv_usec = tv1->tv_usec ;
+        pts_interval = 1;
+    }
+    ffmpeg->pkt.pts = av_rescale_q(pts_interval,(AVRational){1, 1000000L},ffmpeg->video_st->time_base);
+
+    //MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Interval %d PTS %d timebase %d-%d",pts_interval,ffmpeg->pkt.pts,ffmpeg->video_st->time_base.num,ffmpeg->video_st->time_base.den);
+
+    if (ffmpeg->pkt.pts <= ffmpeg->last_pts){
+        //We have a problem with our motion loop timing and sending frames.  Increment by just 1 to at least keep frame in movie.
+        ffmpeg->pkt.pts = ffmpeg->last_pts + 1;
+    }
+    ffmpeg->pkt.dts = ffmpeg->pkt.pts;
+
+    return 0;
+}
+
+static int ffmpeg_set_quality(struct ffmpeg *ffmpeg){
+
+    char crf[4];
+
+    ffmpeg->opts = 0;
+    if (ffmpeg->vbr > 100) ffmpeg->vbr = 100;
+    if (ffmpeg->ctx_codec->codec_id == MY_CODEC_ID_H264 ||
+        ffmpeg->ctx_codec->codec_id == MY_CODEC_ID_HEVC){
+        if (ffmpeg->vbr > 0) {
+            ffmpeg->vbr = (int)(( (100-ffmpeg->vbr) * 51)/100);
+        } else {
+            ffmpeg->vbr = 28;
+        }
+       snprintf(crf, 4, "%d",ffmpeg->vbr);
+       av_dict_set(&ffmpeg->opts, "preset", "ultrafast", 0);
+       av_dict_set(&ffmpeg->opts, "tune", "zerolatency", 0);
+       av_dict_set(&ffmpeg->opts, "crf", crf, 0);
+    } else {
+        /* The selection of 8000 in the else is a subjective number based upon viewing output files */
+        if (ffmpeg->vbr > 0){
+            ffmpeg->vbr =(int)(((100-ffmpeg->vbr)*(100-ffmpeg->vbr)*(100-ffmpeg->vbr) * 8000) / 1000000) + 1;
+            ffmpeg->ctx_codec->flags |= CODEC_FLAG_QSCALE;
+            ffmpeg->ctx_codec->global_quality=ffmpeg->vbr;
+        }
+    }
+    MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s vbr/crf for codec: %d", ffmpeg->vbr);
+
+    return 0;
+}
+
+static int ffmpeg_set_codec(struct ffmpeg *ffmpeg){
+
+    int retcd;
+    char errstr[128];
+    int chkrate;
+
+    ffmpeg->codec = avcodec_find_encoder(ffmpeg->oc->oformat->video_codec);
+    if (!ffmpeg->codec) {
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Codec %s not found", ffmpeg->codec_name);
+        ffmpeg_free_context(ffmpeg);
+        return -1;
+    }
+
+#if (LIBAVFORMAT_VERSION_MAJOR >= 58) || ((LIBAVFORMAT_VERSION_MAJOR == 57) && (LIBAVFORMAT_VERSION_MINOR >= 41))
+    //If we provide the codec to this, it results in a memory leak.  ffmpeg ticket: 5714
+    ffmpeg->video_st = avformat_new_stream(ffmpeg->oc, NULL);
+    if (!ffmpeg->video_st) {
+        MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: Could not alloc stream");
+        ffmpeg_free_context(ffmpeg);
+        return -1;
+    }
+    ffmpeg->ctx_codec = avcodec_alloc_context3(ffmpeg->codec);
+    if (ffmpeg->ctx_codec == NULL) {
+        MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: Failed to allocate decoder!");
+        ffmpeg_free_context(ffmpeg);
+        return -1;
+    }
+#else
+    ffmpeg->video_st = avformat_new_stream(ffmpeg->oc, ffmpeg->codec);
+    if (!ffmpeg->video_st) {
+        MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: Could not alloc stream");
+        ffmpeg_free_context(ffmpeg);
+        return -1;
+    }
+    ffmpeg->ctx_codec = ffmpeg->video_st->codec;
+#endif
+
+    ffmpeg->ctx_codec->codec_id      = ffmpeg->oc->oformat->video_codec;
+    ffmpeg->ctx_codec->codec_type    = AVMEDIA_TYPE_VIDEO;
+    ffmpeg->ctx_codec->bit_rate      = ffmpeg->bps;
+    ffmpeg->ctx_codec->width         = ffmpeg->width;
+    ffmpeg->ctx_codec->height        = ffmpeg->height;
+    ffmpeg->ctx_codec->time_base.num = 1;
+    ffmpeg->ctx_codec->time_base.den = ffmpeg->fps;
+    ffmpeg->ctx_codec->gop_size      = 12;
+    ffmpeg->ctx_codec->pix_fmt       = MY_PIX_FMT_YUV420P;
+    ffmpeg->ctx_codec->max_b_frames  = 0;
+    if (strcmp(ffmpeg->codec_name, "ffv1") == 0){
+      ffmpeg->ctx_codec->strict_std_compliance = -2;
+      ffmpeg->ctx_codec->level = 3;
+    }
+    ffmpeg->ctx_codec->flags |= CODEC_FLAG_GLOBAL_HEADER;
+
+    retcd = ffmpeg_set_quality(ffmpeg);
+    if (retcd < 0){
+        MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: Unable to set quality");
+        return -1;
+    }
+
+    retcd = avcodec_open2(ffmpeg->ctx_codec, ffmpeg->codec, &ffmpeg->opts);
+    if (retcd < 0) {
+        if (ffmpeg->codec->supported_framerates) {
+            const AVRational *fps = ffmpeg->codec->supported_framerates;
+            while (fps->num) {
+                MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s Reported FPS Supported %d/%d", fps->num, fps->den);
+                fps++;
+            }
+        }
+        chkrate = 1;
+        while ((chkrate < 36) && (retcd != 0)) {
+            ffmpeg->ctx_codec->time_base.den = chkrate;
+            retcd = avcodec_open2(ffmpeg->ctx_codec, ffmpeg->codec, &ffmpeg->opts);
+            chkrate++;
+        }
+        if (retcd < 0){
+            av_strerror(retcd, errstr, sizeof(errstr));
+            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Could not open codec %s",errstr);
+            av_dict_free(&ffmpeg->opts);
+            ffmpeg_free_context(ffmpeg);
+            return -1;
+        }
+
+    }
+    av_dict_free(&ffmpeg->opts);
+
+    return 0;
+}
+
+static int ffmpeg_set_stream(struct ffmpeg *ffmpeg){
+
+#if (LIBAVFORMAT_VERSION_MAJOR >= 58) || ((LIBAVFORMAT_VERSION_MAJOR == 57) && (LIBAVFORMAT_VERSION_MINOR >= 41))
+    int retcd;
+    char errstr[128];
+
+    retcd = avcodec_parameters_from_context(ffmpeg->video_st->codecpar,ffmpeg->ctx_codec);
+    if (retcd < 0) {
+        av_strerror(retcd, errstr, sizeof(errstr));
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Failed to copy decoder parameters!: %s", errstr);
+        ffmpeg_free_context(ffmpeg);
+        return -1;
+    }
+#endif
+
+    /*  We try to set the time base for the stream to a number different than the fps/rate.
+    **  A higher fps is better for setting the PTS to avoid dropping frames
+    **  For any of the timelapse options, we don't use the PTS.
+    */
+
+    if (ffmpeg->tlapse != TIMELAPSE_NONE){
+        ffmpeg->video_st->time_base = (AVRational){1, ffmpeg->fps};
+    } else {
+        ffmpeg->video_st->time_base = (AVRational){1, (ffmpeg->fps)};
+        if ((strcmp(ffmpeg->codec_name, "msmpeg4") == 0) ||
+            (strcmp(ffmpeg->codec_name, "mpeg4") == 0)) {
+            ffmpeg->video_st->time_base = (AVRational){1, (ffmpeg->fps*10)};
+        }
+        if ((strcmp(ffmpeg->codec_name, "swf") == 0) ||
+            (strcmp(ffmpeg->codec_name, "ffv1") == 0)) {
+            ffmpeg->video_st->time_base = (AVRational){1, (ffmpeg->fps)};
+        }
+        if ((strcmp(ffmpeg->codec_name, "mkv") == 0) ||
+            (strcmp(ffmpeg->codec_name, "mp4") == 0) ||
+            (strcmp(ffmpeg->codec_name, "flv") == 0) ||
+            (strcmp(ffmpeg->codec_name, "hevc") == 0) ||
+            (strcmp(ffmpeg->codec_name, "mov") == 0)) {
+            ffmpeg->video_st->time_base = (AVRational){1, 1000};
+        }
+    }
+
+    return 0;
+
+}
+
+static int ffmpeg_set_picture(struct ffmpeg *ffmpeg){
+
+    ffmpeg->picture = my_frame_alloc();
+    if (!ffmpeg->picture) {
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: could not alloc frame");
+        ffmpeg_free_context(ffmpeg);
+        return -1;
     }
 
     /* Take care of variable bitrate setting. */
     if (ffmpeg->vbr)
-        picture->quality = ffmpeg->vbr;
+        ffmpeg->picture->quality = ffmpeg->vbr;
 
+    ffmpeg->picture->linesize[0] = ffmpeg->ctx_codec->width;
+    ffmpeg->picture->linesize[1] = ffmpeg->ctx_codec->width / 2;
+    ffmpeg->picture->linesize[2] = ffmpeg->ctx_codec->width / 2;
 
-    /* Setup pointers and line widths. */
-    picture->data[0] = y;
-    picture->data[1] = u;
-    picture->data[2] = v;
-    picture->linesize[0] = ffmpeg->c->width;
-    picture->linesize[1] = ffmpeg->c->width / 2;
-    picture->linesize[2] = ffmpeg->c->width / 2;
+    ffmpeg->picture->format = ffmpeg->ctx_codec->pix_fmt;
+    ffmpeg->picture->width  = ffmpeg->ctx_codec->width;
+    ffmpeg->picture->height = ffmpeg->ctx_codec->height;
 
-    picture->format = ffmpeg->c->pix_fmt;
-    picture->width  = ffmpeg->c->width;
-    picture->height = ffmpeg->c->height;
+    return 0;
 
-    return picture;
 }
-/**
- * ffmpeg_avcodec_log
- *      Handle any logging output from the ffmpeg library avcodec.
- *
- * Parameters
- *      *ignoreme  A pointer we will ignore
- *      errno_flag The error number value
- *      fmt        Text message to be used for log entry in printf() format.
- *      ap         List of variables to be used in formatted message text.
- *
- * Returns
- *      Function returns nothing.
- */
-void ffmpeg_avcodec_log(void *ignoreme ATTRIBUTE_UNUSED, int errno_flag, const char *fmt, va_list vl)
-{
+
+static int ffmpeg_set_outputfile(struct ffmpeg *ffmpeg){
+
+    int retcd;
+    char errstr[128];
+
+    snprintf(ffmpeg->oc->filename, sizeof(ffmpeg->oc->filename), "%s", ffmpeg->filename);
+    /* Open the output file, if needed. */
+    if ((ffmpeg_timelapse_exists(ffmpeg->filename) == 0) || (ffmpeg->tlapse != TIMELAPSE_APPEND)) {
+        if (!(ffmpeg->oc->oformat->flags & AVFMT_NOFILE)) {
+            if (avio_open(&ffmpeg->oc->pb, ffmpeg->filename, MY_FLAG_WRITE) < 0) {
+                if (errno == ENOENT) {
+                    if (create_path(ffmpeg->filename) == -1) {
+                        ffmpeg_free_context(ffmpeg);
+                        return -1;
+                    }
+                    if (avio_open(&ffmpeg->oc->pb, ffmpeg->filename, MY_FLAG_WRITE) < 0) {
+                        MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: error opening file %s", ffmpeg->filename);
+                        ffmpeg_free_context(ffmpeg);
+                        return -1;
+                    }
+                    /* Permission denied */
+                } else if (errno ==  EACCES) {
+                    MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO,"%s: Permission denied. %s",ffmpeg->filename);
+                    ffmpeg_free_context(ffmpeg);
+                    return -1;
+                } else {
+                    MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: Error opening file %s", ffmpeg->filename);
+                    ffmpeg_free_context(ffmpeg);
+                    return -1;
+                }
+            }
+        }
+
+        /* Write the stream header,  For the TIMELAPSE_APPEND
+         * we write the data via standard file I/O so we close the
+         * items here
+         */
+        retcd = avformat_write_header(ffmpeg->oc, NULL);
+        if (retcd < 0){
+            av_strerror(retcd, errstr, sizeof(errstr));
+            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Could not write ffmpeg header %s",errstr);
+            ffmpeg_free_context(ffmpeg);
+            return -1;
+        }
+        if (ffmpeg->tlapse == TIMELAPSE_APPEND) {
+            av_write_trailer(ffmpeg->oc);
+            avio_close(ffmpeg->oc->pb);
+        }
+
+    }
+
+    return 0;
+
+}
+
+static int ffmpeg_put_frame(struct ffmpeg *ffmpeg, const struct timeval *tv1){
+    int retcd;
+
+    av_init_packet(&ffmpeg->pkt);
+    ffmpeg->pkt.data = NULL;
+    ffmpeg->pkt.size = 0;
+
+    retcd = ffmpeg_encode_video(ffmpeg);
+    if (retcd != 0) return retcd;
+
+    if (ffmpeg->tlapse == TIMELAPSE_APPEND) {
+        retcd = ffmpeg_timelapse_append(ffmpeg, ffmpeg->pkt);
+    } else if (ffmpeg->tlapse == TIMELAPSE_NEW) {
+        retcd = av_write_frame(ffmpeg->oc, &ffmpeg->pkt);
+    } else {
+        retcd = ffmpeg_set_pts(ffmpeg, tv1);
+        if (retcd < 0) {
+            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Error while setting PTS");
+            return -1;
+        }
+        retcd = av_write_frame(ffmpeg->oc, &ffmpeg->pkt);
+        ffmpeg->last_pts = ffmpeg->pkt.pts;
+    }
+    my_packet_unref(ffmpeg->pkt);
+
+    if (retcd < 0) {
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Error while writing video frame");
+        ffmpeg_free_context(ffmpeg);
+        return -1;
+    }
+    return retcd;
+
+}
+
+void ffmpeg_avcodec_log(void *ignoreme ATTRIBUTE_UNUSED, int errno_flag ATTRIBUTE_UNUSED, const char *fmt, va_list vl){
+
     char buf[1024];
     char *end;
 
@@ -504,24 +717,12 @@ void ffmpeg_avcodec_log(void *ignoreme ATTRIBUTE_UNUSED, int errno_flag, const c
         *--end = 0;
     }
 
-    /* If the debug_level is correct then send the message to the motion logging routine.
-     * While it is not really desired to look for specific text in the message, there does
-     * not seem another option.  The specific messages indicated are lost camera which we
-     * have our own message and UE golomb is not something that is possible for us to fix.
-     * It is caused by the stream sent from the source camera
-     */
-    if(strstr(buf, "No route to host")  == NULL){
-        if (strstr(buf, "Invalid UE golomb") != NULL) {
-            MOTION_LOG(DBG, TYPE_ENCODER, NO_ERRNO, "%s: %s", buf);
-        } else if (errno_flag <= AV_LOG_ERROR) {
-            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: %s", buf);
-        } else if (errno_flag <= AV_LOG_WARNING) {
-            MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO, "%s: %s", buf);
-        } else if (errno_flag < AV_LOG_DEBUG){
-            MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s: %s", buf);
-        }
+    //We put the avcodec messages to INF level since their error are not necessarily our errors.
+    if (errno_flag <= AV_LOG_WARNING){
+        MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO, "%s: %s", buf);
     }
 }
+
 
 #endif /* HAVE_FFMPEG */
 
@@ -529,14 +730,7 @@ void ffmpeg_avcodec_log(void *ignoreme ATTRIBUTE_UNUSED, int errno_flag, const c
  ****************************************************************************
  ****************************************************************************/
 
-/**
- * ffmpeg_init
- *      Initializes for libavformat.
- *
- * Returns
- *      Function returns nothing.
- */
-void ffmpeg_init(void){
+void ffmpeg_global_init(void){
 #ifdef HAVE_FFMPEG
     int ret;
 
@@ -565,7 +759,7 @@ void ffmpeg_init(void){
 #endif /* HAVE_FFMPEG */
 }
 
-void ffmpeg_finalise(void) {
+void ffmpeg_global_deinit(void) {
 #ifdef HAVE_FFMPEG
 
     avformat_network_deinit();
@@ -577,332 +771,105 @@ void ffmpeg_finalise(void) {
 #endif /* HAVE_FFMPEG */
 }
 
-/**
- * ffmpeg_open
- *      Opens an mpeg file using the new libavformat method. Both mpeg1
- *      and mpeg4 are supported. However, if the current ffmpeg version doesn't allow
- *      mpeg1 with non-standard framerate, the open will fail. Timelapse is a special
- *      case and is tested separately.
- *
- *  Returns
- *      A new allocated ffmpeg struct or NULL if any error happens.
- */
-struct ffmpeg *ffmpeg_open(const char *ffmpeg_video_codec, char *filename,
-                           unsigned char *y, unsigned char *u, unsigned char *v,
-                           int width, int height, int rate, int bps, int vbr, int tlapse,
-                           const struct timeval *tv1)
-{
+int ffmpeg_open(struct ffmpeg *ffmpeg){
+
 #ifdef HAVE_FFMPEG
 
-    AVCodecContext *c;
-    AVCodec *codec;
-    struct ffmpeg *ffmpeg;
     int retcd;
-    char errstr[128];
-    AVDictionary *opts = 0;
 
-    /*
-     * Allocate space for our ffmpeg structure. This structure contains all the
-     * codec and image information we need to generate movies.
-     */
-    ffmpeg = mymalloc(sizeof(struct ffmpeg));
-
-    ffmpeg->tlapse  = tlapse;
-
-    /* Store codec name in ffmpeg->codec, with buffer overflow check. */
-    snprintf(ffmpeg->codec, sizeof(ffmpeg->codec), "%s", ffmpeg_video_codec);
-
-    /* Allocation the output media context. */
     ffmpeg->oc = avformat_alloc_context();
-
     if (!ffmpeg->oc) {
         MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: Could not allocate output context");
-        ffmpeg_cleanups(ffmpeg);
-        return NULL;
+        ffmpeg_free_context(ffmpeg);
+        return -1;
     }
 
-    /* Setup output format */
-    if (ffmpeg->tlapse == TIMELAPSE_APPEND){
-        ffmpeg->oc->oformat = get_oformat("tlapse", filename);
-    } else {
-        ffmpeg->oc->oformat = get_oformat(ffmpeg_video_codec, filename);
-    }
-    if (!ffmpeg->oc->oformat) {
-        ffmpeg_cleanups(ffmpeg);
-        return NULL;
+    retcd = ffmpeg_get_oformat(ffmpeg);
+    if (retcd < 0 ) {
+        MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: Could not get codec!");
+        ffmpeg_free_context(ffmpeg);
+        return -1;
     }
 
-    snprintf(ffmpeg->oc->filename, sizeof(ffmpeg->oc->filename), "%s", filename);
-
-    ffmpeg->video_st = NULL;
-    if (ffmpeg->oc->oformat->video_codec != MY_CODEC_ID_NONE) {
-
-        codec = avcodec_find_encoder(ffmpeg->oc->oformat->video_codec);
-        if (!codec) {
-            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Codec %s not found", ffmpeg_video_codec);
-            ffmpeg_cleanups(ffmpeg);
-            return NULL;
-        }
-
-        ffmpeg->video_st = avformat_new_stream(ffmpeg->oc, codec);
-        if (!ffmpeg->video_st) {
-            MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: Could not alloc stream");
-            ffmpeg_cleanups(ffmpeg);
-            return NULL;
-        }
-    } else {
-        /* We did not get a proper video codec. */
-        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Could not get the codec");
-        ffmpeg_cleanups(ffmpeg);
-        return NULL;
+    retcd = ffmpeg_set_codec(ffmpeg);
+    if (retcd < 0 ) {
+        MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: Failed to allocate codec!");
+        return -1;
     }
 
-    /* Only the newer codec and containers can handle the really fast FPS */
-    if (((strcmp(ffmpeg_video_codec, "msmpeg4") == 0) ||
-        (strcmp(ffmpeg_video_codec, "mpeg4") == 0) ||
-        (strcmp(ffmpeg_video_codec, "swf") == 0) ) && (rate >100)){
-        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s The frame rate specified is too high for the ffmpeg movie type specified. Choose a different ffmpeg container or lower framerate. ");
-        ffmpeg_cleanups(ffmpeg);
-        return NULL;
+    retcd = ffmpeg_set_stream(ffmpeg);
+    if (retcd < 0){
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Could not set the stream");
+        return -1;
     }
 
-    ffmpeg->c     = c = AVSTREAM_CODEC_PTR(ffmpeg->video_st);
-    c->codec_id   = ffmpeg->oc->oformat->video_codec;
-    c->codec_type = AVMEDIA_TYPE_VIDEO;
-    c->bit_rate   = bps;
-    c->width      = width;
-    c->height     = height;
-    c->time_base.num = 1;
-    c->time_base.den = rate;
-    c->gop_size   = 12;
-    c->pix_fmt    = MY_PIX_FMT_YUV420P;
-    c->max_b_frames = 0;
-
-    if (vbr > 100) vbr = 100;
-
-    if (c->codec_id == MY_CODEC_ID_H264 ||
-        c->codec_id == MY_CODEC_ID_HEVC){
-        if (vbr > 0) {
-            ffmpeg->vbr = (int)(( (100-vbr) * 51)/100);
-        } else {
-            ffmpeg->vbr = 28;
-        }
-        av_dict_set(&opts, "preset", "ultrafast", 0);
-        char crf[4];
-        snprintf(crf, 4, "%d",ffmpeg->vbr);
-        av_dict_set(&opts, "crf", crf, 0);
-        av_dict_set(&opts, "tune", "zerolatency", 0);
-    } else {
-        /* The selection of 8000 in the else is a subjective number based upon viewing output files */
-        if (vbr > 0){
-            ffmpeg->vbr =(int)(((100-vbr)*(100-vbr)*(100-vbr) * 8000) / 1000000) + 1;
-            c->flags |= CODEC_FLAG_QSCALE;
-            c->global_quality=ffmpeg->vbr;
-        }
+    retcd = ffmpeg_set_picture(ffmpeg);
+    if (retcd < 0){
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Could not set the stream");
+        return -1;
     }
 
-    MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s vbr/crf for codec: %d", ffmpeg->vbr);
-
-    if (strcmp(ffmpeg_video_codec, "ffv1") == 0) c->strict_std_compliance = -2;
-    c->flags |= CODEC_FLAG_GLOBAL_HEADER;
-
-    retcd = avcodec_open2(c, codec, &opts);
-    if (retcd < 0) {
-        if (codec->supported_framerates) {
-            const AVRational *fps = codec->supported_framerates;
-            while (fps->num) {
-                MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s Reported FPS Supported %d/%d", fps->num, fps->den);
-                fps++;
-            }
-        }
-        int chkrate = 1;
-        while ((chkrate < 36) && (retcd != 0)) {
-            c->time_base.den = chkrate;
-            retcd = avcodec_open2(c, codec, &opts);
-            chkrate++;
-        }
-        if (retcd < 0){
-            av_strerror(retcd, errstr, sizeof(errstr));
-            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Could not open codec %s",errstr);
-            av_dict_free(&opts);
-            ffmpeg_cleanups(ffmpeg);
-            return NULL;
-        }
-
-    }
-    av_dict_free(&opts);
-    MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO, "%s Selected Output FPS %d", c->time_base.den);
-
-    ffmpeg->last_pts = 0;
-    ffmpeg->video_st->time_base.num = 1;
-    ffmpeg->video_st->time_base.den = 1000;
-    if ((strcmp(ffmpeg_video_codec, "swf") == 0) ||
-        (ffmpeg->tlapse != TIMELAPSE_NONE) ) {
-        ffmpeg->video_st->time_base.num = 1;
-        ffmpeg->video_st->time_base.den = rate;
-        if ((rate > 50) && (strcmp(ffmpeg_video_codec, "swf") == 0)){
-            MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO, "%s The FPS could be too high for the SWF container.  Consider other choices.");
-        }
+    retcd = ffmpeg_set_outputfile(ffmpeg);
+    if (retcd < 0){
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Could not set the stream");
+        return -1;
     }
 
-    ffmpeg->video_outbuf = NULL;
-    if (!(ffmpeg->oc->oformat->flags & AVFMT_RAWPICTURE)) {
-        ffmpeg->video_outbuf_size = ffmpeg->c->width * 512;
-        ffmpeg->video_outbuf = mymalloc(ffmpeg->video_outbuf_size);
-    }
-
-    ffmpeg->picture = my_frame_alloc();
-
-    if (!ffmpeg->picture) {
-        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: could not alloc frame");
-        ffmpeg_cleanups(ffmpeg);
-        return NULL;
-    }
-
-    /* Set the frame data. */
-    ffmpeg->picture->data[0] = y;
-    ffmpeg->picture->data[1] = u;
-    ffmpeg->picture->data[2] = v;
-    ffmpeg->picture->linesize[0] = ffmpeg->c->width;
-    ffmpeg->picture->linesize[1] = ffmpeg->c->width / 2;
-    ffmpeg->picture->linesize[2] = ffmpeg->c->width / 2;
-
-    /* Open the output file, if needed. */
-    if ((timelapse_exists(filename) == 0) || (ffmpeg->tlapse != TIMELAPSE_APPEND)) {
-        if (!(ffmpeg->oc->oformat->flags & AVFMT_NOFILE)) {
-            if (avio_open(&ffmpeg->oc->pb, filename, MY_FLAG_WRITE) < 0) {
-                if (errno == ENOENT) {
-                    if (create_path(filename) == -1) {
-                        ffmpeg_cleanups(ffmpeg);
-                        return NULL;
-                    }
-                    if (avio_open(&ffmpeg->oc->pb, filename, MY_FLAG_WRITE) < 0) {
-                        MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: error opening file %s", filename);
-                        ffmpeg_cleanups(ffmpeg);
-                        return NULL;
-                    }
-                    /* Permission denied */
-                } else if (errno ==  EACCES) {
-                    MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO,"%s: Permission denied. %s",filename);
-                    ffmpeg_cleanups(ffmpeg);
-                    return NULL;
-                } else {
-                    MOTION_LOG(ERR, TYPE_ENCODER, SHOW_ERRNO, "%s: Error opening file %s", filename);
-                    ffmpeg_cleanups(ffmpeg);
-                    return NULL;
-                }
-            }
-        }
-
-        ffmpeg->start_time.tv_sec = tv1->tv_sec;
-        ffmpeg->start_time.tv_usec= tv1->tv_usec;
-
-
-        /* Write the stream header,  For the TIMELAPSE_APPEND
-         * we write the data via standard file I/O so we close the
-         * items here
-         */
-        retcd = avformat_write_header(ffmpeg->oc, NULL);
-        if (retcd < 0){
-            av_strerror(retcd, errstr, sizeof(errstr));
-            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Could not write ffmpeg header %s",errstr);
-            ffmpeg_cleanups(ffmpeg);
-            return NULL;
-        }
-        if (ffmpeg->tlapse == TIMELAPSE_APPEND) {
-            av_write_trailer(ffmpeg->oc);
-            avio_close(ffmpeg->oc->pb);
-        }
-
-    }
-    return ffmpeg;
+    return 0;
 
 #else /* No FFMPEG */
 
-    MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO,"%s: No ffmpeg functionality included");
-
-    struct ffmpeg *ffmpeg;
-    ffmpeg = mymalloc(sizeof(struct ffmpeg));
-
-    ffmpeg_video_codec = ffmpeg_video_codec;
-    filename = filename;
-    y = y;
-    u = u;
-    v = v;
-    width = width;
-    height = height;
-    rate = rate;
-    bps = bps;
-    vbr = vbr;
-    tlapse = tlapse;
-    ffmpeg->dummy = 0;
-    tv1 = tv1;
-    return ffmpeg;
+    if (ffmpeg) {
+        MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO,"%s: No ffmpeg functionality included");
+    }else {
+        MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO,"%s: No ffmpeg functionality included");
+    }
+    return -1;
 
 #endif /* HAVE_FFMPEG */
 
 }
 
-/**
- * ffmpeg_close
- *      Closes a video file.
- *
- * Returns
- *      Function returns nothing.
- */
 void ffmpeg_close(struct ffmpeg *ffmpeg){
 #ifdef HAVE_FFMPEG
 
-    if (ffmpeg->tlapse != TIMELAPSE_APPEND) {
-        av_write_trailer(ffmpeg->oc);
-    }
-    /* Close each codec */
-    if (ffmpeg->video_st) {
-        avcodec_close(AVSTREAM_CODEC_PTR(ffmpeg->video_st));
-    }
-    av_freep(&ffmpeg->picture);
-    free(ffmpeg->video_outbuf);
-
-    if (!(ffmpeg->oc->oformat->flags & AVFMT_NOFILE)) {
+    if (ffmpeg != NULL) {
         if (ffmpeg->tlapse != TIMELAPSE_APPEND) {
-            avio_close(ffmpeg->oc->pb);
+            av_write_trailer(ffmpeg->oc);
         }
+        if (!(ffmpeg->oc->oformat->flags & AVFMT_NOFILE)) {
+            if (ffmpeg->tlapse != TIMELAPSE_APPEND) {
+                avio_close(ffmpeg->oc->pb);
+            }
+        }
+        ffmpeg_free_context(ffmpeg);
     }
-    avformat_free_context(ffmpeg->oc);
 
+#else
+    if (ffmpeg != NULL) free(ffmpeg);
 #endif // HAVE_FFMPEG
-
-    free(ffmpeg);
 }
 
-/**
- * ffmpeg_put_other_image
- *      Puts an arbitrary picture defined by y, u and v.
- *
- * Returns
- *      Number of bytes written by ffmpeg_put_frame
- *      -1 if any error happens in ffmpeg_put_frame
- *       0 if error allocating picture.
- */
-int ffmpeg_put_other_image(struct ffmpeg *ffmpeg, unsigned char *y,
-                            unsigned char *u, unsigned char *v, const struct timeval *tv1){
+int ffmpeg_put_image(struct ffmpeg *ffmpeg, unsigned char *image, const struct timeval *tv1){
 #ifdef HAVE_FFMPEG
-    AVFrame *picture;
     int retcd = 0;
     int cnt = 0;
 
-    /* Allocate the encoded raw picture. */
-    picture = ffmpeg_prepare_frame(ffmpeg, y, u, v);
+    if (ffmpeg->picture) {
 
-    if (picture) {
+        /* Setup pointers and line widths. */
+        ffmpeg->picture->data[0] = image;
+        ffmpeg->picture->data[1] = image + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height);
+        ffmpeg->picture->data[2] = ffmpeg->picture->data[1] + ((ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height) / 4);
+
         /* A return code of -2 is thrown by the put_frame
          * when a image is buffered.  For timelapse, we absolutely
          * never want a frame buffered so we keep sending back the
          * the same pic until it flushes or fails in a different way
          */
-        retcd = ffmpeg_put_frame(ffmpeg, picture, tv1);
+        retcd = ffmpeg_put_frame(ffmpeg, tv1);
         while ((retcd == -2) && (ffmpeg->tlapse != TIMELAPSE_NONE)) {
-            retcd = ffmpeg_put_frame(ffmpeg, picture, tv1);
+            retcd = ffmpeg_put_frame(ffmpeg, tv1);
             cnt++;
             if (cnt > 50){
                 MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Excessive attempts to clear buffered packet");
@@ -914,59 +881,14 @@ int ffmpeg_put_other_image(struct ffmpeg *ffmpeg, unsigned char *y,
             retcd = 0;
             MOTION_LOG(DBG, TYPE_ENCODER, NO_ERRNO, "%s: Buffered packet");
         }
-        av_free(picture);
-    }
-    return retcd;
-
-#else
-
-    ffmpeg = ffmpeg;
-    y = y;
-    u = u;
-    v = v;
-    tv1 = tv1;
-    return 0;
-
-#endif // HAVE_FFMPEG
-}
-
-/**
- * ffmpeg_put_image
- *      Puts the image pointed to by ffmpeg->picture.
- *
- * Returns
- *      value returned by ffmpeg_put_frame call.
- */
-int ffmpeg_put_image(struct ffmpeg *ffmpeg, const struct timeval *tv1){
-
-#ifdef HAVE_FFMPEG
-    /* A return code of -2 is thrown by the put_frame
-     * when a image is buffered.  For timelapse, we absolutely
-     * never want a frame buffered so we keep sending back the
-     * the same pic until it flushes or fails in a different way
-     */
-    int retcd;
-    int cnt = 0;
-
-    retcd = ffmpeg_put_frame(ffmpeg, ffmpeg->picture, tv1);
-    while ((retcd == -2) && (ffmpeg->tlapse != TIMELAPSE_NONE)) {
-        retcd = ffmpeg_put_frame(ffmpeg, ffmpeg->picture, tv1);
-        cnt++;
-        if (cnt > 50){
-            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "%s: Excessive attempts to clear buffered packet");
-            retcd = -1;
-        }
-    }
-    //non timelapse buffered is ok
-    if (retcd == -2){
-        retcd = 0;
-        MOTION_LOG(DBG, TYPE_ENCODER, NO_ERRNO, "%s: Buffered packet");
     }
 
     return retcd;
+
 #else
-    ffmpeg = ffmpeg;
-    tv1 = tv1;
+    if (ffmpeg && image && tv1) {
+        MOTION_LOG(DBG, TYPE_ENCODER, NO_ERRNO, "%s: No ffmpeg support");
+    }
     return 0;
 #endif // HAVE_FFMPEG
 }

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -51,6 +51,8 @@ struct ffmpeg {
     int vbr;
     const char *codec_name;
     int64_t last_pts;
+    int test_mode;
+    int gop_cnt;
     struct timeval start_time;
 };
 

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -4,12 +4,14 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <sys/time.h>
-
+#include <stdint.h>
 #include "config.h"
 
-#define TIMELAPSE_NONE   0  /* No timelapse, regular processing */
-#define TIMELAPSE_APPEND 1  /* Use append version of timelapse */
-#define TIMELAPSE_NEW    2  /* Use create new file version of timelapse */
+enum TIMELAPSE_TYPE {
+    TIMELAPSE_NONE,         /* No timelapse, regular processing */
+    TIMELAPSE_APPEND,       /* Use append version of timelapse */
+    TIMELAPSE_NEW           /* Use create new file version of timelapse */
+};
 
 #ifdef HAVE_FFMPEG
 
@@ -19,85 +21,58 @@
 #include <libavutil/mathematics.h>
 
 #if (LIBAVFORMAT_VERSION_MAJOR >= 56)
-
 #define MY_PIX_FMT_YUV420P   AV_PIX_FMT_YUV420P
 #define MY_PIX_FMT_YUVJ420P  AV_PIX_FMT_YUVJ420P
 #define MyPixelFormat AVPixelFormat
-
-#else
-
+#else  //Old ffmpeg pixel formats
 #define MY_PIX_FMT_YUV420P   PIX_FMT_YUV420P
 #define MY_PIX_FMT_YUVJ420P  PIX_FMT_YUVJ420P
 #define MyPixelFormat PixelFormat
+#endif  //Libavformat >= 56
 
-#endif
+#endif // HAVE_FFMPEG
 
 struct ffmpeg {
+#ifdef HAVE_FFMPEG
     AVFormatContext *oc;
     AVStream *video_st;
-    AVCodecContext *c;
-
+    AVCodecContext *ctx_codec;
+    AVCodec *codec;
+    AVPacket pkt;
     AVFrame *picture;       /* contains default image pointers */
-    uint8_t *video_outbuf;
-    int video_outbuf_size;
-
-    void *udata;            /* U & V planes for greyscale images */
-    int vbr;                /* variable bitrate setting */
-    char codec[20];         /* codec name */
-    int tlapse;
+    AVDictionary *opts;
+#endif
+    int width;
+    int height;
+    enum TIMELAPSE_TYPE tlapse;
+    int fps;
+    int bps;
+    char *filename;
+    int vbr;
+    const char *codec_name;
     int64_t last_pts;
     struct timeval start_time;
 };
 
+
+#ifdef HAVE_FFMPEG
+
 AVFrame *my_frame_alloc(void);
 void my_frame_free(AVFrame *frame);
-int ffmpeg_put_frame(struct ffmpeg *, AVFrame *, const struct timeval *tv1);
-void ffmpeg_cleanups(struct ffmpeg *);
-AVFrame *ffmpeg_prepare_frame(struct ffmpeg *, unsigned char *,
-                              unsigned char *, unsigned char *);
+void my_packet_unref(AVPacket pkt);
+void my_avcodec_close(AVCodecContext *codec_context);
 int my_image_get_buffer_size(enum MyPixelFormat pix_fmt, int width, int height);
 int my_image_copy_to_buffer(AVFrame *frame,uint8_t *buffer_ptr,enum MyPixelFormat pix_fmt,int width,int height,int dest_size);
 int my_image_fill_arrays(AVFrame *frame,uint8_t *buffer_ptr,enum MyPixelFormat pix_fmt,int width,int height);
-void my_packet_unref(AVPacket pkt);
-
-
-#else /* No FFMPEG */
-
-struct ffmpeg {
-    void *udata;
-    int dummy;
-    struct timeval start_time;
-};
 
 #endif /* HAVE_FFMPEG */
 
-/* Now the functions that are ok for both situations */
-void ffmpeg_init(void);
-void ffmpeg_finalise(void);
-struct ffmpeg *ffmpeg_open(
-    const char *ffmpeg_video_codec,
-    char *filename,
-    unsigned char *y,    /* YUV420 Y plane */
-    unsigned char *u,    /* YUV420 U plane */
-    unsigned char *v,    /* YUV420 V plane */
-    int width,
-    int height,
-    int rate,            /* framerate, fps */
-    int bps,             /* bitrate; bits per second */
-    int vbr,             /* variable bitrate */
-    int tlapse,
-    const struct timeval *tv1
-    );
-int ffmpeg_put_image(struct ffmpeg *, const struct timeval *tv1);
-int ffmpeg_put_other_image(
-    struct ffmpeg *ffmpeg,
-    unsigned char *y,
-    unsigned char *u,
-    unsigned char *v,
-    const struct timeval *tv1
-    );
-void ffmpeg_close(struct ffmpeg *);
+void ffmpeg_global_init(void);
+void ffmpeg_global_deinit(void);
 void ffmpeg_avcodec_log(void *, int, const char *, va_list);
 
+int ffmpeg_open(struct ffmpeg *ffmpeg);
+int ffmpeg_put_image(struct ffmpeg *ffmpeg, unsigned char *image, const struct timeval *tv1);
+void ffmpeg_close(struct ffmpeg *ffmpeg);
 
 #endif /* _INCLUDE_FFMPEG_H_ */

--- a/motion.c
+++ b/motion.c
@@ -1196,6 +1196,10 @@ static int motion_init(struct context *cnt)
     cnt->passflag = 0;  //only purpose to flag first frame
     cnt->rolling_frame = 0;
 
+    if (cnt->conf.emulate_motion) {
+        MOTION_LOG(INF, TYPE_ALL, NO_ERRNO, "%s: Emulating motion");
+    }
+
     return 0;
 }
 
@@ -1960,7 +1964,6 @@ static void mlp_actions(struct context *cnt){
      */
     if (cnt->conf.emulate_motion && (cnt->startup_frames == 0)) {
         cnt->detecting_motion = 1;
-        MOTION_LOG(INF, TYPE_ALL, NO_ERRNO, "%s: Emulating motion");
         if (cnt->conf.post_capture > 0) {
             /* Setup the postcap counter */
             cnt->postcap = cnt->conf.post_capture;

--- a/motion.c
+++ b/motion.c
@@ -1117,19 +1117,18 @@ static int motion_init(struct context *cnt)
 
     /* Prevent first few frames from triggering motion... */
     cnt->moved = 8;
-    /* 2 sec startup delay so FPS is calculated correct */
-    cnt->startup_frames = cnt->conf.frame_limit * 2;
-
     /* Initialize the double sized characters if needed. */
     if (cnt->conf.text_double)
         cnt->text_size_factor = 2;
     else
         cnt->text_size_factor = 1;
 
-
     /* Work out expected frame rate based on config setting */
     if (cnt->conf.frame_limit < 2)
         cnt->conf.frame_limit = 2;
+
+    /* 2 sec startup delay so FPS is calculated correct */
+    cnt->startup_frames = (cnt->conf.frame_limit * 2) + cnt->conf.pre_capture + cnt->conf.minimum_motion_frames;
 
     cnt->required_frame_time = 1000000L / cnt->conf.frame_limit;
 
@@ -2829,7 +2828,7 @@ int main (int argc, char **argv)
 
     motion_startup(1, argc, argv);
 
-    ffmpeg_init();
+    ffmpeg_global_init();
 
 #ifdef HAVE_MYSQL
     if (mysql_library_init(0, NULL, NULL)) {
@@ -3051,7 +3050,7 @@ int main (int argc, char **argv)
 
     } while (restart); /* loop if we're supposed to restart */
 
-    ffmpeg_finalise();
+    ffmpeg_global_deinit();
 
     // Be sure that http control exits fine
     cnt_list[0]->webcontrol_finish = 1;


### PR DESCRIPTION
The ffmpeg versions after 3.1 eliminated the stream codec which was used
in many different ways in the previous code.  This commit revises the ffmpeg
module to use smaller functions and eliminates the greyscale image handling
since all images are yuv.