### PR TITLE
Updating INSTALL information

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -25,12 +25,14 @@ FFMPEG Packages
     libavcodec-dev
     libavutil-dev
     libswscale-dev
+    libavdevice-dev
 
 Libav Packages
     libavformat-dev
     libavcodec-dev
     libavutil-dev
     libswscale-dev
+    libavdevice-dev
 
 Once required packages are installed, execute:
     autoreconf -fiv


### PR DESCRIPTION
Added libavdevice-dev to the list of dependencies.. because it was not listed in this docfile, but while ./configure it throws error message like:
"configure: error: Required ffmpeg packages 'libavutil-dev libavformat-dev libavcodec-dev libswscale-dev libavdevice-dev' were not found."