### PR TITLE
Handle padded MMAL frames

### DIFF
--- a/mmalcam.c
+++ b/mmalcam.c
@@ -141,7 +141,10 @@ static int create_camera_component(mmalcam_context_ptr mmalcam, const char *mmal
 
     set_video_port_format(mmalcam, video_port->format);
     video_port->format->encoding = MMAL_ENCODING_I420;
-        
+    // set buffer size for an aligned/padded frame
+    video_port->buffer_size = VCOS_ALIGN_UP(mmalcam->width, 32) *
+        VCOS_ALIGN_UP(mmalcam->height, 16) * 3 / 2;
+
     if (mmal_port_parameter_set_boolean(video_port, MMAL_PARAMETER_NO_IMAGE_PADDING, 1)
             != MMAL_SUCCESS) {
         MOTION_LOG(WRN, TYPE_VIDEO, NO_ERRNO, "MMAL no-padding setup failed");

--- a/mmalcam.c
+++ b/mmalcam.c
@@ -382,7 +382,7 @@ int mmalcam_next(struct context *cnt, unsigned char *map)
     MMAL_BUFFER_HEADER_T *camera_buffer = mmal_queue_wait(mmalcam->camera_buffer_queue);
 
     if (camera_buffer->cmd == 0 && (camera_buffer->flags & MMAL_BUFFER_HEADER_FLAG_FRAME_END)
-            && camera_buffer->length == cnt->imgs.size) {
+            && camera_buffer->length >= cnt->imgs.size) {
         mmal_buffer_header_mem_lock(camera_buffer);
         memcpy(map, camera_buffer->data, cnt->imgs.size);
         mmal_buffer_header_mem_unlock(camera_buffer);

--- a/mmalcam.c
+++ b/mmalcam.c
@@ -141,6 +141,12 @@ static int create_camera_component(mmalcam_context_ptr mmalcam, const char *mmal
 
     set_video_port_format(mmalcam, video_port->format);
     video_port->format->encoding = MMAL_ENCODING_I420;
+        
+    if (mmal_port_parameter_set_boolean(video_port, MMAL_PARAMETER_NO_IMAGE_PADDING, 1)
+            != MMAL_SUCCESS) {
+        MOTION_LOG(WRN, TYPE_VIDEO, NO_ERRNO, "MMAL no-padding setup failed");
+    }
+
     status = mmal_port_format_commit(video_port);
 
     if (status) {

--- a/mmalcam.c
+++ b/mmalcam.c
@@ -387,8 +387,9 @@ int mmalcam_next(struct context *cnt, unsigned char *map)
         memcpy(map, camera_buffer->data, cnt->imgs.size);
         mmal_buffer_header_mem_unlock(camera_buffer);
     } else {
-        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "cmd %d flags %08x size %d/%d at %08x",
-                camera_buffer->cmd, camera_buffer->flags, camera_buffer->length, camera_buffer->alloc_size, camera_buffer->data);
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO, "cmd %d flags %08x size %d/%d at %08x, img_size=%d",
+                camera_buffer->cmd, camera_buffer->flags, camera_buffer->length,
+                camera_buffer->alloc_size, camera_buffer->data, cnt->imgs.size);
     }
 
     mmal_buffer_header_release(camera_buffer);


### PR DESCRIPTION
This enhancement allows consumption of frames where resolution is not conforming to RPi firmware requirements, namely that width is a multiple of 32 and height is multiple of 16.

Currently, for such resolutions, MMAL will return a larger buffer that contains a padded frame. mmal_next will fail to process those due to unexpected size.

One way to fix those cases is to utilize MMAL_PARAMETER_NO_IMAGE_PADDING parameter that will trigger an optimized code on GPU to remove padding. One caveat is that removal is done as a second pass on provided buffer which has to accommodate initial padded image. 