### PR TITLE
On mobiles text inside the WEB UI is to small.

### DIFF
--- a/webhttpd.c
+++ b/webhttpd.c
@@ -29,6 +29,7 @@ static const char *ini_template =
     "<!DOCTYPE html>\n"
     "<html>\n"
     "<head><title>Motion "VERSION"</title></head>\n"
+    "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, user-scalable=yes\">"
     "<body>\n";
 
 static const char *set_template =


### PR DESCRIPTION
using "viewport" to solve that. see:
#381
#437

i just insert one line:
"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0, user-scalable=yes\">"

my first pullrequest...

2 screenshots. 1st small text. 2nd with "viewport"

![small_text](https://user-images.githubusercontent.com/22706487/28838994-78ccb33c-76f2-11e7-879a-0d3dad7ba9a0.png)


![with_viewport](https://user-images.githubusercontent.com/22706487/28838985-70f860a2-76f2-11e7-9b05-217827ff78ab.png)
