### PR TITLE
Bugfix: wrong variable logged when extpipe is already closed

### DIFF
--- a/event.c
+++ b/event.c
@@ -569,7 +569,7 @@ static void event_extpipe_put(struct context *cnt,
                            ferror(cnt->extpipe));
         } else {
             MOTION_LOG(ERR, TYPE_EVENTS, NO_ERRNO, "%s: pipe %s not created or closed already ",
-                       cnt->extpipe);
+                       cnt->conf.extpipe);
         }
     }
 }


### PR DESCRIPTION
This caused memory access violation and process crash
Fixes https://github.com/Motion-Project/motion/issues/329