### PR TITLE
Debug movie filename fix and motion detect log enhancement

### DIFF
--- a/event.c
+++ b/event.c
@@ -782,13 +782,18 @@ static void event_ffmpeg_newfile(struct context *cnt,
     }
 
     if (cnt->conf.ffmpeg_output_debug) {
+        char debugfilename[PATH_MAX];
         cnt->ffmpeg_output_debug = mymalloc(sizeof(struct ffmpeg));
         cnt->ffmpeg_output_debug->width  = cnt->imgs.width;
         cnt->ffmpeg_output_debug->height = cnt->imgs.height;
         cnt->ffmpeg_output_debug->tlapse = TIMELAPSE_NONE;
         cnt->ffmpeg_output_debug->fps = cnt->movie_fps;
         cnt->ffmpeg_output_debug->bps = cnt->conf.ffmpeg_bps;
-        cnt->ffmpeg_output_debug->filename = cnt->newfilename;
+        strcpy(debugfilename,cnt->newfilename);
+        debugfilename[strlen(debugfilename)-4] = 0;
+        strcat(debugfilename,"-debug");
+        cnt->ffmpeg_output_debug->filename = debugfilename;
+        MOTION_LOG(NTC, TYPE_EVENTS, NO_ERRNO, "ffopen_open creating (new debug) file [%s]",cnt->ffmpeg_output_debug->filename);
         cnt->ffmpeg_output_debug->vbr = cnt->conf.ffmpeg_vbr;
         cnt->ffmpeg_output_debug->start_time.tv_sec = currenttime_tv->tv_sec;
         cnt->ffmpeg_output_debug->start_time.tv_usec = currenttime_tv->tv_usec;

--- a/motion.c
+++ b/motion.c
@@ -572,8 +572,8 @@ static void motion_detected(struct context *cnt, int dev, struct image_data *img
             event(cnt, EVENT_FIRSTMOTION, img, NULL, NULL,
                 &cnt->imgs.image_ring[cnt->imgs.image_ring_out].timestamp_tv);
 
-            MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO, "Motion detected - starting event %d",
-                       cnt->event_nr);
+            MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO, "Motion detected (%d)- starting event %d",
+                       cnt->current_image->diffs, cnt->event_nr);
 
             /* always save first motion frame as preview-shot, may be changed to an other one later */
             if (cnt->new_img & (NEWIMG_FIRST | NEWIMG_BEST | NEWIMG_CENTER))

--- a/motion_guide.html
+++ b/motion_guide.html
@@ -4846,7 +4846,7 @@ Works like ffmpeg_output_movies but outputs motion pixel type pictures instead.
 This feature generates the special motion type movie where you only see the pixels
 that changes as a graytone image. If labeling is enabled you see the largest area in blue.
 Smartmask is shown in red. The filename given is the same as the normal movies except they
-have an 'm' appended after the filename.
+have an '-debug' appended after the filename.
 <p></p>
 <p></p>
 


### PR DESCRIPTION
The debug filename for movies was not adding suffix. Resolved to add -debug to filename for debug movies. Updated motion_guide to reflect change. Also added diff count to motion detected log entry.