### PR TITLE
fix logging of int64 PTS values

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -431,7 +431,9 @@ static int ffmpeg_set_pts(struct ffmpeg *ffmpeg, const struct timeval *tv1){
         ffmpeg->pkt.pts = av_rescale_q(pts_interval,(AVRational){1, 1000000L},ffmpeg->video_st->time_base) + ffmpeg->base_pts;
 
         if (ffmpeg->test_mode == 1){
-            MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "PTS %d Base PTS %d ms interval %d timebase %d-%d",ffmpeg->pkt.pts,ffmpeg->base_pts,pts_interval,ffmpeg->video_st->time_base.num,ffmpeg->video_st->time_base.den);
+            MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "PTS %"PRId64" Base PTS %"PRId64" ms interval %"PRId64" timebase %d-%d",
+                       ffmpeg->pkt.pts,ffmpeg->base_pts,pts_interval,
+                       ffmpeg->video_st->time_base.num,ffmpeg->video_st->time_base.den);
         }
 
         if (ffmpeg->pkt.pts <= ffmpeg->last_pts){


### PR DESCRIPTION
All PTS values are int64_t type, but on 32-bit machines, %d is 32-bits, so we end up printing the wrong values.
This PR changes %d to a more cross-platform friendly but ugly C99 macro PRId64.