### PR TITLE
Developer Warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,14 @@
 before_script:
   - autoreconf -fiv
-script: ./configure && make
-
+script: ./configure --with-developer-flags && make
 matrix:
   include:
+  - os: osx
+    language: c
+    compiler: gcc
   - os: linux
     language: c
     compiler: gcc
-    addons:
-      apt:
-        packages:
-        - libavformat-dev
-        - libavcodec-dev
-        - libavutil-dev
-        - libswscale-dev
-        - libavdevice-dev
-        - libjpeg8-dev
-        - libzip-dev
-  - os: linux
-    language: c
-    compiler: gcc
-    dist: trusty
     addons:
       apt:
         sources:
@@ -33,4 +21,24 @@ matrix:
         - libavdevice-dev
         - libjpeg8-dev
         - libzip-dev
+  - os: linux
+    language: c
+    compiler: gcc
+    addons:
+      apt:
+        packages:
+        - libavformat-dev
+        - libavcodec-dev
+        - libavutil-dev
+        - libswscale-dev
+        - libavdevice-dev
+        - libjpeg8-dev
+        - libzip-dev
+before_install:
+    - if [ $TRAVIS_OS_NAME = osx ]; then 
+        brew upgrade ffmpeg;
+        brew upgrade pkg-config;
+        brew upgrade jpeg;
+        brew install ffmpeg pkg-config libjpeg;
+      fi;
 

--- a/conf.c
+++ b/conf.c
@@ -1911,9 +1911,9 @@ void conf_print(struct context **cnt)
                     free(val);
                 } else if (thread == 0) {
                     /* The 'camera_dir' option should keep the installed default value */
-                    val = "value";
+                    sprintf(val, "%s","value");
                     if (!strncmp(config_params[i].param_name, "camera_dir", 10))
-                        val =  sysconfdir"/motion/conf.d";
+                        sprintf(val, "%s",sysconfdir"/motion/conf.d");
 
                     fprintf(conffile, "%s\n", config_params[i].param_help);
                     fprintf(conffile, "; %s %s\n\n", config_params[i].param_name, val);

--- a/configure.ac
+++ b/configure.ac
@@ -564,7 +564,7 @@ AC_ARG_WITH([developer-flags],
     [DEVELOPER_FLAGS=no])
 
 if test "${DEVELOPER_FLAGS}" = "yes"; then
-    TEMP_CFLAGS="${TEMP_CFLAGS} -W -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Winline -Wredundant-decls -Wno-long-long -ggdb -g3"
+    TEMP_CFLAGS="${TEMP_CFLAGS} -W -Werror -Wall -Wextra -Wformat -Wshadow -Wpointer-arith -Wwrite-strings -Waggregate-return -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Winline -Wredundant-decls -Wno-long-long -ggdb -g3"
 fi
 
 CFLAGS="${TEMP_CFLAGS} $CPU_OPTIONS"

--- a/jpegutils.c
+++ b/jpegutils.c
@@ -230,7 +230,7 @@ int jpgutl_decode_jpeg (unsigned char *jpeg_data_in, int jpeg_data_len,
 {
     JSAMPARRAY      line;           /* Array of decomp data lines */
     unsigned char  *wline;          /* Will point to line[0] */
-    int             i;
+    unsigned int    i;
     unsigned char  *img_y, *img_cb, *img_cr;
     unsigned char   offset_y;
 

--- a/motion.c
+++ b/motion.c
@@ -1358,12 +1358,13 @@ static void mlp_mask_privacy(struct context *cnt){
   // Mask brightness.
   //
   int index = pixels;
+  int increment = sizeof(unsigned long);
 
-  while (index >= sizeof(unsigned long)) {
+  while (index >= increment) {
      *((unsigned long *)image) &= *((unsigned long *)mask);
-     image += sizeof(unsigned long);
-     mask += sizeof(unsigned long);
-     index -= sizeof(unsigned long);
+     image += increment;
+     mask += increment;
+     index -= increment;
   }
   while (--index >= 0) {
      *(image++) &= *(mask++);
@@ -1374,8 +1375,8 @@ static void mlp_mask_privacy(struct context *cnt){
   index = cnt->imgs.size - pixels;
   const unsigned char *maskuv = cnt->imgs.mask_privacy_uv;
 
-  while (index >= sizeof(unsigned long)) {
-     index -= sizeof(unsigned long);
+  while (index >= increment) {
+     index -= increment;
      /*
       * Replace the masked bytes with 0x080. This is done using two masks:
       * the normal privacy mask is used to clear the masked bits, the
@@ -1383,10 +1384,10 @@ static void mlp_mask_privacy(struct context *cnt){
       * is that we process 4 or 8 bytes in just two operations.
       */
      *((unsigned long *)image) &= *((unsigned long *)mask);
-     mask += sizeof(unsigned long);
+     mask += increment;
      *((unsigned long *)image) |= *((unsigned long *)maskuv);
-     maskuv += sizeof(unsigned long);
-     image += sizeof(unsigned long);
+     maskuv += increment;
+     image += increment;
   }
   while (--index >= 0) {
      if (*(mask++) == 0x00) *image = 0x80; // Mask last remaining bytes.

--- a/rotate.c
+++ b/rotate.c
@@ -76,11 +76,11 @@ static void reverse_inplace_quad(unsigned char *src, int size)
 static void flip_inplace_horizontal(unsigned char *src, int width, int height) {
     uint8_t *nsrc, *ndst;
     register uint8_t tmp;
-    unsigned int l,w;
+    int l,w;
 
     for(l=0; l < height/2; l++) {
-        nsrc = (uint8_t *)(src + l*width); 
-        ndst = (uint8_t *)(src + (width*(height-l-1))); 
+        nsrc = (uint8_t *)(src + l*width);
+        ndst = (uint8_t *)(src + (width*(height-l-1)));
         for(w=0; w < width; w++) {
             tmp =*ndst;
             *ndst++ = *nsrc;
@@ -94,11 +94,11 @@ static void flip_inplace_vertical(unsigned char *src, int width, int height)
 {
     uint8_t *nsrc, *ndst;
     register uint8_t tmp;
-    unsigned int l;
+    int l;
 
     for(l=0; l < height; l++) {
-        nsrc = (uint8_t *)src + l*width; 
-        ndst = nsrc + width - 1; 
+        nsrc = (uint8_t *)src + l*width;
+        ndst = nsrc + width - 1;
         while (nsrc < ndst) {
             tmp = *ndst;
             *ndst-- = *nsrc;
@@ -361,7 +361,7 @@ int rotate_map(struct context *cnt, unsigned char *map)
         break;
     default:
         break;
-    }    
+    }
 
     switch (deg) {
     case 90:


### PR DESCRIPTION
1.  Small changes to eliminate compiler warnings.
2.  Change the configure script for --with-developer-flags
    Added   -Wall, -Wextra, -Werror -Wformat
    Removed -Wcast-align