### PR TITLE
Fix pthread_setname_np detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,17 +128,20 @@ fi
 if test x$THREADS = xyes; then
   TEMP_LIBS="$TEMP_LIBS -pthread"
   TEMP_CFLAGS="${TEMP_CFLAGS} -D_THREAD_SAFE"
-fi
 
 ##############################################################################
 ###  Check for pthread_setname_np (nonstandard GNU extension)
 ##############################################################################
-AC_MSG_CHECKING([for pthread_setname_np])
-AC_COMPILE_IFELSE(
+  AC_MSG_CHECKING([for pthread_setname_np])
+  HOLD_LIBS="$LIBS"
+  LIBS="$TEMP_LIBS"
+  AC_LINK_IFELSE(
     [AC_LANG_PROGRAM([#include <pthread.h>], [pthread_setname_np(pthread_self(), "name")])],
     [AC_DEFINE([HAVE_PTHREAD_SETNAME_NP], [1], [Define if you have pthread_setname_np function.])
     AC_MSG_RESULT([yes])],
     [AC_MSG_RESULT([no])] )
+  LIBS="$HOLD_LIBS"
+fi
 
 ##############################################################################
 ###  Check for JPG

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,6 @@
 # Process this file with autoconf to produce a configure script
 
 AC_INIT(motion, esyscmd(['./version.sh']))
-AC_GNU_SOURCE
 AC_CONFIG_SRCDIR([motion.c])
 AC_CONFIG_HEADERS(config.h)
 AC_PROG_CC
@@ -136,7 +135,14 @@ if test x$THREADS = xyes; then
   HOLD_LIBS="$LIBS"
   LIBS="$TEMP_LIBS"
   AC_LINK_IFELSE(
-    [AC_LANG_PROGRAM([#include <pthread.h>], [pthread_setname_np(pthread_self(), "name")])],
+    [AC_LANG_SOURCE[
+      #define _GNU_SOURCE
+      #include <pthread.h>
+      int main(int argc, char** argv) {
+        int ret = pthread_setname_np(pthread_self(), "name");
+        return ret;
+      }
+    ]],
     [AC_DEFINE([HAVE_PTHREAD_SETNAME_NP], [1], [Define if you have pthread_setname_np function.])
     AC_MSG_RESULT([yes])],
     [AC_MSG_RESULT([no])] )
@@ -146,13 +152,42 @@ if test x$THREADS = xyes; then
 ##############################################################################
   AC_MSG_CHECKING([for pthread_getname_np])
   AC_LINK_IFELSE(
-    [AC_LANG_PROGRAM([#include <pthread.h>], [pthread_getname_np(pthread_self(), NULL, 0)])],
+    [AC_LANG_SOURCE[
+      #define _GNU_SOURCE
+      #include <pthread.h>
+      int main(int argc, char** argv) {
+        char buf[1024];
+        int ret = pthread_getname_np(pthread_self(), buf, sizeof(buf));
+        return ret;
+      }
+    ]],
     [AC_DEFINE([HAVE_PTHREAD_GETNAME_NP], [1], [Define if you have pthread_getname_np function.])
     AC_MSG_RESULT([yes])],
     [AC_MSG_RESULT([no])] )
 
   LIBS="$HOLD_LIBS"
 fi
+
+##############################################################################
+###  Check for XSI strerror_r
+##############################################################################
+AC_MSG_CHECKING([for XSI strerror_r])
+HOLD_CFLAGS="$CFLAGS"
+CFLAGS="$CFLAGS -Werror"
+AC_LINK_IFELSE(
+  [AC_LANG_SOURCE[
+    #include <string.h>
+    #include <errno.h>
+    int main(int argc, char** argv) {
+      char buf[1024];
+      int ret = strerror_r(ENOMEM, buf, sizeof(buf));
+      return ret;
+    }
+  ]],
+  [AC_DEFINE([XSI_STRERROR_R], [1], [Define if you have XSI strerror_r function.])
+  AC_MSG_RESULT([yes])],
+  [AC_MSG_RESULT([no])] )
+CFLAGS="$HOLD_CFLAGS"
 
 ##############################################################################
 ###  Check for JPG

--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,17 @@ if test x$THREADS = xyes; then
     [AC_DEFINE([HAVE_PTHREAD_SETNAME_NP], [1], [Define if you have pthread_setname_np function.])
     AC_MSG_RESULT([yes])],
     [AC_MSG_RESULT([no])] )
+
+##############################################################################
+###  Check for pthread_getname_np (nonstandard GNU extension)
+##############################################################################
+  AC_MSG_CHECKING([for pthread_getname_np])
+  AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM([#include <pthread.h>], [pthread_getname_np(pthread_self(), NULL, 0)])],
+    [AC_DEFINE([HAVE_PTHREAD_GETNAME_NP], [1], [Define if you have pthread_getname_np function.])
+    AC_MSG_RESULT([yes])],
+    [AC_MSG_RESULT([no])] )
+
   LIBS="$HOLD_LIBS"
 fi
 

--- a/logger.c
+++ b/logger.c
@@ -206,10 +206,8 @@ void motion_log(int level, unsigned int type, int errno_flag, const char *fmt, .
      */
     errno_save = errno;
 
-    char threadname[32] = "unknown";
-#if ((!defined(BSD) && HAVE_PTHREAD_SETNAME_NP) || defined(__APPLE__))
-    pthread_getname_np(pthread_self(), threadname, sizeof(threadname));
-#endif
+    char threadname[32];
+    util_threadname_get(threadname);
 
     /*
      * Prefix the message with the thread number and name,

--- a/motion.c
+++ b/motion.c
@@ -6,6 +6,9 @@
  *    See also the file 'COPYING'.
  *
  */
+#define _GNU_SOURCE   /* pthread_setname_np/pthread_getname_np needs this */
+#include <pthread.h>
+
 #include "motion.h"
 #include "ffmpeg.h"
 #include "video_common.h"

--- a/motion.c
+++ b/motion.c
@@ -3772,7 +3772,7 @@ void util_threadname_set(const char *abbr, int threadnbr, const char *threadname
 
 void util_threadname_get(char *threadname){
 
-#if ((!defined(BSD) && HAVE_PTHREAD_SETNAME_NP) || defined(__APPLE__))
+#if ((!defined(BSD) && HAVE_PTHREAD_GETNAME_NP) || defined(__APPLE__))
     char currname[16];
     pthread_getname_np(pthread_self(), currname, sizeof(currname));
     snprintf(threadname, sizeof(currname), "%s",currname);

--- a/motion.h
+++ b/motion.h
@@ -100,11 +100,6 @@ struct image_data;
 #define ATTRIBUTE_UNUSED
 #endif
 
-/* strerror_r() XSI vs GNU */
-#if (defined(BSD)) || ((_POSIX_C_SOURCE >= 200112L || _XOPEN_SOURCE >= 600) && ! _GNU_SOURCE)
-#define XSI_STRERROR_R
-#endif
-
 
 /*
  *  The macro below defines a version of sleep using nanosleep

--- a/netcam_jpeg.c
+++ b/netcam_jpeg.c
@@ -12,6 +12,9 @@
  *    This program is published under the GNU Public license
  */
 
+#define _GNU_SOURCE    /* memmem needs this */
+#include <string.h>
+
 #include "rotate.h"    /* already includes motion.h */
 #include <jpeglib.h>
 #include <jerror.h>

--- a/stream.c
+++ b/stream.c
@@ -18,6 +18,9 @@
  *    Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+#define _GNU_SOURCE   /* MOTION_PTHREAD_SETNAME (pthread_setname_np) needs this */
+#include <pthread.h>
+
 #include "md5.h"
 #include "picture.h"
 #include <sys/socket.h>

--- a/video_common.c
+++ b/video_common.c
@@ -9,6 +9,9 @@
  *
  */
 
+#define _GNU_SOURCE    /* memmem needs this */
+#include <string.h>
+
 #include "motion.h"
 #include "video_common.h"
 #include "video_v4l2.h"


### PR DESCRIPTION
Commit 6617c6f2c8aad041d3428bea11206fd2e61763b1 replaced
AC_LINK_IFELSE with AC_COMPILE_IFELSE. This has broken the
pthread_setname_np detection as compilation will always succeed even if
pthread_setname_np is not available (if the function is not found, a
simple warning will be displayed in config.log).

The correct fix is to put back AC_LINK_IFELSE with -pthread in LIBS
otherwise compilation will fail on toolchain without pthread_setname_np.

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>