### PR TITLE
Various fixes for RTSP crashes and/or Valgrind errors

### DIFF
--- a/netcam.c
+++ b/netcam.c
@@ -1876,7 +1876,7 @@ static void *netcam_handler_loop(void *arg)
         }
 
         if (netcam->caps.streaming == NCS_RTSP) {
-            if (netcam->rtsp->format_context == NULL) {      // We must have disconnected.  Try to reconnect
+            if (!netcam->rtsp->active) {      // We must have disconnected.  Try to reconnect
                 if ((netcam->rtsp->status == RTSP_CONNECTED) ||
                     (netcam->rtsp->status == RTSP_READINGIMAGE)){
                     MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "%s: Reconnecting with camera....");

--- a/netcam_rtsp.h
+++ b/netcam_rtsp.h
@@ -24,6 +24,7 @@ struct rtsp_context {
     char*                 user;
     char*                 pass;
     int                   interrupted;
+    int                   active;
     enum RTSP_STATUS      status;
     struct timeval        startreadtime;
     struct SwsContext*   swsctx;


### PR DESCRIPTION
Related to issue #233.

* Use a dedicated `active` flag to tell if a `netcam->rtsp` context is connected and running, rather than checking (`netcam->rtsp->format_context != NULL`), because the latter may be true without a working connection. (There may be a better name for this flag than "active.")

* `netcam_open_codec()` and `netcam_rtsp_open_context()` should not return 0 if something is wrong

* Pass a `netcam` context into `netcam_interrupt_rtsp()` instead of `netcam->rtsp` so that the callback can check `netcam->finish` and react appropriately to the shutdown signal