### PR TITLE
Fix movie gap elimination setting incorrect PTS

### DIFF
--- a/event.c
+++ b/event.c
@@ -733,6 +733,7 @@ static void event_ffmpeg_newfile(struct context *cnt,
         cnt->ffmpeg_output->start_time.tv_sec = currenttime_tv->tv_sec;
         cnt->ffmpeg_output->start_time.tv_usec = currenttime_tv->tv_usec;
         cnt->ffmpeg_output->last_pts = 0;
+        cnt->ffmpeg_output->base_pts = 0;
         cnt->ffmpeg_output->gop_cnt = 0;
         cnt->ffmpeg_output->codec_name = codec;
         if (strcmp(cnt->conf.ffmpeg_video_codec, "test") == 0) {
@@ -763,6 +764,7 @@ static void event_ffmpeg_newfile(struct context *cnt,
         cnt->ffmpeg_output_debug->start_time.tv_sec = currenttime_tv->tv_sec;
         cnt->ffmpeg_output_debug->start_time.tv_usec = currenttime_tv->tv_usec;
         cnt->ffmpeg_output_debug->last_pts = 0;
+        cnt->ffmpeg_output_debug->base_pts = 0;
         cnt->ffmpeg_output_debug->gop_cnt = 0;
         cnt->ffmpeg_output_debug->codec_name = codec;
         if (strcmp(cnt->conf.ffmpeg_video_codec, "test") == 0) {
@@ -818,6 +820,7 @@ static void event_ffmpeg_timelapse(struct context *cnt,
         cnt->ffmpeg_timelapse->start_time.tv_sec = currenttime_tv->tv_sec;
         cnt->ffmpeg_timelapse->start_time.tv_usec = currenttime_tv->tv_usec;
         cnt->ffmpeg_timelapse->last_pts = 0;
+        cnt->ffmpeg_timelapse->base_pts = 0;
         cnt->ffmpeg_timelapse->test_mode = 0;
         cnt->ffmpeg_timelapse->gop_cnt = 0;
 

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -429,25 +429,21 @@ static int ffmpeg_set_pts(struct ffmpeg *ffmpeg, const struct timeval *tv1){
             ffmpeg->start_time.tv_usec = tv1->tv_usec ;
             pts_interval = 0;
         }
-        pts_interval += ffmpeg->base_pts;
-        if (pts_interval == 0)
-            pts_interval++;
-        if (pts_interval <= ffmpeg->last_pts){
-            //We have a problem with our motion loop timing and sending frames.  Increment by just 1 to at least keep frame in movie.
-            pts_interval = ffmpeg->last_pts + 1;
-            if (ffmpeg->test_mode == 1){
-                MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s: BAD TIMING!! PTS reset to incremental counter new PTS %d ", pts_interval);
-            }
-        }
-        // Convert pts_interval to stream time base
-        ffmpeg->pkt.pts = av_rescale_q(pts_interval,(AVRational){1, 1000000L},ffmpeg->video_st->time_base)  + 1;
+        ffmpeg->pkt.pts = av_rescale_q(pts_interval,(AVRational){1, 1000000L},ffmpeg->video_st->time_base) + ffmpeg->base_pts;
 
         if (ffmpeg->test_mode == 1){
             MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s: ms interval %d PTS %d timebase %d-%d",pts_interval,ffmpeg->pkt.pts,ffmpeg->video_st->time_base.num,ffmpeg->video_st->time_base.den);
         }
 
+        if (ffmpeg->pkt.pts <= ffmpeg->last_pts){
+            //We have a problem with our motion loop timing and sending frames.  Increment by just 1 to at least keep frame in movie.
+            ffmpeg->pkt.pts = ffmpeg->last_pts + 1;
+            if (ffmpeg->test_mode == 1){
+                MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s: BAD TIMING!! PTS reset to incremental counter new PTS %d ",ffmpeg->pkt.pts);
+            }
+        }
         ffmpeg->pkt.dts = ffmpeg->pkt.pts;
-        ffmpeg->last_pts = pts_interval;
+        ffmpeg->last_pts = ffmpeg->pkt.pts;
     }
     return 0;
 }
@@ -931,3 +927,19 @@ int ffmpeg_put_image(struct ffmpeg *ffmpeg, unsigned char *image, const struct t
 #endif // HAVE_FFMPEG
 }
 
+void ffmpeg_reset_movie_start_time(struct ffmpeg *ffmpeg, const struct timeval *tv1){
+#ifdef HAVE_FFMPEG
+    int64_t one_frame_interval = av_rescale_q(1,(AVRational){1, ffmpeg->fps},ffmpeg->video_st->time_base);
+    if (one_frame_interval <= 0)
+        one_frame_interval = 1;
+    ffmpeg->base_pts = ffmpeg->last_pts + one_frame_interval;
+
+    ffmpeg->start_time.tv_sec = tv1->tv_sec;
+    ffmpeg->start_time.tv_usec = tv1->tv_usec;
+
+#else
+    if (ffmpeg && tv1) {
+        MOTION_LOG(DBG, TYPE_ENCODER, NO_ERRNO, "%s: No ffmpeg support");
+    }
+#endif // HAVE_FFMPEG
+}

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -52,6 +52,7 @@ struct ffmpeg {
     int vbr;
     const char *codec_name;
     int64_t last_pts;
+    int64_t base_pts;
     int test_mode;
     int gop_cnt;
     struct timeval start_time;

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -78,5 +78,6 @@ void ffmpeg_avcodec_log(void *, int, const char *, va_list);
 int ffmpeg_open(struct ffmpeg *ffmpeg);
 int ffmpeg_put_image(struct ffmpeg *ffmpeg, unsigned char *image, const struct timeval *tv1);
 void ffmpeg_close(struct ffmpeg *ffmpeg);
+void ffmpeg_reset_movie_start_time(struct ffmpeg *ffmpeg, const struct timeval *tv1);
 
 #endif /* _INCLUDE_FFMPEG_H_ */

--- a/motion.c
+++ b/motion.c
@@ -2066,6 +2066,7 @@ static void mlp_actions(struct context *cnt){
              *  get a pause in the movie.
             */
             if ( (cnt->detecting_motion == 0) && (cnt->ffmpeg_output != NULL) ) {
+                cnt->ffmpeg_output->base_pts = cnt->ffmpeg_output->last_pts + 1000000L / cnt->movie_fps;
                 cnt->ffmpeg_output->start_time.tv_sec=cnt->current_image->timestamp_tv.tv_sec;
                 cnt->ffmpeg_output->start_time.tv_usec=cnt->current_image->timestamp_tv.tv_usec;
             }

--- a/motion.c
+++ b/motion.c
@@ -2065,11 +2065,8 @@ static void mlp_actions(struct context *cnt){
              *  no motion then we reset the start movie time so that we do not
              *  get a pause in the movie.
             */
-            if ( (cnt->detecting_motion == 0) && (cnt->ffmpeg_output != NULL) ) {
-                cnt->ffmpeg_output->base_pts = cnt->ffmpeg_output->last_pts + 1000000L / cnt->movie_fps;
-                cnt->ffmpeg_output->start_time.tv_sec=cnt->current_image->timestamp_tv.tv_sec;
-                cnt->ffmpeg_output->start_time.tv_usec=cnt->current_image->timestamp_tv.tv_usec;
-            }
+            if ( (cnt->detecting_motion == 0) && (cnt->ffmpeg_output != NULL) )
+                ffmpeg_reset_movie_start_time(cnt->ffmpeg_output, &cnt->current_image->timestamp_tv);
 
             cnt->detecting_motion = 1;
 


### PR DESCRIPTION
We eliminate gaps in movie (motion-->no_motion-->motion) by resetting movie start time. By doing so, we unintentionally reset the PTS value that has to be monotonically increasing, which triggers the error handling code that forces PTS to increment by 1 time unit per frame. The effect is a lot of frames are encoded into a short duration of few seconds, i.e. fast playback.

This PR does two things:
- Change last_pts to store pts_interval (in micro-seconds) instead of packet PTS (in stream time base unit). This allows us to store last_pts into base_pts in micro-seconds time base so it can be manipulated later.
- When we reset the movie start_time, we store last_pts into base_pts plus 1 frame duration, because it takes at least 1 frame to change cnt->detecting_motion state. In effect, this gives us a smooth playback experience.
