### PR TITLE
Fix --without-webp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,7 +132,7 @@ AM_COND_IF([FOUND_PKGCONFIG],,[AC_MSG_ERROR([Required package 'pkg-config' not f
 AC_ARG_WITH([webp],
     AS_HELP_STRING([--with-webp],
       [Compile with Webp image support]),
-    WEBP="yes",
+    WEBP="$withval",
     WEBP="no")
 
 HAVE_WEBP=""


### PR DESCRIPTION
Currently if the user sets --without-webp, WEBP is set to yes as
AC_ARG_WITH defines that its third argument is "action-if-present" so
use $withval to retrieve the value instead of always setting WEBP to yes

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>