### PR TITLE
Additional Travis Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,16 @@
-before_script:
-  - autoreconf -fiv
-script: ./configure --with-developer-flags && make
+sudo: required
+
 matrix:
   include:
   - os: osx
     language: c
     compiler: gcc
   - os: linux
+    env:  BUILD_IMAGE=14.04
     language: c
     compiler: gcc
     addons:
       apt:
-        sources:
-        - sourceline: 'ppa:mc3man/trusty-media'
         packages:
         - libavformat-dev
         - libavcodec-dev
@@ -21,24 +19,51 @@ matrix:
         - libavdevice-dev
         - libjpeg8-dev
         - libzip-dev
+        - libsqlite3-dev
+        - libpq-dev
+        - libmysqlclient-dev
   - os: linux
+    env:  DOCKER_IMAGE=ubuntu:16.04
+    services:  docker
     language: c
     compiler: gcc
-    addons:
-      apt:
-        packages:
-        - libavformat-dev
-        - libavcodec-dev
-        - libavutil-dev
-        - libswscale-dev
-        - libavdevice-dev
-        - libjpeg8-dev
-        - libzip-dev
-before_install:
-    - if [ $TRAVIS_OS_NAME = osx ]; then 
-        brew upgrade ffmpeg;
-        brew upgrade pkg-config;
-        brew upgrade jpeg;
-        brew install ffmpeg pkg-config libjpeg;
-      fi;
+  - os: linux
+    env:  DOCKER_IMAGE=ubuntu:17.04
+    services:  docker
+    language: c
+    compiler: gcc
 
+before_install:
+  - if [ x$DOCKER_IMAGE != "x" ]; then
+      echo $DOCKER_IMAGE;
+      docker pull $DOCKER_IMAGE;
+      docker run -d -v $(pwd):/motion -w /motion $DOCKER_IMAGE /bin/bash -c 'while true; do sleep 1; done';
+    fi;
+
+before_script:
+  - if [ $TRAVIS_OS_NAME = osx ]; then
+      brew upgrade ffmpeg pkg-config jpeg;
+      brew install ffmpeg pkg-config libjpeg;
+      autoreconf -fiv;
+    fi;
+  - if [ $BUILD_IMAGE = "14.04" ]; then
+      autoreconf -fiv;
+    fi;
+  - if [ x$DOCKER_IMAGE != "x" ]; then
+      docker exec $(docker ps -aq) /bin/bash -c 'apt-get -qq update';
+      docker exec $(docker ps -aq) /bin/bash -c 'apt-get install -y build-essential libjpeg8-dev libzip-dev autoconf automake pkgconf libtool git';
+      docker exec $(docker ps -aq) /bin/bash -c 'apt-get install -y libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev';
+      docker exec $(docker ps -aq) /bin/bash -c 'apt-get install -y libsqlite3-dev libpq-dev libmysqlclient-dev';
+      docker exec $(docker ps -aq) /bin/bash -c 'autoreconf -fiv';
+    fi;
+
+script:
+  - if [ $TRAVIS_OS_NAME = osx ]; then
+      ./configure --with-developer-flags && make;
+    fi;
+  - if [ $BUILD_IMAGE = "14.04" ]; then
+      ./test_builds.sh;
+    fi;
+  - if [ x$DOCKER_IMAGE != "x" ]; then
+      docker exec $(docker ps -aq) /bin/bash -c './test_builds.sh';
+    fi;

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
     compiler: gcc
 
 before_install:
-  - if [ x$DOCKER_IMAGE != "x" ]; then
+  - if [ "x$DOCKER_IMAGE" != "x" ]; then
       echo $DOCKER_IMAGE;
       docker pull $DOCKER_IMAGE;
       docker run -d -v $(pwd):/motion -w /motion $DOCKER_IMAGE /bin/bash -c 'while true; do sleep 1; done';
@@ -46,10 +46,10 @@ before_script:
       brew install ffmpeg pkg-config libjpeg;
       autoreconf -fiv;
     fi;
-  - if [ $BUILD_IMAGE = "14.04" ]; then
+  - if [ "$BUILD_IMAGE" = "14.04" ]; then
       autoreconf -fiv;
     fi;
-  - if [ x$DOCKER_IMAGE != "x" ]; then
+  - if [ "x$DOCKER_IMAGE" != "x" ]; then
       docker exec $(docker ps -aq) /bin/bash -c 'apt-get -qq update';
       docker exec $(docker ps -aq) /bin/bash -c 'apt-get install -y build-essential libjpeg8-dev libzip-dev autoconf automake pkgconf libtool git';
       docker exec $(docker ps -aq) /bin/bash -c 'apt-get install -y libavformat-dev libavcodec-dev libavutil-dev libswscale-dev libavdevice-dev';
@@ -61,9 +61,9 @@ script:
   - if [ $TRAVIS_OS_NAME = osx ]; then
       ./configure --with-developer-flags && make;
     fi;
-  - if [ $BUILD_IMAGE = "14.04" ]; then
+  - if [ "$BUILD_IMAGE" = "14.04" ]; then
       ./test_builds.sh;
     fi;
-  - if [ x$DOCKER_IMAGE != "x" ]; then
+  - if [ "x$DOCKER_IMAGE" != "x" ]; then
       docker exec $(docker ps -aq) /bin/bash -c './test_builds.sh';
     fi;

--- a/configure.ac
+++ b/configure.ac
@@ -254,6 +254,9 @@ AS_IF([test "x$with_ffmpeg" != "xno"], [
        if pkg-config $FFMPEG_DEPS; then
                FFMPEG_CFLAGS=`pkg-config --cflags $FFMPEG_DEPS`
                FFMPEG_LIBS=`pkg-config --libs $FFMPEG_DEPS`
+               FFMPEG_VER=`pkg-config --modversion libavformat`
+               AC_MSG_CHECKING(for libavformat)
+               AC_MSG_RESULT(yes $FFMPEG_VER)
                HAVE_FFMPEG="yes"
        else
               AC_MSG_ERROR([Required ffmpeg packages 'libavutil-dev libavformat-dev libavcodec-dev libswscale-dev libavdevice-dev' were not found.  Please check motion_guide.html and install necessary dependencies or use the '--without-ffmpeg' configuration option.])

--- a/test_builds.sh
+++ b/test_builds.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+SUMMARY=""
+RESULT="OK"
+STARS="*****************************"
+
+##################################################################################################
+OPTION=" --with-developer-flags"
+RESULT_CONFIG="Failed"
+RESULT_MAKE="Failed"
+printf "\n\n$STARS Testing $OPTION $STARS\n\n"
+if ./configure $OPTION; then
+  RESULT_CONFIG="OK"
+  if make; then
+    RESULT_MAKE="OK"
+  else
+    RESULT="FAIL"
+  fi
+else
+  RESULT="FAIL"
+fi
+SUMMARY=$SUMMARY"\n Option(s): "$OPTION" Config: "$RESULT_CONFIG" make: "$RESULT_MAKE
+
+##################################################################################################
+OPTION=" --with-developer-flags --without-ffmpeg "
+RESULT_CONFIG="Failed"
+RESULT_MAKE="Failed"
+printf "\n\n$STARS Testing $OPTION $STARS\n\n"
+if ./configure $OPTION; then
+  RESULT_CONFIG="OK"
+  if make; then
+    RESULT_MAKE="OK"
+  else
+    RESULT="FAIL"
+  fi
+else
+  RESULT="FAIL"
+fi
+SUMMARY=$SUMMARY"\n Option(s): "$OPTION" Config: "$RESULT_CONFIG" make: "$RESULT_MAKE
+
+##################################################################################################
+OPTION=" --with-developer-flags --without-mysql "
+RESULT_CONFIG="Failed"
+RESULT_MAKE="Failed"
+printf "\n\n$STARS Testing $OPTION $STARS\n\n"
+if ./configure $OPTION; then
+  RESULT_CONFIG="OK"
+  if make; then
+    RESULT_MAKE="OK"
+  else
+    RESULT="FAIL"
+  fi
+else
+  RESULT="FAIL"
+fi
+SUMMARY=$SUMMARY"\n Option(s): "$OPTION" Config: "$RESULT_CONFIG" make: "$RESULT_MAKE
+
+##################################################################################################
+OPTION=" --with-developer-flags --without-sqlite3 "
+RESULT_CONFIG="Failed"
+RESULT_MAKE="Failed"
+printf "\n\n$STARS Testing $OPTION $STARS\n\n"
+if ./configure $OPTION; then
+  RESULT_CONFIG="OK"
+  if make; then
+    RESULT_MAKE="OK"
+  else
+    RESULT="FAIL"
+  fi
+else
+  RESULT="FAIL"
+fi
+SUMMARY=$SUMMARY"\n Option(s): "$OPTION" Config: "$RESULT_CONFIG" make: "$RESULT_MAKE
+
+##################################################################################################
+OPTION=" --with-developer-flags --without-pgsql "
+RESULT_CONFIG="Failed"
+RESULT_MAKE="Failed"
+printf "\n\n$STARS Testing $OPTION $STARS\n\n"
+if ./configure $OPTION; then
+  RESULT_CONFIG="OK"
+  if make; then
+    RESULT_MAKE="OK"
+  else
+    RESULT="FAIL"
+  fi
+else
+  RESULT="FAIL"
+fi
+SUMMARY=$SUMMARY"\n Option(s): "$OPTION" Config: "$RESULT_CONFIG" make: "$RESULT_MAKE
+
+##################################################################################################
+OPTION=" --with-developer-flags --without-v4l2 "
+RESULT_CONFIG="Failed"
+RESULT_MAKE="Failed"
+printf "\n\n$STARS Testing $OPTION $STARS\n\n"
+if ./configure $OPTION; then
+  RESULT_CONFIG="OK"
+  if make; then
+    RESULT_MAKE="OK"
+  else
+    RESULT="FAIL"
+  fi
+else
+  RESULT="FAIL"
+fi
+SUMMARY=$SUMMARY"\n Option(s): "$OPTION" Config: "$RESULT_CONFIG" make: "$RESULT_MAKE
+
+##################################################################################################
+OPTION=" --with-developer-flags --without-mysql --without-sqlite3 --without-pgsql "
+RESULT_CONFIG="Failed"
+RESULT_MAKE="Failed"
+printf "\n\n$STARS Testing $OPTION $STARS\n\n"
+if ./configure $OPTION; then
+  RESULT_CONFIG="OK"
+  if make; then
+    RESULT_MAKE="OK"
+  else
+    RESULT="FAIL"
+  fi
+else
+  RESULT="FAIL"
+fi
+SUMMARY=$SUMMARY"\n Option(s): "$OPTION" Config: "$RESULT_CONFIG" make: "$RESULT_MAKE
+
+##################################################################################################
+
+printf "\n\n$STARS Test Build Results$STARS\n"
+printf "$SUMMARY\n"
+if test $RESULT = "FAIL"; then
+  printf " Test builds failed\n"
+  printf "\n\n$STARS$STARS\n"
+  exit 1
+else
+  printf " Test builds OK\n"
+  printf "\n\n$STARS$STARS\n"
+  exit 0
+fi


### PR DESCRIPTION
This commit includes the following revisions to the testing.
1.  Add a output from the configure script to indicate version of libavformat.
2.  Add test_builds.sh script which includes tests for following with/without options.
    --with-developer-flags, --without-ffmpeg, --without-mysql, --without-pgsql
    --without-v4l2, --without-mysqlite3
3.  Add testing via docker for 16.04 and 17.04