### PR TITLE
Two small config and guide fixes

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -783,7 +783,7 @@ config_param config_params[] = {
     "# Enables and defines variable bitrate for the ffmpeg encoder.\n"
     "# ffmpeg_bps is ignored if variable bitrate is enabled.\n"
     "# Valid values: 0 (default) = fixed bitrate defined by ffmpeg_bps,\n"
-    "# or the range 2 - 31 where 2 means best quality and 31 is worst.",
+    "# or the range 1 - 100 where 1 means worst quality and 100 is best.",
     0,
     CONF_OFFSET(ffmpeg_vbr),
     copy_int,

--- a/motion_guide.html
+++ b/motion_guide.html
@@ -1357,7 +1357,7 @@ Some configuration options are only used if Motion is built on a system that has
 		<td align="left"><a href="#movie_filename" >movie_filename</a></td>
 	</tr>
 	<tr>
-		<td height="17" align="left">netcam_http</td>
+		<td height="17" align="left">netcam_keepalive</td>
 		<td align="left">netcam_keepalive</td>
 		<td align="left"><a href="#netcam_keepalive" >netcam_keepalive</a></td>
 	</tr>


### PR DESCRIPTION
This fixes the comment for ffmpeg_variable_bitrate in 'config_params', which is used to write out the config file from the webui. Comment now matches the default config file. Reference issue #362.

Also noticed a missed change in the guide for 'netcam_http' to 'netcam_keepalive'.