### PR TITLE
Various fixes to Motion's interaction with FFmpeg vis-a-vis RTSP

### DIFF
--- a/motion.h
+++ b/motion.h
@@ -38,6 +38,7 @@
 #include <signal.h>
 #include <limits.h>
 #include <errno.h>
+#include <assert.h>
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <sys/types.h>


### PR DESCRIPTION
* Added `<assert.h>` to motion.h, so we can do assertions

* Changed the return-code semantics of `rtsp_decode_video()` and `rtsp_decode_packet()` to a tristate: negative on error, zero if no output is currently available, positive if output was successfully obtained

* Assert that `avcodec_send_packet()` never returns `AVERROR(EAGAIN)` (i.e. we never overfill the codec with packets)

* Treat `AVERROR(EAGAIN)` from `avcodec_receive_frame()` as a no-output, non-error condition (it means we need to send more packets before we can get a frame)

* Changed `netcam_read_rtsp_image()` to handle the case where the codec has a frame ready for output without needing any new packets

* Simplified the logic in the `netcam_read_rtsp_image()` packet-read loop

* Improved wording of some log messages

* Removed needless variable initializations