### PR TITLE
Resolve Developer Warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ matrix:
   - os: osx
     language: c
     compiler: gcc
-  - os: osx
-    language: c
-    compiler: clang
   - os: linux
     language: c
     compiler: gcc

--- a/conf.c
+++ b/conf.c
@@ -1911,9 +1911,9 @@ void conf_print(struct context **cnt)
                     free(val);
                 } else if (thread == 0) {
                     /* The 'camera_dir' option should keep the installed default value */
-                    val = "value";
+                    sprintf(val, "%s","value");
                     if (!strncmp(config_params[i].param_name, "camera_dir", 10))
-                        val =  sysconfdir"/motion/conf.d";
+                        sprintf(val, "%s",sysconfdir"/motion/conf.d");
 
                     fprintf(conffile, "%s\n", config_params[i].param_help);
                     fprintf(conffile, "; %s %s\n\n", config_params[i].param_name, val);

--- a/configure.ac
+++ b/configure.ac
@@ -564,7 +564,7 @@ AC_ARG_WITH([developer-flags],
     [DEVELOPER_FLAGS=no])
 
 if test "${DEVELOPER_FLAGS}" = "yes"; then
-    TEMP_CFLAGS="${TEMP_CFLAGS} -W -Wshadow -Wpointer-arith -Wcast-align -Wwrite-strings -Waggregate-return -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Winline -Wredundant-decls -Wno-long-long -ggdb -g3"
+    TEMP_CFLAGS="${TEMP_CFLAGS} -W -Werror -Wall -Wextra -Wformat -Wshadow -Wpointer-arith -Wwrite-strings -Waggregate-return -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Winline -Wredundant-decls -Wno-long-long -ggdb -g3"
 fi
 
 CFLAGS="${TEMP_CFLAGS} $CPU_OPTIONS"

--- a/motion.c
+++ b/motion.c
@@ -1358,12 +1358,13 @@ static void mlp_mask_privacy(struct context *cnt){
   // Mask brightness.
   //
   int index = pixels;
+  int increment = sizeof(unsigned long);
 
-  while (index >= sizeof(unsigned long)) {
+  while (index >= increment) {
      *((unsigned long *)image) &= *((unsigned long *)mask);
-     image += sizeof(unsigned long);
-     mask += sizeof(unsigned long);
-     index -= sizeof(unsigned long);
+     image += increment;
+     mask += increment;
+     index -= increment;
   }
   while (--index >= 0) {
      *(image++) &= *(mask++);
@@ -1374,8 +1375,8 @@ static void mlp_mask_privacy(struct context *cnt){
   index = cnt->imgs.size - pixels;
   const unsigned char *maskuv = cnt->imgs.mask_privacy_uv;
 
-  while (index >= sizeof(unsigned long)) {
-     index -= sizeof(unsigned long);
+  while (index >= increment) {
+     index -= increment;
      /*
       * Replace the masked bytes with 0x080. This is done using two masks:
       * the normal privacy mask is used to clear the masked bits, the
@@ -1383,10 +1384,10 @@ static void mlp_mask_privacy(struct context *cnt){
       * is that we process 4 or 8 bytes in just two operations.
       */
      *((unsigned long *)image) &= *((unsigned long *)mask);
-     mask += sizeof(unsigned long);
+     mask += increment;
      *((unsigned long *)image) |= *((unsigned long *)maskuv);
-     maskuv += sizeof(unsigned long);
-     image += sizeof(unsigned long);
+     maskuv += increment;
+     image += increment;
   }
   while (--index >= 0) {
      if (*(mask++) == 0x00) *image = 0x80; // Mask last remaining bytes.

--- a/rotate.c
+++ b/rotate.c
@@ -76,11 +76,11 @@ static void reverse_inplace_quad(unsigned char *src, int size)
 static void flip_inplace_horizontal(unsigned char *src, int width, int height) {
     uint8_t *nsrc, *ndst;
     register uint8_t tmp;
-    unsigned int l,w;
+    int l,w;
 
     for(l=0; l < height/2; l++) {
-        nsrc = (uint8_t *)(src + l*width); 
-        ndst = (uint8_t *)(src + (width*(height-l-1))); 
+        nsrc = (uint8_t *)(src + l*width);
+        ndst = (uint8_t *)(src + (width*(height-l-1)));
         for(w=0; w < width; w++) {
             tmp =*ndst;
             *ndst++ = *nsrc;
@@ -94,11 +94,11 @@ static void flip_inplace_vertical(unsigned char *src, int width, int height)
 {
     uint8_t *nsrc, *ndst;
     register uint8_t tmp;
-    unsigned int l;
+    int l;
 
     for(l=0; l < height; l++) {
-        nsrc = (uint8_t *)src + l*width; 
-        ndst = nsrc + width - 1; 
+        nsrc = (uint8_t *)src + l*width;
+        ndst = nsrc + width - 1;
         while (nsrc < ndst) {
             tmp = *ndst;
             *ndst-- = *nsrc;
@@ -361,7 +361,7 @@ int rotate_map(struct context *cnt, unsigned char *map)
         break;
     default:
         break;
-    }    
+    }
 
     switch (deg) {
     case 90:


### PR DESCRIPTION
1.  Revise the developer warnings to treat all warnings as errors
2.  Revise a few of the comparisons of signed to unsigned.
3.  Isolate the setjmp to separate function since it is warning on 14.04
4.  Remove redundant clang OSX test since gcc is really clang according to travis logs