### PR TITLE
Limit parameters available on webcontrol

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -193,7 +193,8 @@ config_param config_params[] = {
     1,
     CNT_OFFSET(daemon),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "process_id_file",
@@ -201,7 +202,8 @@ config_param config_params[] = {
     1,
     CONF_OFFSET(pid_file),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "setup_mode",
@@ -212,7 +214,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(setup_mode),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "camera_name",
@@ -221,7 +224,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(camera_name),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "logfile",
@@ -229,7 +233,8 @@ config_param config_params[] = {
     1,
     CONF_OFFSET(log_file),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "log_level",
@@ -237,7 +242,8 @@ config_param config_params[] = {
     1,
     CONF_OFFSET(log_level),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "log_type",
@@ -245,7 +251,8 @@ config_param config_params[] = {
     1,
     CONF_OFFSET(log_type_str),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "videodevice",
@@ -257,7 +264,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(video_device),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "v4l2_palette",
@@ -267,7 +275,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(v4l2_palette),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
 #ifdef __FreeBSD__
     {
@@ -277,7 +286,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(tuner_device),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
 #endif
     {
@@ -287,7 +297,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(input),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "norm",
@@ -296,7 +307,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(norm),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "frequency",
@@ -304,7 +316,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(frequency),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "flip_axis",
@@ -313,7 +326,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(flip_axis),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "rotate",
@@ -322,7 +336,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(rotate_deg),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "width",
@@ -330,7 +345,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(width),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "height",
@@ -338,7 +354,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(height),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "framerate",
@@ -347,7 +364,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(frame_limit),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "minimum_frame_time",
@@ -357,7 +375,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(minimum_frame_time),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "netcam_url",
@@ -367,7 +386,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(netcam_url),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "netcam_highres",
@@ -375,7 +395,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(netcam_highres),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "netcam_userpass",
@@ -384,7 +405,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(netcam_userpass),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "netcam_keepalive",
@@ -396,7 +418,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(netcam_keepalive),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "netcam_proxy",
@@ -406,7 +429,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(netcam_proxy),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "netcam_tolerant_check",
@@ -415,7 +439,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(netcam_tolerant_check),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "rtsp_uses_tcp",
@@ -424,7 +449,8 @@ config_param config_params[] = {
     1,
     CONF_OFFSET(rtsp_uses_tcp),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_ADVANCED
     },
 #ifdef HAVE_MMAL
     {
@@ -435,7 +461,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(mmalcam_name),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "mmalcam_control_params",
@@ -444,7 +471,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(mmalcam_control_params),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
 #endif
     {
@@ -456,7 +484,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(autobright),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "brightness",
@@ -467,7 +496,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(brightness),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "contrast",
@@ -476,7 +506,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(contrast),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "saturation",
@@ -485,7 +516,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(saturation),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "hue",
@@ -494,7 +526,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(hue),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "power_line_frequency",
@@ -510,7 +543,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(power_line_frequency),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "roundrobin_frames",
@@ -521,7 +555,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(roundrobin_frames),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "roundrobin_skip",
@@ -529,7 +564,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(roundrobin_skip),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "switchfilter",
@@ -537,7 +573,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(switchfilter),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "threshold",
@@ -549,7 +586,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(max_changes),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "threshold_tune",
@@ -557,7 +595,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(threshold_tune),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "noise_level",
@@ -565,7 +604,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(noise),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "noise_tune",
@@ -573,7 +613,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(noise_tune),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "despeckle_filter",
@@ -584,7 +625,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(despeckle_filter),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "area_detect",
@@ -596,7 +638,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(area_detect),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "mask_file",
@@ -605,7 +648,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(mask_file),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "mask_privacy",
@@ -614,7 +658,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(mask_privacy),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "smart_mask_speed",
@@ -623,18 +668,19 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(smart_mask_speed),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "lightswitch",
     "# Ignore sudden massive light intensity changes given as a percentage of the picture\n"
     "# area that changed intensity. If set to 1, motion will do some kind of\n"
     "# auto-lightswitch. Valid range: 0 - 100 , default: 0 = disabled",
-
     0,
     CONF_OFFSET(lightswitch),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "minimum_motion_frames",
@@ -644,7 +690,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(minimum_motion_frames),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "pre_capture",
@@ -656,7 +703,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(pre_capture),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "post_capture",
@@ -664,7 +712,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(post_capture),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "event_gap",
@@ -677,7 +726,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(event_gap),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "max_movie_time",
@@ -686,7 +736,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(max_movie_time),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "emulate_motion",
@@ -694,7 +745,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(emulate_motion),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "output_pictures",
@@ -710,7 +762,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(output_pictures),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "output_debug_pictures",
@@ -718,7 +771,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(motion_img),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "quality",
@@ -726,7 +780,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(quality),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "camera_id",
@@ -736,7 +791,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(camera_id),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "picture_type",
@@ -745,7 +801,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(picture_type),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "ffmpeg_output_movies",
@@ -759,7 +816,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(ffmpeg_output),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "ffmpeg_output_debug_movies",
@@ -768,7 +826,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(ffmpeg_output_debug),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "ffmpeg_bps",
@@ -777,7 +836,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(ffmpeg_bps),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "ffmpeg_variable_bitrate",
@@ -788,7 +848,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(ffmpeg_vbr),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "ffmpeg_video_codec",
@@ -807,7 +868,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(ffmpeg_video_codec),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "ffmpeg_passthrough",
@@ -818,7 +880,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(ffmpeg_passthrough),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "ffmpeg_duplicate_frames",
@@ -827,7 +890,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(ffmpeg_duplicate_frames),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "use_extpipe",
@@ -841,7 +905,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(useextpipe),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "extpipe",
@@ -850,7 +915,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(extpipe),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
     {
     "snapshot_interval",
@@ -861,7 +927,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(snapshot_interval),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "locate_motion_mode",
@@ -883,7 +950,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(locate_motion_mode),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "locate_motion_style",
@@ -896,7 +964,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(locate_motion_style),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "text_right",
@@ -906,7 +975,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(text_right),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "text_left",
@@ -916,7 +986,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(text_left),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "text_changes",
@@ -926,7 +997,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(text_changes),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "text_event",
@@ -939,7 +1011,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(text_event),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "text_double",
@@ -947,7 +1020,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(text_double),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "exif_text",
@@ -957,7 +1031,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(exif_text),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "target_dir",
@@ -979,7 +1054,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(filepath),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "snapshot_filename",
@@ -993,7 +1069,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(snappath),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "picture_filename",
@@ -1007,7 +1084,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(imagepath),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "movie_filename",
@@ -1020,7 +1098,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(moviepath),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "timelapse_interval",
@@ -1028,7 +1107,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(timelapse_interval),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "timelapse_mode",
@@ -1036,7 +1116,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(timelapse_mode),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "timelapse_codec",
@@ -1044,7 +1125,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(timelapse_codec),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "timelapse_fps",
@@ -1052,7 +1134,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(timelapse_fps),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "timelapse_filename",
@@ -1064,7 +1147,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(timepath),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "ipv6_enabled",
@@ -1075,7 +1159,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(ipv6_enabled),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "stream_port",
@@ -1086,7 +1171,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(stream_port),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "substream_port",
@@ -1097,7 +1183,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(substream_port),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "stream_quality",
@@ -1105,7 +1192,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(stream_quality),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "stream_motion",
@@ -1114,7 +1202,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(stream_motion),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "stream_maxrate",
@@ -1122,7 +1211,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(stream_maxrate),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "stream_localhost",
@@ -1130,7 +1220,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(stream_localhost),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "stream_limit",
@@ -1140,7 +1231,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(stream_limit),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "stream_auth_method",
@@ -1151,7 +1243,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(stream_auth_method),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_RESTRICTED
     },
     {
     "stream_authentication",
@@ -1160,7 +1253,8 @@ config_param config_params[] = {
     1,
     CONF_OFFSET(stream_authentication),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
     {
     "stream_preview_scale",
@@ -1168,7 +1262,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(stream_preview_scale),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "stream_preview_newline",
@@ -1176,7 +1271,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(stream_preview_newline),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "webcontrol_port",
@@ -1187,7 +1283,8 @@ config_param config_params[] = {
     1,
     CONF_OFFSET(webcontrol_port),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "webcontrol_localhost",
@@ -1195,7 +1292,8 @@ config_param config_params[] = {
     1,
     CONF_OFFSET(webcontrol_localhost),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "webcontrol_html_output",
@@ -1203,7 +1301,8 @@ config_param config_params[] = {
     1,
     CONF_OFFSET(webcontrol_html_output),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "webcontrol_authentication",
@@ -1212,7 +1311,18 @@ config_param config_params[] = {
     1,
     CONF_OFFSET(webcontrol_authentication),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
+    },
+    {
+    "webcontrol_parms",
+    "# Parameters to include on webcontrol.  0=none, 1=limited, 2=advanced, 3=restricted\n"
+    "# Default: 0 (none)",
+    1,
+    CONF_OFFSET(webcontrol_parms),
+    copy_int,
+    print_int,
+    WEBUI_LEVEL_NEVER
     },
     {
     "track_type",
@@ -1225,7 +1335,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(type),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_auto",
@@ -1233,7 +1344,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(active),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_port",
@@ -1241,7 +1353,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(port),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_motorx",
@@ -1249,7 +1362,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(motorx),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_motorx_reverse",
@@ -1257,7 +1371,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(motorx_reverse),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_motory",
@@ -1265,7 +1380,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(motory),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_motory_reverse",
@@ -1273,7 +1389,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(motory_reverse),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_maxx",
@@ -1281,7 +1398,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(maxx),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_minx",
@@ -1289,7 +1407,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(minx),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_maxy",
@@ -1297,7 +1416,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(maxy),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_miny",
@@ -1305,7 +1425,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(miny),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_homex",
@@ -1313,7 +1434,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(homex),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_homey",
@@ -1321,7 +1443,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(homey),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_iomojo_id",
@@ -1329,7 +1452,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(iomojo_id),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_step_angle_x",
@@ -1339,7 +1463,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(step_angle_x),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_step_angle_y",
@@ -1349,7 +1474,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(step_angle_y),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_move_wait",
@@ -1358,7 +1484,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(move_wait),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_speed",
@@ -1366,7 +1493,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(speed),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "track_stepsize",
@@ -1374,7 +1502,8 @@ config_param config_params[] = {
     0,
     TRACK_OFFSET(stepsize),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "quiet",
@@ -1399,7 +1528,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(quiet),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "on_event_start",
@@ -1408,7 +1538,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(on_event_start),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
     {
     "on_event_end",
@@ -1417,7 +1548,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(on_event_end),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
     {
     "on_picture_save",
@@ -1426,7 +1558,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(on_picture_save),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
     {
     "on_motion_detected",
@@ -1434,7 +1567,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(on_motion_detected),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
     {
     "on_area_detected",
@@ -1443,7 +1577,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(on_area_detected),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
 #ifdef HAVE_FFMPEG
     {
@@ -1453,7 +1588,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(on_movie_start),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
     {
     "on_movie_end",
@@ -1462,7 +1598,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(on_movie_end),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
 #endif /* HAVE_FFMPEG */
     {
@@ -1474,7 +1611,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(on_camera_lost),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
     {
     "on_camera_found",
@@ -1483,7 +1621,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(on_camera_found),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
     {
     "sql_log_picture",
@@ -1495,7 +1634,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(sql_log_image),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "sql_log_snapshot",
@@ -1503,7 +1643,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(sql_log_snapshot),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "sql_log_movie",
@@ -1511,7 +1652,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(sql_log_movie),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "sql_log_timelapse",
@@ -1519,7 +1661,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(sql_log_timelapse),
     copy_bool,
-    print_bool
+    print_bool,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "sql_query_start",
@@ -1527,7 +1670,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(sql_query_start),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "sql_query",
@@ -1535,7 +1679,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(sql_query),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "database_type",
@@ -1546,7 +1691,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(database_type),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "database_dbname",
@@ -1555,7 +1701,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(database_dbname),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "database_host",
@@ -1563,7 +1710,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(database_host),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "database_user",
@@ -1571,7 +1719,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(database_user),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
     {
     "database_password",
@@ -1579,7 +1728,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(database_password),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
     },
     {
     "database_port",
@@ -1588,7 +1738,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(database_port),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "database_busy_timeout",
@@ -1596,7 +1747,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(database_busy_timeout),
     copy_int,
-    print_int
+    print_int,
+    WEBUI_LEVEL_ADVANCED
     },
     {
     "video_pipe",
@@ -1608,7 +1760,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(vidpipe),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "motion_video_pipe",
@@ -1617,7 +1770,8 @@ config_param config_params[] = {
     0,
     CONF_OFFSET(motionvidpipe),
     copy_string,
-    print_string
+    print_string,
+    WEBUI_LEVEL_LIMITED
     },
     {
     "camera",
@@ -1630,7 +1784,8 @@ config_param config_params[] = {
     1,
     0,
     config_camera,
-    print_camera
+    print_camera,
+    WEBUI_LEVEL_ADVANCED
     },
     /* using a conf.d style camera addition */
     {
@@ -1643,9 +1798,10 @@ config_param config_params[] = {
     1,
     CONF_OFFSET(camera_dir),
     read_camera_dir,
-    print_string
+    print_string,
+    WEBUI_LEVEL_ADVANCED
     },
-    { NULL, NULL, 0, 0, NULL, NULL }
+    { NULL, NULL, 0, 0, NULL, NULL, 0 }
 };
 
 /*

--- a/conf.h
+++ b/conf.h
@@ -84,6 +84,7 @@ struct config {
     int webcontrol_port;
     int webcontrol_localhost;
     int webcontrol_html_output;
+    int webcontrol_parms;
     const char *webcontrol_authentication;
     unsigned long frequency;
     int tuner_number;
@@ -168,6 +169,7 @@ typedef struct {
     int conf_value;                   /* pointer to a field in struct context     */
     conf_copy_func  copy;             /* a function to set the value in 'config'  */
     conf_print_func print;            /* a function to output the value to a file */
+    int  webui_level;                 /* Enum to display in webui: 0,1,2,3,99(always to never)*/
 } config_param;
 
 extern config_param config_params[];

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -501,6 +501,10 @@ webcontrol_html_output on
 # Default: not defined (Disabled)
 ; webcontrol_authentication username:password
 
+# Parameters to include on webcontrol.  0=none, 1=limited, 2=advanced, 3=restricted
+# Default: 0 (none)
+webcontrol_parms 0
+
 
 ############################################################
 # Tracking (Pan/Tilt)

--- a/motion.1
+++ b/motion.1
@@ -1611,6 +1611,26 @@ The authentication method to use for viewing the web control.
 .RE
 
 .TP
+.B webcontrol_parms
+.RS
+.nf
+Values:
+.RS
+0 = No parameters available to change on web control
+1 = Limited list of parameters available to change
+2 = Advanced list of parameters (usually requires restart to become effective)
+3 = Restricted list of parameters (User IDs, passwords, commands to execute, etc)
+.RE
+Default: 0
+Description:
+.fi
+.RS
+The type of parameters that are able to be modified via the web interface.  This parameter can never be modified
+via the web interface and must be specified directly in the configuration file.
+.RE
+.RE
+
+.TP
 .B track_type
 .RS
 .nf

--- a/motion.c
+++ b/motion.c
@@ -3169,6 +3169,7 @@ int main (int argc, char **argv)
          * Create a thread for the control interface if requested. Create it
          * detached and with 'motion_web_control' as the thread function.
          */
+
         if (cnt_list[0]->conf.webcontrol_port) {
             pthread_mutex_lock(&global_lock);
             threads_running++;

--- a/motion.h
+++ b/motion.h
@@ -255,6 +255,14 @@ enum CAMERA_TYPE {
     CAMERA_TYPE_NETCAM
 };
 
+enum WEBUI_LEVEL{
+  WEBUI_LEVEL_ALWAYS     = 0,
+  WEBUI_LEVEL_LIMITED    = 1,
+  WEBUI_LEVEL_ADVANCED   = 2,
+  WEBUI_LEVEL_RESTRICTED = 3,
+  WEBUI_LEVEL_NEVER      = 99
+};
+
 struct image_data {
     unsigned char *image_norm;
     unsigned char *image_high;

--- a/motion_guide.html
+++ b/motion_guide.html
@@ -2085,6 +2085,12 @@ Some configuration options are only used if Motion is built on a system that has
 		<td align="left">webcontrol_localhost</td>
 		<td align="left"><a href="#webcontrol_localhost" >webcontrol_localhost</a></td>
 	</tr>
+    <tr>
+		<td height="17" align="left"></td>
+		<td align="left"></td>
+		<td align="left"></td>
+		<td align="left"><a href="#webcontrol_parms" >webcontrol_parms</a></td>
+	</tr>
 	<tr>
 		<td height="17" align="left">control_port</td>
 		<td align="left">webcontrol_port</td>
@@ -2516,6 +2522,10 @@ Some configuration options are only used if Motion is built on a system that has
        <td bgcolor="#edf4f9" ><a href="#webcontrol_html_output" >webcontrol_html_output</a> </td>
        <td bgcolor="#edf4f9" ><a href="#webcontrol_authentication" >webcontrol_authentication</a> </td>
      </tr>
+     <tr>
+       <td bgcolor="#edf4f9" ><a href="#webcontrol_parms" >webcontrol_parms</a> </td>
+     </tr>
+
    </tbody>
 </table>
 
@@ -5355,6 +5365,28 @@ The syntax is username:password
 <p></p>
 <p></p>
 </ul>
+
+<h3><a name="webcontrol_parms"></a> webcontrol_parms </h3>
+<p></p>
+<ul>
+  <li> Type: Integer</li>
+  <li> Range / Valid values: 0 - 3</li>
+  <li> Default: 0 (disabled)</li>
+</ul>
+<p></p>
+Sets the type of parameters that will be listed on the webcontrol page and available for
+modification.
+<ul>
+  <li> 0: None - No configuration parameters will be available.</li>
+  <li> 1: Limited- A limited list of parameters will be available. </li>
+  <li> 2: Advanced - The advanced list of parameters will be available.  These typically require Motion to be restarted to become effective.</li>
+  <li> 3: Restricted - User IDs, passwords and "On" commands.</li>
+</ul>
+The default for this parameter is 0 none to enhance the security of the web interface.  The setting of the
+webcontrol_parms is NEVER included on the web interface and this parameter must be specified via the configuration file.
+Care should be exercised when using level restricted level because if the webcontrol is compromised,
+it may compromise the computer.
+<p></p>
 
 <h3><a name="Options_Database"></a>Database</h3>
 <ul>

--- a/webhttpd.c
+++ b/webhttpd.c
@@ -466,7 +466,9 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
 
                 for (i=0; config_params[i].param_name != NULL; i++) {
 
-                    if ((thread != 0) && (config_params[i].main_thread))
+                    if (((thread != 0) && (config_params[i].main_thread)) ||
+                        (config_params[i].webui_level > cnt[0]->conf.webcontrol_parms) ||
+                        (config_params[i].webui_level == WEBUI_LEVEL_NEVER) )
                         continue;
 
                     value = config_params[i].print(cnt, NULL, i, thread);
@@ -568,7 +570,10 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                 /* check if command exists and type of command and not end of URI */
                 i=0;
                 while (config_params[i].param_name != NULL) {
-                    if ((thread != 0) && (config_params[i].main_thread)) {
+
+                    if (((thread != 0) && (config_params[i].main_thread)) ||
+                        (config_params[i].webui_level > cnt[0]->conf.webcontrol_parms) ||
+                        (config_params[i].webui_level == WEBUI_LEVEL_NEVER) ) {
                         i++;
                         continue;
                     }
@@ -670,7 +675,9 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                     (((length_uri = length_uri - strlen(command)) == 0))) {
                     i=0;
                     while (config_params[i].param_name != NULL) {
-                        if ((thread != 0) && (config_params[i].main_thread)) {
+                        if (((thread != 0) && (config_params[i].main_thread)) ||
+                            (config_params[i].webui_level > cnt[0]->conf.webcontrol_parms) ||
+                            (config_params[i].webui_level == WEBUI_LEVEL_NEVER) ) {
                             i++;
                             continue;
                         }
@@ -768,7 +775,9 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
 
                 send_template(client_socket, res);
                 for (i=0; config_params[i].param_name != NULL; i++) {
-                    if ((thread != 0) && (config_params[i].main_thread))
+                    if (((thread != 0) && (config_params[i].main_thread)) ||
+                        (config_params[i].webui_level > cnt[0]->conf.webcontrol_parms) ||
+                        (config_params[i].webui_level == WEBUI_LEVEL_NEVER) )
                         continue;
                     sprintf(res, "<option value='%s'>%s</option>\n",
                             config_params[i].param_name, config_params[i].param_name);
@@ -816,7 +825,9 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                     const char *value = NULL;
                     i = 0;
                     while (config_params[i].param_name != NULL) {
-                        if ((thread != 0) && (config_params[i].main_thread)) {
+                        if (((thread != 0) && (config_params[i].main_thread)) ||
+                            (config_params[i].webui_level > cnt[0]->conf.webcontrol_parms) ||
+                            (config_params[i].webui_level == WEBUI_LEVEL_NEVER) ) {
                             i++;
                             continue;
                         }
@@ -901,7 +912,9 @@ static unsigned int config(char *pointer, char *res, unsigned int length_uri,
                         cnt[thread]->conf.camera_name ? cnt[thread]->conf.camera_name : "");
                 send_template(client_socket, res);
                 for (i=0; config_params[i].param_name != NULL; i++) {
-                    if ((thread != 0) && (config_params[i].main_thread))
+                    if (((thread != 0) && (config_params[i].main_thread)) ||
+                        (config_params[i].webui_level > cnt[0]->conf.webcontrol_parms) ||
+                        (config_params[i].webui_level == WEBUI_LEVEL_NEVER) )
                         continue;
                     sprintf(res, "<option value='%s'>%s</option>\n",
                             config_params[i].param_name, config_params[i].param_name);
@@ -2701,6 +2714,8 @@ void *motion_web_control(void *arg)
     util_threadname_set("wc", 0,NULL);
 
     httpd_run(cnt);
+
+
 
     /*
      * Update how many threads we have running. This is done within a


### PR DESCRIPTION
Implement a new configuration option which allows users to specify the type of parameters which can be accessed via the webcontrol page.  The new option permits levels 0(none) to 3(restricted) with a default of none.  This option is to enhance the security associated with the application for users that may expose the webcontrol port publicly.