### PR TITLE
Revert "Eliminate pauses in movies during events"

### DIFF
--- a/motion.c
+++ b/motion.c
@@ -2061,15 +2061,6 @@ static void mlp_actions(struct context *cnt){
         if (frame_count >= cnt->conf.minimum_motion_frames) {
 
             cnt->current_image->flags |= (IMAGE_TRIGGER | IMAGE_SAVE);
-            /*  If we were previously detecting motion, started a movie, then got
-             *  no motion then we reset the start movie time so that we do not
-             *  get a pause in the movie.
-            */
-            if ( (cnt->detecting_motion == 0) && (cnt->ffmpeg_output != NULL) ) {
-                cnt->ffmpeg_output->start_time.tv_sec=cnt->current_image->timestamp_tv.tv_sec;
-                cnt->ffmpeg_output->start_time.tv_usec=cnt->current_image->timestamp_tv.tv_usec;
-            }
-
             cnt->detecting_motion = 1;
 
             /* Setup the postcap counter */


### PR DESCRIPTION
This reverts commit 686b75a35fb2363c932b61deaf44ff35a524a329.

Resetting the movie start_time is bad for H264 encoders because it sets the PTS backwards. PTS has to be increasing monotonically.

The PTS value is based on pts_interval, which is the time difference between the start of movie and the current frame we're encoding. When we reset the movie start_time to a later time, we are essentially reducing the PTS value, and there's a code that catches bad timing in ffmpeg.c, and increments PTS value by 1 time unit. The effect of this is a lot of frames encoded into a short period of time, i.e. fast playback when there's motion-->no_motion-->motion.

Elimination of pauses in movies needs to be implemented properly.