### PR TITLE
Fix ioctl sign-extension warning on FreeBSD

### DIFF
--- a/video_v4l2.c
+++ b/video_v4l2.c
@@ -165,7 +165,7 @@ typedef struct {
 /**
  * xioctl
  */
-#ifdef __OpenBSD__
+#if defined (__OpenBSD__) || defined (__FreeBSD__)
 static int xioctl(src_v4l2_t *vid_source, unsigned long request, void *arg)
 #else
 static int xioctl(src_v4l2_t *vid_source, int request, void *arg)


### PR DESCRIPTION
I was running Motion 4.0.1 on FreeBSD 10.3-STABLE amd64. After connecting a webcam (Logitech C920). the console gives a continues stream of messages like this:

May 26 13:42:11 aurora kernel: WARNING pid 40273 (motion): ioctl sign-extension ioctl ffffffffc058560f
May 26 13:42:11 aurora kernel: WARNING pid 40273 (motion): ioctl sign-extension ioctl ffffffffc0585611
May 26 13:42:11 aurora kernel: WARNING pid 40273 (motion): ioctl sign-extension ioctl ffffffffc058560f
May 26 13:42:11 aurora kernel: WARNING pid 40273 (motion): ioctl sign-extension ioctl ffffffffc0585611
... etc.

This patch fixes that by making sure that the ioct() call gets a proper unsigned long request parameter.