### PR TITLE
Additional PTS Changes

### DIFF
--- a/event.c
+++ b/event.c
@@ -732,7 +732,7 @@ static void event_ffmpeg_newfile(struct context *cnt,
         cnt->ffmpeg_output->vbr = cnt->conf.ffmpeg_vbr;
         cnt->ffmpeg_output->start_time.tv_sec = currenttime_tv->tv_sec;
         cnt->ffmpeg_output->start_time.tv_usec = currenttime_tv->tv_usec;
-        cnt->ffmpeg_output->last_pts = 0;
+        cnt->ffmpeg_output->last_pts = -1;
         cnt->ffmpeg_output->base_pts = 0;
         cnt->ffmpeg_output->gop_cnt = 0;
         cnt->ffmpeg_output->codec_name = codec;
@@ -763,7 +763,7 @@ static void event_ffmpeg_newfile(struct context *cnt,
         cnt->ffmpeg_output_debug->vbr = cnt->conf.ffmpeg_vbr;
         cnt->ffmpeg_output_debug->start_time.tv_sec = currenttime_tv->tv_sec;
         cnt->ffmpeg_output_debug->start_time.tv_usec = currenttime_tv->tv_usec;
-        cnt->ffmpeg_output_debug->last_pts = 0;
+        cnt->ffmpeg_output_debug->last_pts = -1;
         cnt->ffmpeg_output_debug->base_pts = 0;
         cnt->ffmpeg_output_debug->gop_cnt = 0;
         cnt->ffmpeg_output_debug->codec_name = codec;
@@ -819,7 +819,7 @@ static void event_ffmpeg_timelapse(struct context *cnt,
         cnt->ffmpeg_timelapse->vbr = cnt->conf.ffmpeg_vbr;
         cnt->ffmpeg_timelapse->start_time.tv_sec = currenttime_tv->tv_sec;
         cnt->ffmpeg_timelapse->start_time.tv_usec = currenttime_tv->tv_usec;
-        cnt->ffmpeg_timelapse->last_pts = 0;
+        cnt->ffmpeg_timelapse->last_pts = -1;
         cnt->ffmpeg_timelapse->base_pts = 0;
         cnt->ffmpeg_timelapse->test_mode = 0;
         cnt->ffmpeg_timelapse->gop_cnt = 0;


### PR DESCRIPTION
1.  Revise the PTS to allow for the capture of the first image by revising the initialization of last_pts
2.  Elminate the incrementing by 1 when we have timing issues since this puts all subsequent
    frames out of sync with timing/pts problems
3.  Unref the packets when encode and PTS functions return errors to prevent leaks.
4.  Revise logging to report more values when in test mode.