### PR TITLE
autoconf: allow out-of-tree builds.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -40,12 +40,14 @@ OBJ          = motion.o logger.o conf.o draw.o jpegutils.o \
 			   alg.o event.o picture.o rotate.o webhttpd.o \
 			   stream.o md5.o netcam_rtsp.o ffmpeg.o \
 			   @MMAL_OBJ@ @SQLITE_OBJ@
-SRC          = $(OBJ:.o=.c)
+SRC          = $(foreach obj,$(OBJ:.o=.c),@top_srcdir@/$(obj))
 DOC          = CHANGELOG COPYING CREDITS README.md motion_guide.html mask1.png normal.jpg outputmotion1.jpg outputnormal1.jpg
+DOC_FILES    = $(foreach doc,$(DOC),@top_srcdir@/$(doc))
 EXAMPLES     = *.conf motion.service
 EXAMPLES_BIN = motion.init-Debian motion.init-FreeBSD.sh
 PROGS        = motion
 DEPEND_FILE  = .depend
+
 
 ################################################################################
 # ALL and PROGS build Motion and, possibly, Motion-control.                    #
@@ -99,9 +101,9 @@ pre-mobject-info:
 ################################################################################
 # Define the compile command for C files.                                      #
 ################################################################################
-#%.o: %.c
-#	@echo -e "\tCompiling $< into $@..."
-#	@$(CC) -c $(CFLAGS) $< -o $@
+%.o: @top_srcdir@/%.c
+	@echo -e "\tCompiling $< into $@..."
+	@$(CC) -c $(CFLAGS) -I@top_builddir@ $< -o $@
 
 ################################################################################
 # Include the dependency file if it exists.                                    #
@@ -120,7 +122,7 @@ endif
 ################################################################################
 $(DEPEND_FILE): *.h $(SRC)
 	@echo "Generating dependencies, please wait..."
-	@$(CC) $(CFLAGS) -M $(SRC) > .tmp
+	@$(CC) $(CFLAGS) -I@top_builddir@ -M $(SRC) > .tmp
 	@mv -f .tmp $(DEPEND_FILE)
 	@echo
 
@@ -175,8 +177,8 @@ install:
 	@sed -e 's|$${prefix}|$(prefix)|' camera2-dist.conf > camera2-dist.conf.tmp && mv -f camera2-dist.conf.tmp camera2-dist.conf
 	@sed -e 's|$${prefix}|$(prefix)|' camera3-dist.conf > camera3-dist.conf.tmp && mv -f camera3-dist.conf.tmp camera3-dist.conf
 	@sed -e 's|$${prefix}|$(prefix)|' camera4-dist.conf > camera4-dist.conf.tmp && mv -f camera4-dist.conf.tmp camera4-dist.conf
-	$(INSTALL_DATA) motion.1 $(DESTDIR)$(mandir)/man1
-	$(INSTALL_DATA) $(DOC) $(DESTDIR)$(docdir)
+	$(INSTALL_DATA) @top_srcdir@/motion.1 $(DESTDIR)$(mandir)/man1
+	$(INSTALL_DATA) $(DOC_FILES) $(DESTDIR)$(docdir)
 	$(INSTALL_DATA) $(EXAMPLES) $(DESTDIR)$(examplesdir)
 	$(INSTALL) $(EXAMPLES_BIN) $(DESTDIR)$(examplesdir)
 	$(INSTALL_DATA) motion-dist.conf $(DESTDIR)$(sysconfdir)/motion


### PR DESCRIPTION
Fix `Makefile.in` so that it doesn't require build tree to be the same as the source tree.