### PR TITLE
Bugfix: config write causes crash

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -1910,13 +1910,15 @@ void conf_print(struct context **cnt)
 
                     free(val);
                 } else if (thread == 0) {
+                    char value[PATH_MAX];
                     /* The 'camera_dir' option should keep the installed default value */
-                    sprintf(val, "%s","value");
                     if (!strncmp(config_params[i].param_name, "camera_dir", 10))
-                        sprintf(val, "%s",sysconfdir"/motion/conf.d");
+                        sprintf(value, "%s", sysconfdir"/motion/conf.d");
+                    else
+                        sprintf(value, "%s", "value");
 
                     fprintf(conffile, "%s\n", config_params[i].param_help);
-                    fprintf(conffile, "; %s %s\n\n", config_params[i].param_name, val);
+                    fprintf(conffile, "; %s %s\n\n", config_params[i].param_name, value);
                 }
             }
         }


### PR DESCRIPTION
While testing in regards to issue #515, I found that writing the config kept causing a crash. I traced it down to the correction by @Mr-DaveDev of my improper `val = ...` method.  
Using a separate buffer for this should be safer than my initial reuse of the other, freed buffer.