### PR TITLE
WIP: Log client IP (stream, webcontrol) where useful

### DIFF
--- a/stream.c
+++ b/stream.c
@@ -47,7 +47,7 @@ struct auth_param {
 static void get_host(char *buf, int fd)
 {
     struct sockaddr_storage client;
-    socklen_t client_len;
+    socklen_t client_len = sizeof(client);
     int res = getpeername(fd, (struct sockaddr *)&client, &client_len);
     if (res != 0)
         return;

--- a/stream.c
+++ b/stream.c
@@ -39,6 +39,27 @@ struct auth_param {
     struct config *conf;
 };
 
+/**
+ * get_host
+ *      Gets the host (IP) of a client from the socket file descriptor
+ * Returns nothing
+ */
+static void get_host(char *buf, int fd)
+{
+    struct sockaddr_storage client;
+    socklen_t client_len;
+    int res = getpeername(fd, (struct sockaddr *)&client, &client_len);
+    if (res != 0)
+        return;
+
+    char host[NI_MAXHOST];
+    res = getnameinfo((struct sockaddr *)&client, client_len, host, sizeof(host), NULL, 0, NI_NUMERICHOST);
+    if (res != 0)
+        return;
+
+    strncpy(buf, host, NI_MAXHOST - 1);
+}
+
 pthread_mutex_t stream_auth_mutex;
 
 /**
@@ -217,6 +238,9 @@ static void* handle_basic_auth(void* param)
 
         if (strcmp(auth, authentication)) {
             free(authentication);
+            char host[NI_MAXHOST] = "unknown";
+            get_host(host, p->sock);
+            MOTION_LOG(ALR, TYPE_STREAM, NO_ERRNO, "motion-stream - failed auth attempt from %s", host);
             goto Error;
         }
         free(authentication);

--- a/webhttpd.c
+++ b/webhttpd.c
@@ -341,7 +341,7 @@ static void response_client(int client_socket, const char *template, char *back)
 static void get_host(char *buf, int fd)
 {
     struct sockaddr_in6 client;
-    socklen_t client_len;
+    socklen_t client_len = sizeof(client);
     int res = getpeername(fd, (struct sockaddr *)&client, &client_len);
     if (res != 0)
         return;
@@ -2661,7 +2661,6 @@ void httpd_run(struct context **cnt)
         } else {
             /* Get the Client request */
             client_sent_quit_message = read_client(client_socket_fd, cnt, authentication);
-            MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "motion-httpd - Read from client");
             char host[NI_MAXHOST] = "unknown";
             get_host(host, client_socket_fd);
             MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "motion-httpd - Read from client (%s)", host);

--- a/webhttpd.c
+++ b/webhttpd.c
@@ -334,6 +334,27 @@ static void response_client(int client_socket, const char *template, char *back)
 }
 
 /**
+ * get_host
+ *      Gets the host (IP) of a client from the socket file descriptor
+ * Returns nothing
+ */
+static void get_host(char *buf, int fd)
+{
+    struct sockaddr_in6 client;
+    socklen_t client_len;
+    int res = getpeername(fd, (struct sockaddr *)&client, &client_len);
+    if (res != 0)
+        return;
+
+    char host[NI_MAXHOST];
+    res = getnameinfo((struct sockaddr *)&client, client_len, host, sizeof(host), NULL, 0, NI_NUMERICHOST);
+    if (res != 0)
+        return;
+
+    strncpy(buf, host, NI_MAXHOST - 1);
+}
+
+/**
  * replace
  */
 static char *replace(const char *str, const char *old, const char *new)
@@ -2520,6 +2541,9 @@ static unsigned int read_client(int client_socket, void *userdata, char *auth)
                         char response[1024] = {'\0'};
                         snprintf(response, sizeof (response), request_auth_response_template, method);
                         warningkill = write_nonblock(client_socket, response, strlen(response));
+                        char host[NI_MAXHOST] = "unknown";
+                        get_host(host, client_socket);
+                        MOTION_LOG(ALR, TYPE_STREAM, NO_ERRNO, "motion-httpd - failed auth attempt from %s", host);
                         free(hostname);
                         pthread_mutex_unlock(&httpd_mutex);
                         return 1;
@@ -2638,6 +2662,9 @@ void httpd_run(struct context **cnt)
             /* Get the Client request */
             client_sent_quit_message = read_client(client_socket_fd, cnt, authentication);
             MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "motion-httpd - Read from client");
+            char host[NI_MAXHOST] = "unknown";
+            get_host(host, client_socket_fd);
+            MOTION_LOG(NTC, TYPE_STREAM, NO_ERRNO, "motion-httpd - Read from client (%s)", host);
 
             /* Close Connection */
             if (client_socket_fd)


### PR DESCRIPTION
## Enhancement
This PR adds the requested functionality from #348.
- Add a log line including client IP to failed auth attempts in both stream and webcontrol.
- Add client IP to the generic webcontrol 'read request' log line.

### Testing
Successfully tested on both stream and webcontrol with:
- [x] IPv4
- [ ] IPv6
I don't have IPv6 within my LAN. I could probably spin up a temp VPS with v6 to test this at some point; unless someone else can test this on their current (dev) setup.

#### Disclaimers
My C is a little rusty and I haven't dealt with sockets much before. Any suggestions are welcome.
_~~This will conflict with #428 (log macro)~~ (rebased and resolved)_