### PR TITLE
Tune h264_omx encode video quality

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -451,6 +451,7 @@ static int ffmpeg_set_pts(struct ffmpeg *ffmpeg, const struct timeval *tv1){
 
 static int ffmpeg_set_quality(struct ffmpeg *ffmpeg){
 
+    char crf[4];
     int bit_rate;
 
     ffmpeg->opts = 0;
@@ -465,9 +466,10 @@ static int ffmpeg_set_quality(struct ffmpeg *ffmpeg){
             bit_rate = ffmpeg->bps;
             ffmpeg->vbr = 28;
         }
+        snprintf(crf, 4, "%d",ffmpeg->vbr);
         av_dict_set(&ffmpeg->opts, "preset", "ultrafast", 0);
         av_dict_set(&ffmpeg->opts, "tune", "zerolatency", 0);
-        av_dict_set_int(&ffmpeg->opts, "crf", ffmpeg->vbr, 0);
+        av_dict_set(&ffmpeg->opts, "crf", crf, 0);
         if ((strcmp(ffmpeg->codec->name, "h264_omx") == 0) || (strcmp(ffmpeg->codec->name, "mpeg4_omx") == 0)) {
             // Clip bit rate to min and max
             if (bit_rate < 40000)

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -451,7 +451,7 @@ static int ffmpeg_set_pts(struct ffmpeg *ffmpeg, const struct timeval *tv1){
 
 static int ffmpeg_set_quality(struct ffmpeg *ffmpeg){
 
-    char crf[4];
+    int bit_rate;
 
     ffmpeg->opts = 0;
     if (ffmpeg->vbr > 100) ffmpeg->vbr = 100;
@@ -459,13 +459,24 @@ static int ffmpeg_set_quality(struct ffmpeg *ffmpeg){
         ffmpeg->ctx_codec->codec_id == MY_CODEC_ID_HEVC){
         if (ffmpeg->vbr > 0) {
             ffmpeg->vbr = (int)(( (100-ffmpeg->vbr) * 51)/100);
+            //bit_rate = ffmpeg->width * ffmpeg->height * ffmpeg->fps * quality_factor
+            bit_rate = (ffmpeg->width * ffmpeg->height * ffmpeg->fps * ffmpeg->vbr) >> 8;
         } else {
+            bit_rate = ffmpeg->bps;
             ffmpeg->vbr = 28;
         }
-       snprintf(crf, 4, "%d",ffmpeg->vbr);
-       av_dict_set(&ffmpeg->opts, "preset", "ultrafast", 0);
-       av_dict_set(&ffmpeg->opts, "tune", "zerolatency", 0);
-       av_dict_set(&ffmpeg->opts, "crf", crf, 0);
+        av_dict_set(&ffmpeg->opts, "preset", "ultrafast", 0);
+        av_dict_set(&ffmpeg->opts, "tune", "zerolatency", 0);
+        av_dict_set_int(&ffmpeg->opts, "crf", ffmpeg->vbr, 0);
+        if ((strcmp(ffmpeg->codec->name, "h264_omx") == 0) || (strcmp(ffmpeg->codec->name, "mpeg4_omx") == 0)) {
+            // Clip bit rate to min and max
+            if (bit_rate < 40000)
+                bit_rate = 40000;
+            else if (bit_rate > 3000000)
+                bit_rate = 3000000;
+            ffmpeg->ctx_codec->profile = FF_PROFILE_H264_HIGH;
+            ffmpeg->ctx_codec->bit_rate = bit_rate;
+        }
     } else {
         /* The selection of 8000 in the else is a subjective number based upon viewing output files */
         if (ffmpeg->vbr > 0){

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -451,33 +451,29 @@ static int ffmpeg_set_pts(struct ffmpeg *ffmpeg, const struct timeval *tv1){
 
 static int ffmpeg_set_quality(struct ffmpeg *ffmpeg){
 
-    char crf[4];
-    int bit_rate;
-
     ffmpeg->opts = 0;
     if (ffmpeg->vbr > 100) ffmpeg->vbr = 100;
     if (ffmpeg->ctx_codec->codec_id == MY_CODEC_ID_H264 ||
         ffmpeg->ctx_codec->codec_id == MY_CODEC_ID_HEVC){
-        if (ffmpeg->vbr > 0) {
-            ffmpeg->vbr = (int)(( (100-ffmpeg->vbr) * 51)/100);
-            //bit_rate = ffmpeg->width * ffmpeg->height * ffmpeg->fps * quality_factor
-            bit_rate = (ffmpeg->width * ffmpeg->height * ffmpeg->fps * ffmpeg->vbr) >> 8;
-        } else {
-            bit_rate = ffmpeg->bps;
-            ffmpeg->vbr = 28;
-        }
-        snprintf(crf, 4, "%d",ffmpeg->vbr);
+        if (ffmpeg->vbr <= 0)
+            ffmpeg->vbr = 45; // default to 45% quality
         av_dict_set(&ffmpeg->opts, "preset", "ultrafast", 0);
         av_dict_set(&ffmpeg->opts, "tune", "zerolatency", 0);
-        av_dict_set(&ffmpeg->opts, "crf", crf, 0);
         if ((strcmp(ffmpeg->codec->name, "h264_omx") == 0) || (strcmp(ffmpeg->codec->name, "mpeg4_omx") == 0)) {
-            // Clip bit rate to min and max
-            if (bit_rate < 40000)
-                bit_rate = 40000;
-            else if (bit_rate > 3000000)
-                bit_rate = 3000000;
+            // H264 OMX encoder quality can only be controlled via bit_rate
+            // bit_rate = ffmpeg->width * ffmpeg->height * ffmpeg->fps * quality_factor
+            ffmpeg->vbr = (ffmpeg->width * ffmpeg->height * ffmpeg->fps * ffmpeg->vbr) >> 7;
+            // Clip bit rate to min
+            if (ffmpeg->vbr < 4000) // magic number
+                ffmpeg->vbr = 4000;
             ffmpeg->ctx_codec->profile = FF_PROFILE_H264_HIGH;
-            ffmpeg->ctx_codec->bit_rate = bit_rate;
+            ffmpeg->ctx_codec->bit_rate = ffmpeg->vbr;
+        } else {
+            // Control other H264 encoders quality via CRF
+            char crf[4];
+            ffmpeg->vbr = (int)(( (100-ffmpeg->vbr) * 51)/100);
+            snprintf(crf, 4, "%d", ffmpeg->vbr);
+            av_dict_set(&ffmpeg->opts, "crf", crf, 0);
         }
     } else {
         /* The selection of 8000 in the else is a subjective number based upon viewing output files */
@@ -487,7 +483,7 @@ static int ffmpeg_set_quality(struct ffmpeg *ffmpeg){
             ffmpeg->ctx_codec->global_quality=ffmpeg->vbr;
         }
     }
-    MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "vbr/crf for codec: %d", ffmpeg->vbr);
+    MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO, "%s codec vbr/crf/bit_rate: %d", ffmpeg->codec->name, ffmpeg->vbr);
 
     return 0;
 }


### PR DESCRIPTION
h264_omx encoder does not take CRF option. Video quality can only be set via bit rate option.
