### PR TITLE
Netcam Boundary

### DIFF
--- a/netcam.c
+++ b/netcam.c
@@ -659,6 +659,10 @@ static int netcam_read_first_header(netcam_context_ptr netcam)
 
                      MOTION_LOG(INF, TYPE_NETCAM, NO_ERRNO, "Boundary string [%s]",
                                 netcam->boundary);
+                } else {
+                    MOTION_LOG(NTC, TYPE_NETCAM, NO_ERRNO, "Boundary string not found in header");
+                    free(header);
+                    return -1;
                 }
                 break;
             case 3:  /* MJPG-Block style streaming. */


### PR DESCRIPTION
If the boundary is not found for http streaming netcams in the header report and return error code.

Closes #389 