### PR TITLE
Add a runtime argument to dump config options

### DIFF
--- a/conf.h
+++ b/conf.h
@@ -184,6 +184,7 @@ struct context **conf_load(struct context **);
 struct context **conf_cmdparse(struct context **, const char *, const char *);
 const char *config_type(config_param *);
 void conf_print(struct context **);
+void dump_config_options(struct context **);
 void malloc_strings(struct context *);
 char *mystrdup(const char *);
 char *mystrcpy(char *, const char *);

--- a/motion.1
+++ b/motion.1
@@ -26,22 +26,25 @@ Run in daemon mode.
 Run in non-daemon mode.
 .TP
 .B \-s
-Run in setup mode. Also forces non-daemon mode
+Run in setup mode. Also forces non-daemon mode.
+.TP
+.B \-o
+Dump config options to log (for support purposes).
 .TP
 .B \-d
 Run with message log level 1-9.
 .TP
 .B \-k
-Run with message log type 1-9
+Run with message log type 1-9.
 .TP
 .B \-l
-Full path and file name for the log file
+Full path and file name for the log file.
 .TP
 .B \-p
 Full path and filename for process id file (pid file). E.g /var/run/motion.pid. Default is not defined. Pid file is only created when Motion is started in daemon mode.
 .TP
 .B \-m
-Start in pause mode
+Start in pause mode.
 .TP
 .SH "CONFIG FILE OPTIONS"
 These are the options that can be used in the config file.

--- a/motion.c
+++ b/motion.c
@@ -2764,6 +2764,9 @@ static void motion_startup(int daemonize, int argc, char *argv[])
     set_log_level(cnt_list[0]->log_level);
     set_log_type(cnt_list[0]->log_type);
 
+    if (cnt_list[0]->dump_config_options)
+        dump_config_options(cnt_list);
+
     initialize_chars();
 
     if (daemonize) {

--- a/motion.h
+++ b/motion.h
@@ -378,6 +378,7 @@ struct context {
     char log_type_str[6];
     int log_level;
     unsigned int log_type;
+    unsigned int dump_config_options;
 
     struct config conf;
     struct images imgs;

--- a/motion_guide.html
+++ b/motion_guide.html
@@ -964,6 +964,7 @@ motion [ -hbnsm ] [ -c config file path ] [ -d level ] [ -k level ] [ -p process
   <li>-b : Run in daemon mode</li>
   <li>-n : Run in non-daemon mode</li>
   <li>-s : Run in setup mode. Also forces non-daemon mode.</li>
+  <li>-o : Dump config options to log (for support purposes).</li>
   <li>-d : Run with message log level 1 - 9</li>
   <li>-k : Run with message log type 1 - 9</li>
   <li>-l : Full path and file name for log file</li>


### PR DESCRIPTION
Basing off the discussion in #509 (@Mr-Dave's comment - point 2 to be exact), this PR adds a runtime argument to dump the config options to the log(file). This seemed better than another log level as it needs explicit enabling and not accidental setting in the config.  
I based the sensitive information to redact off that discussion/the [Privacy Wiki](https://github.com/Motion-Project/motion/wiki/Privacy) entry, except for any of the script calls. I'm not sure the config would show sensitive information for these parameters.

### Testing
- [x] Single config file
- [x] Main and single camera files
- [x] Main and multiple camera files
- [x] Logging to file
- [x] Logging to syslog 