### PR TITLE
Detect mysql library path in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -267,7 +267,7 @@ if test "x${MYSQL}" = "xno"; then
 else
     AC_MSG_CHECKING([for MySQL library directory])
     MYSQL_C_LIB_DIR=
-    MYSQL_lib_check="/usr/lib64 /usr/lib /usr/lib64/mysql /usr/lib/mysql /usr/lib/i386-linux-gnu /usr/local/lib64"
+    MYSQL_lib_check="/usr/lib64 /usr/lib /usr/lib64/mysql /usr/lib/mysql /usr/lib/x86_64-linux-gnu /usr/lib/i386-linux-gnu /usr/local/lib64"
     for m in $MYSQL_lib_check; do        if test -d "$m" && \
            (test -f "$m/libmysqlclient.so" || \
             test -f "$m/libmysqlclient.a"); then
@@ -291,7 +291,7 @@ else
     AC_MSG_RESULT([$MYSQL_C_LIB_DIR])
 
     case "$MYSQL_C_LIB_DIR" in
-        /usr/lib |  /usr/lib/i386-linux-gnu)
+        /usr/lib |  /usr/lib/*-linux-gnu)
             MYSQL_C_LIB_DIR=
             ;;
         *)

--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,40 @@ if test "x${MYSQL}" = "xno"; then
     AC_MSG_CHECKING(for mysql support)
     AC_MSG_RESULT(skipped)
 else
+    AC_MSG_CHECKING([for MySQL library directory])
+    MYSQL_C_LIB_DIR=
+    MYSQL_lib_check="/usr/lib64 /usr/lib /usr/lib64/mysql /usr/lib/mysql /usr/local/lib64"
+    for m in $MYSQL_lib_check; do        if test -d "$m" && \
+           (test -f "$m/libmysqlclient.so" || \
+            test -f "$m/libmysqlclient.a"); then
+            MYSQL_C_LIB_DIR=$m
+            break
+        fi
+    done
+    if test -z "$MYSQL_C_LIB_DIR"; then
+        AC_MSG_RESULT([no])
+        AC_MSG_ERROR([Didn't find mysqlclient library in '$MYSQL_lib_check'])
+    fi
+
+    case "$MYSQL_C_LIB_DIR" in
+        /* )
+            ;;
+        * )
+            AC_MSG_RESULT([])
+            AC_MSG_ERROR([The MySQL library directory ($MYSQL_C_LIB_DIR) must be an absolute path.]) ;;
+    esac
+
+    AC_MSG_RESULT([$MYSQL_C_LIB_DIR])
+
+    case "$MYSQL_C_LIB_DIR" in
+        /usr/lib)
+            MYSQL_C_LIB_DIR=
+            ;;
+        *)
+            TEMP_LDFLAGS="$TEMP_LDFLAGS -L${MYSQL_C_LIB_DIR}"
+            ;;
+    esac
+
     AC_CHECK_HEADERS(mysql/mysql.h,[MYSQL="yes"],[MYSQL="no"])
     AC_MSG_CHECKING(for mysql support)
     AC_MSG_RESULT($MYSQL)

--- a/configure.ac
+++ b/configure.ac
@@ -267,7 +267,7 @@ if test "x${MYSQL}" = "xno"; then
 else
     AC_MSG_CHECKING([for MySQL library directory])
     MYSQL_C_LIB_DIR=
-    MYSQL_lib_check="/usr/lib64 /usr/lib /usr/lib64/mysql /usr/lib/mysql /usr/local/lib64"
+    MYSQL_lib_check="/usr/lib64 /usr/lib /usr/lib64/mysql /usr/lib/mysql /usr/lib/i386-linux-gnu /usr/local/lib64"
     for m in $MYSQL_lib_check; do        if test -d "$m" && \
            (test -f "$m/libmysqlclient.so" || \
             test -f "$m/libmysqlclient.a"); then
@@ -291,7 +291,7 @@ else
     AC_MSG_RESULT([$MYSQL_C_LIB_DIR])
 
     case "$MYSQL_C_LIB_DIR" in
-        /usr/lib)
+        /usr/lib |  /usr/lib/i386-linux-gnu)
             MYSQL_C_LIB_DIR=
             ;;
         *)


### PR DESCRIPTION
Currently configure makes no effort to determine if the mysqlclient lib needs a -L ld argument.

Add some code to detect where libmysqlclient.[so|a] is.