### PR TITLE
Added issue template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,7 @@
+1. version [x.y.z, hash, other]: 
+2. installed as a package or compiled from sources [deb, rpm, git, other]: 
+3. standalone or part of third party [motion, MotionEyeOS, other]: 
+4. video stream source [V4L (card or USB), net cam (mjpeg, rtsp, other), mmal]: 
+5. hardware [x86, ARM, other]: 
+6. operating system [Linux (which), FreeBSD, other]: 
+


### PR DESCRIPTION
In order to make issue resolve faster we need to collect some basic info about motion. Addition to already existing contribution template (https://github.com/Motion-Project/motion/issues/298)
This commit provides issue template that will be used as a default for all new issue