### PR TITLE
fix close all fds off by one error

### DIFF
--- a/event.c
+++ b/event.c
@@ -77,7 +77,7 @@ static void exec_command(struct context *cnt, char *command, char *filename, int
          * Close any file descriptor except console because we will
          * like to see error messages
          */
-        for (i = getdtablesize(); i > 2; --i)
+        for (i = getdtablesize() - 1; i > 2; i--)
             close(i);
 
         execl("/bin/sh", "sh", "-c", stamp, " &", NULL);


### PR DESCRIPTION
Fix close all file descriptors off by 1 error.

According to documentation, getdtablesize() returns the maximum number of files a process can have open, one more than the largest possible value for a file descriptor.

That means we close file descriptors starting from getdtablesize() - 1.