### PR TITLE
do not force packet keyframe

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -349,8 +349,6 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
         //Packet is freed upon failure of encoding
         return -1;
     }
-    if (ffmpeg->picture->key_frame == 1)
-      ffmpeg->pkt.flags |= AV_PKT_FLAG_KEY;
 
     return 0;
 
@@ -372,9 +370,6 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
         my_packet_unref(ffmpeg->pkt);
         return -2;
     }
-
-    if (ffmpeg->picture->key_frame == 1)
-      ffmpeg->pkt.flags |= AV_PKT_FLAG_KEY;
 
     return 0;
 
@@ -401,9 +396,6 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
 
     ffmpeg->pkt.size = retcd;
     ffmpeg->pkt.data = video_outbuf;
-
-    if (ffmpeg->picture->key_frame == 1)
-      ffmpeg->pkt.flags |= AV_PKT_FLAG_KEY;
 
     free(video_outbuf);
 

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -394,8 +394,15 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
         return -2;
     }
 
+    // Encoder did not provide metadata, set it up manually
     ffmpeg->pkt.size = retcd;
     ffmpeg->pkt.data = video_outbuf;
+
+    if (ffmpeg->picture->key_frame == 1)
+      ffmpeg->pkt.flags |= AV_PKT_FLAG_KEY;
+
+    ffmpeg->pkt.pts = ffmpeg->picture->pts;
+    ffmpeg->pkt.dts = ffmpeg->pkt.pts;
 
     free(video_outbuf);
 


### PR DESCRIPTION
We should not be messing with the keyframe flag in the encoded packet because encoders are likely to be buffered and even asynchronous. This PR removes setting of keyframe flag in the encoded packet.

This is a prerequisite for:
- decoupling `avcodec_receive_packet` and `avcodec_send_frame`.
- codec draining.