### PR TITLE
decouple ffmpeg avcodec send and receive

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -341,6 +341,15 @@ static int ffmpeg_get_oformat(struct ffmpeg *ffmpeg){
     return 0;
 }
 
+static int ffmpeg_write_packet(struct ffmpeg *ffmpeg){
+
+    if (ffmpeg->tlapse == TIMELAPSE_APPEND) {
+        return ffmpeg_timelapse_append(ffmpeg, ffmpeg->pkt);
+    } else {
+        return av_write_frame(ffmpeg->oc, &ffmpeg->pkt);
+    }
+}
+
 static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
 
 #if (LIBAVFORMAT_VERSION_MAJOR >= 58) || ((LIBAVFORMAT_VERSION_MAJOR == 57) && (LIBAVFORMAT_VERSION_MINOR >= 41))
@@ -348,25 +357,41 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
     int retcd = 0;
     char errstr[128];
 
+    av_init_packet(&ffmpeg->pkt);
+    ffmpeg->pkt.data = NULL;
+    ffmpeg->pkt.size = 0;
+
     retcd = avcodec_send_frame(ffmpeg->ctx_codec, ffmpeg->picture);
     if (retcd < 0 ){
         av_strerror(retcd, errstr, sizeof(errstr));
         MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "Error sending frame for encoding:%s",errstr);
-        return -1;
-    }
-    retcd = avcodec_receive_packet(ffmpeg->ctx_codec, &ffmpeg->pkt);
-    if (retcd == AVERROR(EAGAIN)){
-        //Buffered packet.  Throw special return code
         my_packet_unref(ffmpeg->pkt);
-        return -2;
-    }
-    if (retcd < 0 ){
-        av_strerror(retcd, errstr, sizeof(errstr));
-        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "Error receiving encoded packet video:%s",errstr);
-        //Packet is freed upon failure of encoding
         return -1;
+    }
+    while (retcd >= 0) {
+        retcd = avcodec_receive_packet(ffmpeg->ctx_codec, &ffmpeg->pkt);
+        if (retcd == AVERROR(EAGAIN)){
+            //Buffered packet.  Throw special return code
+            my_packet_unref(ffmpeg->pkt);
+            return -2;
+        }
+        if (retcd < 0 ){
+            av_strerror(retcd, errstr, sizeof(errstr));
+            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "Error receiving encoded packet video:%s",errstr);
+            my_packet_unref(ffmpeg->pkt);
+            return -1;
+        } else {
+            retcd = ffmpeg_write_packet(ffmpeg);
+            if (retcd < 0) {
+                MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "Error while writing video frame");
+                my_packet_unref(ffmpeg->pkt);
+                ffmpeg_free_context(ffmpeg);
+                return -1;
+            }
+        }
     }
 
+    my_packet_unref(ffmpeg->pkt);
     return 0;
 
 #elif (LIBAVFORMAT_VERSION_MAJOR >= 55) || ((LIBAVFORMAT_VERSION_MAJOR == 54) && (LIBAVFORMAT_VERSION_MINOR > 6))
@@ -375,11 +400,15 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
     char errstr[128];
     int got_packet_ptr;
 
+    av_init_packet(&ffmpeg->pkt);
+    ffmpeg->pkt.data = NULL;
+    ffmpeg->pkt.size = 0;
+
     retcd = avcodec_encode_video2(ffmpeg->ctx_codec, &ffmpeg->pkt, ffmpeg->picture, &got_packet_ptr);
     if (retcd < 0 ){
         av_strerror(retcd, errstr, sizeof(errstr));
         MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "Error encoding video:%s",errstr);
-        //Packet is freed upon failure of encoding
+        my_packet_unref(ffmpeg->pkt);
         return -1;
     }
     if (got_packet_ptr == 0){
@@ -388,6 +417,15 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
         return -2;
     }
 
+    retcd = ffmpeg_write_packet(ffmpeg);
+    if (retcd < 0) {
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "Error while writing video frame");
+        my_packet_unref(ffmpeg->pkt);
+        ffmpeg_free_context(ffmpeg);
+        return -1;
+    }
+
+    my_packet_unref(ffmpeg->pkt);
     return 0;
 
 #else
@@ -395,6 +433,10 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
     int retcd = 0;
     uint8_t *video_outbuf;
     int video_outbuf_size;
+
+    av_init_packet(&ffmpeg->pkt);
+    ffmpeg->pkt.data = NULL;
+    ffmpeg->pkt.size = 0;
 
     video_outbuf_size = (ffmpeg->ctx_codec->width +16) * (ffmpeg->ctx_codec->height +16) * 1;
     video_outbuf = mymalloc(video_outbuf_size);
@@ -421,8 +463,18 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
     ffmpeg->pkt.pts = ffmpeg->picture->pts;
     ffmpeg->pkt.dts = ffmpeg->pkt.pts;
 
-    free(video_outbuf);
+    retcd = ffmpeg_write_packet(ffmpeg);
+    if (retcd < 0) {
+        av_strerror(retcd, errstr, sizeof(errstr));
+        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "Error while writing video frame");
+        my_packet_unref(ffmpeg->pkt);
+        free(video_outbuf);
+        ffmpeg_free_context(ffmpeg);
+        return -1;
+    }
 
+    my_packet_unref(ffmpeg->pkt);
+    free(video_outbuf);
     return 0;
 
 #endif
@@ -759,35 +811,16 @@ static int ffmpeg_set_outputfile(struct ffmpeg *ffmpeg){
 static int ffmpeg_put_frame(struct ffmpeg *ffmpeg, const struct timeval *tv1){
     int retcd;
 
-    av_init_packet(&ffmpeg->pkt);
-    ffmpeg->pkt.data = NULL;
-    ffmpeg->pkt.size = 0;
-
     retcd = ffmpeg_set_pts(ffmpeg, tv1);
     if (retcd < 0) {
         //If there is an error, it has already been reported.
-        my_packet_unref(ffmpeg->pkt);
         return 0;
     }
 
     retcd = ffmpeg_encode_video(ffmpeg);
-    if (retcd != 0){
-        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "Error while encoding picture");
-        my_packet_unref(ffmpeg->pkt);
-        return retcd;
-    }
-
-    if (ffmpeg->tlapse == TIMELAPSE_APPEND) {
-        retcd = ffmpeg_timelapse_append(ffmpeg, ffmpeg->pkt);
-    } else {
-        retcd = av_write_frame(ffmpeg->oc, &ffmpeg->pkt);
-    }
-    my_packet_unref(ffmpeg->pkt);
-
-    if (retcd < 0) {
-        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "Error while writing video frame");
-        ffmpeg_free_context(ffmpeg);
-        return -1;
+    if (retcd < 0){
+        if (retcd != -2)
+            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "Error while encoding picture");
     }
     return retcd;
 


### PR DESCRIPTION
This is a prerequisite to codec draining described in issue #492.

Decouple `avcodec_receive_packet` and `avcodec_send_frame` as intended by the new ffmpeg API. Older ffmpeg API calls will **NOT** be decoupled.

Reason for decoupling the send and receive:
An encoder may accept multiple frames as input and output nothing at all until a later time when the encoder outputs multiple encoded packets at once. This may be because of encoder input buffering and encoder optimization. How many frames are buffered depends entirely on encoder implementation. Most (if not all) modern encoders behave this way, and the new ffmpeg API reflects this fact as well. See this [blog](https://blogs.gentoo.org/lu_zero/2016/03/29/new-avcodec-api/) post for more information about the new ffmpeg API.

In order to deal with this type of encoders, `avcodec_receive_packet` has to be called multiple times after each `avcodec_send_frame`.
