### PR TITLE
Fix cross-compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ if test "${DISTRO}" = "Darwin"; then
   TEMP_LDFLAGS="${LDFLAGS} -L/sw/lib"
   TEMP_LIBS="-L/sw/lib"
 else
-  if test "x${DISTRO}" != "Linux"; then
+  if test "${DISTRO}" != "Linux"; then
     TEMP_CFLAGS="${CFLAGS} -I/usr/local/include"
     TEMP_CPPFLAGS="${CPPFLAGS} -I/usr/local/include"
     TEMP_LDFLAGS="${LDFLAGS} -L/usr/local/lib"


### PR DESCRIPTION
Currently if "x${DISTRO}" isn't set to "Linux", unsafe header/library
path for cross-compilation such as '-I/usr/local/include' are used.
As a result, motion can't be cross-compiled, so change "x${DISTRO}" to
"${DISTRO}" as it seems that this was the intended use.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>