### PR TITLE
Guide Update

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,16 @@
 Summary of Changes
+   * Updated motion_guide.html
+   * Revise webcontrol page to indicate the webcontrol_parms selection
+   * Validate v4l2 parms when using v4l2 via netcam
+   * Capture images at start to prevent immediate events
+   * Initialize thread number to eliminate inaccurate log notice.
+   * Allow URLS with underscores
+   * Passthrough recording for rtsp cameras.
+   * Remove default SQL (which was specific to Maria)
+   * Default webp image type to be included in builds.
+   * Include EXIF for webp images.
+   * Report to log when user specifies invalid URL.
+   * Updated version script to include date and dirty vs clean.
 Version 4.1.1 Changes Below
    * Fix file name for debug movies
    * Fix image saving when using highres option

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Issues on the github site are intended to discuss code problems, crashes and application enhancements.  If you are having an issue with the setup, 
 configuration or use of Motion, we have the following additional resources which are better suited to meet these needs.
 
-  * User guide:  [Motion User Guide](http://htmlpreview.github.com/?https://github.com/Motion-Project/motion/blob/master/motion_guide.html)
+  * User guide:  [Motion User Guide](https://motion-project.github.io/motion_guide.html)
   * User Group List:  Please sign-up and send your issue to the list [Motion User](https://lists.sourceforge.net/lists/listinfo/motion-user)  
   * IRC:  [#motion](irc://chat.freenode.net/motion) on freenode
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,7 +1,8 @@
+0. Reviewed guide and contributing documents? (Yes/No):
 1. version [x.y.z, hash, other]: 
 2. installed as a package or compiled from sources [deb, rpm, git, other]: 
 3. standalone or part of third party [motion, MotionEyeOS, other]: 
 4. video stream source [V4L (card or USB), net cam (mjpeg, rtsp, other), mmal]: 
 5. hardware [x86, ARM, other]: 
-6. operating system [Linux (which), FreeBSD, other]: 
+6. operating system [16.04, Stretch, etc, FreeBSD, other]: 
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ words, it can detect motion.
 
 The documentation for Motion is contained within the file motion_guide.html.
 
-The offline version of this file is available in the **doc/motion** directory.  The 
-online version of the motion_guide.html file is within the master branch and can be viewed [here](http://htmlpreview.github.com/?https://github.com/Motion-Project/motion/blob/master/motion_guide.html)
+The offline version of this file is available in the **doc/motion** directory.  The
+online version of the motion_guide.html file can be viewed [here](https://motion-project.github.io/motion_guide.html)
 
-In addition to the detailed building instructions included within the guide, the 
+In addition to the detailed building instructions included within the guide, the
 INSTALL file contains abbreviated building instructions.
 
 ## Resources

--- a/conf.c
+++ b/conf.c
@@ -2821,6 +2821,7 @@ static struct context **config_camera(struct context **cnt, const char *str,
 static void usage()
 {
     printf("motion Version "VERSION", Copyright 2000-2017 Jeroen Vreeken/Folkert van Heusden/Kenneth Lavrsen/Motion-Project maintainers\n");
+    printf("\nHome page :\t https://motion-project.github.io/ \n");
     printf("\nusage:\tmotion [options]\n");
     printf("\n\n");
     printf("Possible options:\n\n");

--- a/motion_build.html
+++ b/motion_build.html
@@ -9,11 +9,11 @@
 </head>
 <body style="margin-left:15%;">
   <ul class="nav-button">
-    <li class="nav-button"><a href="motion_support.html">Support</a></li>
-    <li class="nav-button"><a href="motion_news.html">News</a></li>
-    <li class="nav-button"><a href="motion_guide.html">Documentation</a></li>
-    <li class="nav-button"><a href="motion_download.html">Download</a></li>
-    <li class="nav-button"><a href="index.html">Home</a></li>
+    <li class="nav-button"><a href="https://motion-project.github.io/motion_support.html">Support</a></li>
+    <li class="nav-button"><a href="https://motion-project.github.io/motion_news.html">News</a></li>
+    <li class="nav-button"><a href="https://motion-project.github.io/motion_guide.html">Documentation</a></li>
+    <li class="nav-button"><a href="https://motion-project.github.io/motion_download.html">Download</a></li>
+    <li class="nav-button"><a href="https://motion-project.github.io/index.html">Home</a></li>
     <li class="nav-button" style="float: left;"> <img src="motion.gif" width="125" height="50"> </li>
   </ul>
   <section class="page-header">

--- a/motion_config.html
+++ b/motion_config.html
@@ -9,11 +9,11 @@
 </head>
 <body style="margin-left:15%;">
   <ul class="nav-button">
-    <li class="nav-button"><a href="motion_support.html">Support</a></li>
-    <li class="nav-button"><a href="motion_news.html">News</a></li>
-    <li class="nav-button"><a href="motion_guide.html">Documentation</a></li>
-    <li class="nav-button"><a href="motion_download.html">Download</a></li>
-    <li class="nav-button"><a href="index.html">Home</a></li>
+    <li class="nav-button"><a href="https://motion-project.github.io/motion_support.html">Support</a></li>
+    <li class="nav-button"><a href="https://motion-project.github.io/motion_news.html">News</a></li>
+    <li class="nav-button"><a href="https://motion-project.github.io/motion_guide.html">Documentation</a></li>
+    <li class="nav-button"><a href="https://motion-project.github.io/motion_download.html">Download</a></li>
+    <li class="nav-button"><a href="https://motion-project.github.io/index.html">Home</a></li>
     <li class="nav-button" style="float: left;"> <img src="motion.gif" width="125" height="50"> </li>
   </ul>
   <section class="page-header">

--- a/motion_guide.html
+++ b/motion_guide.html
@@ -9,11 +9,11 @@
   </head>
   <body>
     <ul class="nav-button">
-      <li class="nav-button"><a href="motion_support.html">Support</a></li>
-      <li class="nav-button"><a href="motion_news.html">News</a></li>
-      <li class="nav-button"><a href="motion_guide.html">Documentation</a></li>
-      <li class="nav-button"><a href="motion_download.html">Download</a></li>
-      <li class="nav-button"><a href="index.html">Home</a></li>
+      <li class="nav-button"><a href="https://motion-project.github.io/motion_support.html">Support</a></li>
+      <li class="nav-button"><a href="https://motion-project.github.io/motion_news.html">News</a></li>
+      <li class="nav-button"><a href="https://motion-project.github.io/motion_guide.html">Documentation</a></li>
+      <li class="nav-button"><a href="https://motion-project.github.io/motion_download.html">Download</a></li>
+      <li class="nav-button"><a href="https://motion-project.github.io/index.html">Home</a></li>
       <li class="nav-button" style="float: left;"> <img src="motion.gif" width="125" height="50"> </li>
     </ul>
     <section class="page-header">
@@ -44,22 +44,20 @@
       <p></p>
       <h3><a name="Git_Master_Guides"></a> Current Git Master</h3>
       <ul>
-      <li> <a href="http://htmlpreview.github.com/?https://github.com/Motion-Project/motion/blob/master/motion_build.html"> Installing with apt/debs and building from source </a></li>
-      <li> <a href="http://htmlpreview.github.com/?https://github.com/Motion-Project/motion/blob/master/motion_config.html"> Configuration </a></li>
-      <li> <a href="http://htmlpreview.github.com/?https://github.com/Motion-Project/motion/blob/master/motion_config.html#Command_Line_Options"> Command Line Options </a></li>
-      <li> <a href="http://htmlpreview.github.com/?https://github.com/Motion-Project/motion/blob/master/motion_config.html#The_Config_Files">Configuration Files</a></li>
-      <li> <a href="http://htmlpreview.github.com/?https://github.com/Motion-Project/motion/blob/master/motion_config.html#Signals_Sent"> Signals (sent with e.g. kill command) </a></li>
+      <li> <a href="https://rawgit.com/Motion-Project/motion/master/motion_build.html"> Installing with apt/debs and building from source </a></li>
+      <li> <a href="https://rawgit.com/Motion-Project/motion/master/motion_config.html"> Configuration </a></li>
+      <li> <a href="https://rawgit.com/Motion-Project/motion/master/motion_config.html#Command_Line_Options"> Command Line Options </a></li>
+      <li> <a href="https://rawgit.com/Motion-Project/motion/master/motion_config.html#The_Config_Files">Configuration Files</a></li>
+      <li> <a href="https://rawgit.com/Motion-Project/motion/master/motion_config.html#Signals_Sent"> Signals (sent with e.g. kill command) </a></li>
       <li> Configuration Options</li>
         <ul>
-          <li> <a href="http://htmlpreview.github.com/?https://github.com/Motion-Project/motion/blob/master/motion_config.html#Configuration_OptionsAlpha"> Listed alphabetically with mapping of old option names to current names </a></li>
-          <li> <a href="http://htmlpreview.github.com/?https://github.com/Motion-Project/motion/blob/master/motion_config.html#Configuration_OptionsTopic"> Listed by topic </a></li>
-          <li> <a href="http://htmlpreview.github.com/?https://github.com/Motion-Project/motion/blob/master/motion_config.html#Configuration_OptionsDetail"> Detail descriptions of each option</a></li>
+          <li> <a href="https://rawgit.com/Motion-Project/motion/master/motion_config.html#Configuration_OptionsAlpha"> Listed alphabetically with mapping of old option names to current names </a></li>
+          <li> <a href="https://rawgit.com/Motion-Project/motion/master/motion_config.html#Configuration_OptionsTopic"> Listed by topic </a></li>
+          <li> <a href="https://rawgit.com/Motion-Project/motion/master/motion_config.html#Configuration_OptionsDetail"> Detail descriptions of each option</a></li>
           </ul>
       <p></p>
       <p></p>
       </ul>
-
-
 
     </section>
   </body>


### PR DESCRIPTION
1.  Change from htmlpreview to rawgit.
2.  In guide have top menu always point to home page.
3.  Include the home page in the usage notice.
4.  Reference home page guide as preferred default
5.  Update changelog with revisions since 4.1.1