### PR TITLE
Put back the detection of pthread_setname_np

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -110,6 +110,16 @@ if test x$THREADS = xyes; then
 fi
 
 ##############################################################################
+###  Check for pthread_setname_np (nonstandard GNU extension)
+##############################################################################
+AC_MSG_CHECKING([for pthread_setname_np])
+AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM([#include <pthread.h>], [pthread_setname_np(pthread_self(), "name")])],
+    [AC_DEFINE([HAVE_PTHREAD_SETNAME_NP], [1], [Define if you have pthread_setname_np function.])
+    AC_MSG_RESULT([yes])],
+    [AC_MSG_RESULT([no])] )
+
+##############################################################################
 ###  Check for JPG
 ##############################################################################
 AC_CHECK_HEADERS(setjmp.h jerror.h jpeglib.h,[JPGS="yes"],[JPGS="no"])

--- a/logger.c
+++ b/logger.c
@@ -202,7 +202,7 @@ void motion_log(int level, unsigned int type, int errno_flag, const char *fmt, .
     errno_save = errno;
 
     char threadname[32] = "unknown";
-#if (!defined(BSD) || defined(__APPLE__))
+#if ((!defined(BSD) && HAVE_PTHREAD_SETNAME_NP) || defined(__APPLE__))
     pthread_getname_np(pthread_self(), threadname, sizeof(threadname));
 #endif
 

--- a/motion.h
+++ b/motion.h
@@ -62,8 +62,10 @@
 #define MOTION_PTHREAD_SETNAME(name)  pthread_setname_np(name)
 #elif defined(BSD)
 #define MOTION_PTHREAD_SETNAME(name)  pthread_set_name_np(pthread_self(), name)
-#else
+#elif HAVE_PTHREAD_SETNAME_NP
 #define MOTION_PTHREAD_SETNAME(name)  pthread_setname_np(pthread_self(), name)
+#else
+#define MOTION_PTHREAD_SETNAME(name)
 #endif
 
 /**

--- a/netcam_rtsp.c
+++ b/netcam_rtsp.c
@@ -560,7 +560,7 @@ static int netcam_rtsp_open_context(netcam_context_ptr netcam){
     {
         char newtname[16];
         char curtname[16] = "unknown";
-#if (!defined(BSD) || defined(__APPLE__))
+#if ((!defined(BSD) && HAVE_PTHREAD_SETNAME_NP) || defined(__APPLE__))
         pthread_getname_np(pthread_self(), curtname, sizeof(curtname));
 #endif
         snprintf(newtname, sizeof(newtname), "av%d%s%s",


### PR DESCRIPTION
pthread_setname_np is a nonstandard GNU extension so put back its
detection, deleted by commit ab5835d43595ffc6e3b88b2ea5e4cd87a8c53e14,
to be able to cross-compile motion with non glibc toolchains

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>