### PR TITLE
Cross origin resource sharing (CORS) config parameter.

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -167,7 +167,7 @@ static struct context **copy_int(struct context **, const char *, int);
 static struct context **config_camera(struct context **cnt, const char *str, int val);
 static struct context **read_camera_dir(struct context **cnt, const char *str, int val);
 static struct context **copy_vid_ctrl(struct context **, const char *, int);
-static struct context **copy_cors_header(struct context **cnt, const char *str, int val);
+static struct context **copy_uri(struct context **cnt, const char *str, int val);
 
 static const char *print_bool(struct context **, char **, int, unsigned int);
 static const char *print_int(struct context **, char **, int, unsigned int);
@@ -1278,7 +1278,7 @@ config_param config_params[] = {
     "# Default: not defined (Disabled)",
     0,
     CONF_OFFSET(stream_cors_header),
-    copy_cors_header,
+    copy_uri,
     print_string,
     WEBUI_LEVEL_RESTRICTED
     },
@@ -2501,24 +2501,24 @@ struct context **copy_vid_ctrl(struct context **cnt, const char *config_val, int
     return cnt;
 }
 
-static struct context **copy_cors_header(struct context **cnt, const char *str, int val) {
+static struct context **copy_uri(struct context **cnt, const char *str, int val) {
 
-    // Here's a complicated URI regex I found here: http://snipplr.com/view/6889/regular-expressions-for-uri-validationparsing/
-    const char *regex_str = "/^([a-z0-9+.-]+):(?://(?:((?:[a-z0-9-._~!$&'()*+,;=:]|%[0-9A-F]{2})*)@)?((?:[a-z0-9-._~!$&'()*+,;=]|%[0-9A-F]{2})*)(?::(\\d*))?(/(?:[a-z0-9-._~!$&'()*+,;=:@/]|%[0-9A-F]{2})*)?|(/?(?:[a-z0-9-._~!$&'()*+,;=:@]|%[0-9A-F]{2})+(?:[a-z0-9-._~!$&'()*+,;=:@/]|%[0-9A-F]{2})*)?)(?:\\?((?:[a-z0-9-._~!$&'()*+,;=:/?@]|%[0-9A-F]{2})*))?(?:#((?:[a-z0-9-._~!$&'()*+,;=:/?@]|%[0-9A-F]{2})*))?$/i";
+    // Here's a complicated regex I found here: https://stackoverflow.com/questions/38608116/how-to-check-a-specified-string-is-a-valid-url-or-not-using-c-code
+    // Use it for validating URIs.
+    const char *regex_str = "^(https?:\\/\\/)?([\\da-z\\.-]+)\\.([a-z\\.]{2,6})([\\/\\w \\.-]*)*\\/?$";
 
     regex_t regex;
-    if (regcomp(&regex, regex_str, 0) != 0) {
-        MOTION_LOG(ERR, TYPE_STREAM, NO_ERRNO, "Error compiling regex in copy_cors_header");
+    if (regcomp(&regex, regex_str, REG_EXTENDED) != 0) {
+        MOTION_LOG(ERR, TYPE_STREAM, NO_ERRNO, "Error compiling regex in copy_uri");
         cnt = copy_string(cnt, "", val);
         return cnt;
     }
 
     // A single asterisk is also valid, so check for that.
     if (strcmp(str, "*") != 0 && regexec(&regex, str, 0, NULL, 0) == REG_NOMATCH) {
-        MOTION_LOG(ERR, TYPE_STREAM, NO_ERRNO, "Invalid origin for cors_header in copy_cors_header");
+        MOTION_LOG(ERR, TYPE_STREAM, NO_ERRNO, "Invalid origin for cors_header in copy_uri");
         cnt = copy_string(cnt, "", val);
         return cnt;
-
     }
 
     cnt = copy_string(cnt, str, val);

--- a/conf.c
+++ b/conf.c
@@ -2510,17 +2510,17 @@ static struct context **copy_uri(struct context **cnt, const char *str, int val)
     regex_t regex;
     if (regcomp(&regex, regex_str, REG_EXTENDED) != 0) {
         MOTION_LOG(ERR, TYPE_STREAM, NO_ERRNO, "Error compiling regex in copy_uri");
-        cnt = copy_string(cnt, "", val);
         return cnt;
     }
 
     // A single asterisk is also valid, so check for that.
     if (strcmp(str, "*") != 0 && regexec(&regex, str, 0, NULL, 0) == REG_NOMATCH) {
         MOTION_LOG(ERR, TYPE_STREAM, NO_ERRNO, "Invalid origin for cors_header in copy_uri");
-        cnt = copy_string(cnt, "", val);
+        regfree(&regex);
         return cnt;
     }
 
+    regfree(&regex);
     cnt = copy_string(cnt, str, val);
     return cnt;
 

--- a/conf.c
+++ b/conf.c
@@ -167,7 +167,6 @@ static struct context **copy_int(struct context **, const char *, int);
 static struct context **config_camera(struct context **cnt, const char *str, int val);
 static struct context **read_camera_dir(struct context **cnt, const char *str, int val);
 static struct context **copy_vid_ctrl(struct context **, const char *, int);
-static struct context **copy_uri(struct context **cnt, const char *str, int val);
 
 static const char *print_bool(struct context **, char **, int, unsigned int);
 static const char *print_int(struct context **, char **, int, unsigned int);
@@ -2313,7 +2312,8 @@ void malloc_strings(struct context *cnt)
     unsigned int i = 0;
     char **val;
     while (config_params[i].param_name != NULL) {
-        if (config_params[i].copy == copy_string) { /* if member is a string */
+        if (config_params[i].copy == copy_string ||
+            config_params[i].copy == copy_uri) { /* if member is a string */
             /* val is made to point to a pointer to the current string. */
             val = (char **)((char *)cnt+config_params[i].conf_value);
 
@@ -2518,7 +2518,7 @@ struct context **copy_vid_ctrl(struct context **cnt, const char *config_val, int
     return cnt;
 }
 
-static struct context **copy_uri(struct context **cnt, const char *str, int val) {
+struct context **copy_uri(struct context **cnt, const char *str, int val) {
 
     // Here's a complicated regex I found here: https://stackoverflow.com/questions/38608116/how-to-check-a-specified-string-is-a-valid-url-or-not-using-c-code
     // Use it for validating URIs.
@@ -2624,6 +2624,8 @@ const char *config_type(config_param *configparam)
         return "int";
     if (configparam->copy == copy_bool)
         return "bool";
+    if (configparam->copy == copy_uri)
+        return "uri";
 
     return "unknown";
 }

--- a/conf.c
+++ b/conf.c
@@ -85,6 +85,7 @@ struct config conf_template = {
     .stream_localhost =                1,
     .stream_limit =                    0,
     .stream_auth_method =              0,
+    .stream_cors_header =              NULL,
     .stream_authentication =           NULL,
     .stream_preview_scale =            25,
     .stream_preview_newline =          0,
@@ -1271,6 +1272,16 @@ config_param config_params[] = {
     WEBUI_LEVEL_RESTRICTED
     },
     {
+    "stream_cors_header",
+    "# Set the cross-origin resource sharing (CORS) header\n"
+    "# Default: not defined (Disabled)",
+    0,
+    CONF_OFFSET(stream_cors_header),
+    copy_string,
+    print_string,
+    WEBUI_LEVEL_RESTRICTED
+    },
+    {
     "stream_authentication",
     "# Authentication for the stream. Syntax username:password\n"
     "# Default: not defined (Disabled)",
@@ -2246,6 +2257,7 @@ void conf_output_parms(struct context **cnt)
                 if (!strncmp(name, "netcam_url", 10) ||
                     !strncmp(name, "netcam_userpass", 15) ||
                     !strncmp(name, "netcam_highres", 14) ||
+                    !strncmp(name, "stream_cors_header", 18) ||
                     !strncmp(name, "stream_authentication", 21) ||
                     !strncmp(name, "webcontrol_authentication", 25) ||
                     !strncmp(name, "database_user", 13) ||

--- a/conf.h
+++ b/conf.h
@@ -74,6 +74,7 @@ struct config {
     int stream_localhost;
     int stream_limit;
     int stream_auth_method;
+    const char *stream_cors_header;
     const char *stream_authentication;
     int stream_preview_scale;
     int stream_preview_newline;

--- a/conf.h
+++ b/conf.h
@@ -184,6 +184,7 @@ extern dep_config_param dep_config_params[];
 
 struct context **conf_load(struct context **);
 struct context **copy_string(struct context **, const char *, int);
+struct context **copy_uri(struct context **, const char *, int);
 struct context **conf_cmdparse(struct context **, const char *, const char *);
 void conf_output_parms(struct context **cnt);
 const char *config_type(config_param *);

--- a/motion.1
+++ b/motion.1
@@ -1513,6 +1513,22 @@ The authentication method to use for viewing the stream.
 .RE
 
 .TP
+.B stream_cors_header
+.RS
+.nf
+Values: User specified string
+Default: Not defined
+Description:
+.fi
+.RS
+The Access-Control-Allow-Origin header value to be sent with the stream.
+If unspecified, no Access-Control-Allow-Origin header is sent.
+The header allows browsers to access the stream via cross-origin resource sharing (CORS).
+For example, * allows access from browser client code served from any domain.
+.RE
+.RE
+
+.TP
 .B stream_authentication
 .RS
 .nf

--- a/motion.c
+++ b/motion.c
@@ -278,7 +278,8 @@ static void context_destroy(struct context *cnt)
 
     /* Free memory allocated for config parameters */
     for (j = 0; config_params[j].param_name != NULL; j++) {
-        if (config_params[j].copy == copy_string) {
+        if (config_params[j].copy == copy_string ||
+            config_params[j].copy == copy_uri) {
             void **val;
             val = (void *)((char *)cnt+(int)config_params[j].conf_value);
             if (*val) {

--- a/motion.c
+++ b/motion.c
@@ -1195,7 +1195,7 @@ static int motion_init(struct context *cnt)
     /* Initialize stream server if stream port is specified to not 0 */
     if (cnt->conf.stream_port) {
         if (stream_init (&(cnt->stream), cnt->conf.stream_port, cnt->conf.stream_localhost,
-            cnt->conf.ipv6_enabled) == -1) {
+            cnt->conf.ipv6_enabled, cnt->conf.stream_cors_header) == -1) {
             MOTION_LOG(ERR, TYPE_ALL, SHOW_ERRNO, "Problem enabling motion-stream server in port %d",
                        cnt->conf.stream_port);
             cnt->conf.stream_port = 0;
@@ -1212,7 +1212,7 @@ static int motion_init(struct context *cnt)
         if ((cnt->conf.width / 2) % 8 == 0  && (cnt->conf.height / 2) % 8 == 0
         && cnt->imgs.type == VIDEO_PALETTE_YUV420P){
             if (stream_init (&(cnt->substream), cnt->conf.substream_port, cnt->conf.stream_localhost,
-                cnt->conf.ipv6_enabled) == -1) {
+                cnt->conf.ipv6_enabled, cnt->conf.stream_cors_header) == -1) {
                 MOTION_LOG(ERR, TYPE_ALL, SHOW_ERRNO, "Problem enabling motion-substream server in port %d",
                            cnt->conf.substream_port);
                 cnt->conf.substream_port = 0;

--- a/motion_config.html
+++ b/motion_config.html
@@ -957,8 +957,8 @@
         </tr>
         <tr>
           <td height="17" align="left"><br /></td>
-          <td align="left">stream_cors_header</td>
-          <td align="left">stream_cors_header</td>
+          <td align="left"></td>
+          <td align="left"></td>
           <td align="left"><a href="#stream_cors_header" >stream_cors_header</a></td>
         </tr>
         <tr>
@@ -1682,7 +1682,6 @@
             </tr>
             <tr>
               <td bgcolor="#edf4f9" ><a href="#stream_auth_method" >stream_auth_method</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#stream_cors_header" >stream_cors_header</a> </td>
               <td bgcolor="#edf4f9" ><a href="#stream_authentication" >stream_authentication</a> </td>
               <td bgcolor="#edf4f9" ><a href="#stream_preview_scale" >stream_preview_scale</a> </td>
               <td bgcolor="#edf4f9" ><a href="#stream_preview_newline" >stream_preview_newline</a> </td>
@@ -1695,6 +1694,7 @@
             </tr>
             <tr>
               <td bgcolor="#edf4f9" ><a href="#webcontrol_parms" >webcontrol_parms</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#stream_cors_header" >stream_cors_header</a> </td>
             </tr>
            </tbody>
         </table>

--- a/motion_config.html
+++ b/motion_config.html
@@ -4604,14 +4604,14 @@
         <p></p>
         <ul>
           <li> Type: String</li>
-          <li> Range / Valid values: TODO</li>
+          <li> Range / Valid values: * or a valid URI</li>
           <li> Default: Not Defined</li>
         </ul>
         <p></p>
         The Access-Control-Allow-Origin header value to be sent with the stream.
         If unspecified, no Access-Control-Allow-Origin header is sent.
         The header allows browsers to access the stream via cross-origin resource sharing (CORS).
-        For example, * allows access from browser client code served from any domain.
+        For example, * allows access from browser client code served from any origin.
         <p></p>
 
         <h3><a name="stream_preview_scale"></a> stream_preview_scale </h3>

--- a/motion_config.html
+++ b/motion_config.html
@@ -957,6 +957,12 @@
         </tr>
         <tr>
           <td height="17" align="left"><br /></td>
+          <td align="left">stream_cors_header</td>
+          <td align="left">stream_cors_header</td>
+          <td align="left"><a href="#stream_cors_header" >stream_cors_header</a></td>
+        </tr>
+        <tr>
+          <td height="17" align="left"><br /></td>
           <td align="left">stream_authentication</td>
           <td align="left">stream_authentication</td>
           <td align="left"><a href="#stream_authentication" >stream_authentication</a></td>
@@ -1676,6 +1682,7 @@
             </tr>
             <tr>
               <td bgcolor="#edf4f9" ><a href="#stream_auth_method" >stream_auth_method</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#stream_cors_header" >stream_cors_header</a> </td>
               <td bgcolor="#edf4f9" ><a href="#stream_authentication" >stream_authentication</a> </td>
               <td bgcolor="#edf4f9" ><a href="#stream_preview_scale" >stream_preview_scale</a> </td>
               <td bgcolor="#edf4f9" ><a href="#stream_preview_newline" >stream_preview_newline</a> </td>
@@ -4591,6 +4598,20 @@
         <p></p>
         This parameter establishes the username and password to use for the stream.
         The syntax is username:password
+        <p></p>
+
+        <h3><a name="stream_cors_header"></a> stream_cors_header </h3>
+        <p></p>
+        <ul>
+          <li> Type: String</li>
+          <li> Range / Valid values: TODO</li>
+          <li> Default: Not Defined</li>
+        </ul>
+        <p></p>
+        The Access-Control-Allow-Origin header value to be sent with the stream.
+        If unspecified, no Access-Control-Allow-Origin header is sent.
+        The header allows browsers to access the stream via cross-origin resource sharing (CORS).
+        For example, * allows access from browser client code served from any domain.
         <p></p>
 
         <h3><a name="stream_preview_scale"></a> stream_preview_scale </h3>

--- a/stream.c
+++ b/stream.c
@@ -995,6 +995,10 @@ static void stream_add_client(struct stream *list, int sc, const char *cors_head
         header_len += snprintf(&header_buffer[header_len-2], HEADER_BUFFER_LEN-header_len, "Access-Control-Allow-Origin: %s\r\n\r\n", cors_header);
     }
 
+    if (header_len == HEADER_BUFFER_LEN-1) {
+        MOTION_LOG(ERR, TYPE_STREAM, NO_ERRNO, "Error building header in stream_add_client, stream_cors_header config parameter is probably too long");
+    }
+
     memset(new, 0, sizeof(struct stream));
     new->socket = sc;
 

--- a/stream.c
+++ b/stream.c
@@ -908,6 +908,7 @@ static void stream_flush(struct stream *list, int *stream_count, int lim)
                 if (--client->tmpbuffer->ref <= 0) {
                     free(client->tmpbuffer->ptr);
                     free(client->tmpbuffer);
+                    if (client->cors_header != NULL) free(client->cors_header);
                 }
 
                 /* Mark this client's buffer as empty. */
@@ -1102,7 +1103,6 @@ int stream_init(struct stream *stm,
     stm->socket = http_bindsock(port, localhost, ipv6_enabled);
     stm->next = NULL;
     stm->prev = NULL;
-
     stm->cors_header = NULL;
 
     if (cors_header != NULL) {
@@ -1144,9 +1144,7 @@ void stream_stop(struct stream *stm)
         if (list->tmpbuffer) {
             free(list->tmpbuffer->ptr);
             free(list->tmpbuffer);
-            if (list->cors_header != NULL) {
-                free(list->cors_header);
-            }
+            if (list->cors_header != NULL) free(list->cors_header);
         }
 
         close(list->socket);

--- a/stream.c
+++ b/stream.c
@@ -979,6 +979,7 @@ static void stream_add_client(struct stream *list, int sc)
     struct stream *new = mymalloc(sizeof(struct stream));
     static const char header[] = "HTTP/1.0 200 OK\r\n"
                                  "Server: Motion/"VERSION"\r\n"
+                                 "Access-Control-Allow-Origin: *\r\n" // TODO(jack) Add a config.
                                  "Connection: close\r\n"
                                  "Max-Age: 0\r\n"
                                  "Expires: 0\r\n"

--- a/stream.c
+++ b/stream.c
@@ -1136,6 +1136,7 @@ void stream_stop(struct stream *stm)
 
     close(stm->socket);
     stm->socket = -1;
+    free(stm->cors_header);
 
     while (next) {
         list = next;

--- a/stream.c
+++ b/stream.c
@@ -979,17 +979,18 @@ static void stream_add_client(struct stream *list, int sc, const char *cors_head
 {
     struct stream *new = mymalloc(sizeof(struct stream));
 
-    static char header_buffer[HEADER_BUFFER_LEN] = "HTTP/1.0 200 OK\r\n"
-                                                   "Server: Motion/"VERSION"\r\n"
-                                                   "Connection: close\r\n"
-                                                   "Max-Age: 0\r\n"
-                                                   "Expires: 0\r\n"
-                                                   "Cache-Control: no-cache, private\r\n"
-                                                   "Pragma: no-cache\r\n"
-                                                   "Content-Type: multipart/x-mixed-replace; "
-                                                   "boundary=BoundaryString\r\n\r\n";
-
-    size_t header_len = strlen(header_buffer);
+    static char header_buffer[HEADER_BUFFER_LEN];
+    size_t header_len = snprintf(header_buffer,
+                                 HEADER_BUFFER_LEN,
+                                 "HTTP/1.0 200 OK\r\n"
+                                 "Server: Motion/"VERSION"\r\n"
+                                 "Connection: close\r\n"
+                                 "Max-Age: 0\r\n"
+                                 "Expires: 0\r\n"
+                                 "Cache-Control: no-cache, private\r\n"
+                                 "Pragma: no-cache\r\n"
+                                 "Content-Type: multipart/x-mixed-replace; "
+                                 "boundary=BoundaryString\r\n\r\n");
 
     if (cors_header != NULL) {
         header_len += snprintf(&header_buffer[header_len-2], HEADER_BUFFER_LEN-header_len, "Access-Control-Allow-Origin: %s\r\n\r\n", cors_header);
@@ -1005,7 +1006,6 @@ static void stream_add_client(struct stream *list, int sc, const char *cors_head
     if ((new->tmpbuffer = stream_tmpbuffer(header_len)) == NULL) {
         MOTION_LOG(ERR, TYPE_STREAM, SHOW_ERRNO, "Error creating tmpbuffer in stream_add_client");
     } else {
-        //memcpy(new->tmpbuffer->ptr, header, sizeof(header)-1);
         memcpy(new->tmpbuffer->ptr, header_buffer, header_len);
         new->tmpbuffer->size = header_len;
     }

--- a/stream.c
+++ b/stream.c
@@ -26,7 +26,6 @@
 #include <netdb.h>
 #include <ctype.h>
 #include <fcntl.h>
-#include <regex.h>      /* For validating the CORS header parameter. */
 
 #define STREAM_REALM       "Motion Stream Security Access"
 #define KEEP_ALIVE_TIMEOUT 100
@@ -1107,26 +1106,6 @@ int stream_init(struct stream *stm,
     stm->cors_header = NULL;
 
     if (cors_header != NULL) {
-
-        // Validate cors_header.
-
-        // A single asterisk is valid.
-        if (strcmp(cors_header, "*") != 0) {
-
-            // Here's a complicated URI regex I found here: http://snipplr.com/view/6889/regular-expressions-for-uri-validationparsing/
-            regex_t regex;
-            const char *str = "/^([a-z0-9+.-]+):(?://(?:((?:[a-z0-9-._~!$&'()*+,;=:]|%[0-9A-F]{2})*)@)?((?:[a-z0-9-._~!$&'()*+,;=]|%[0-9A-F]{2})*)(?::(\\d*))?(/(?:[a-z0-9-._~!$&'()*+,;=:@/]|%[0-9A-F]{2})*)?|(/?(?:[a-z0-9-._~!$&'()*+,;=:@]|%[0-9A-F]{2})+(?:[a-z0-9-._~!$&'()*+,;=:@/]|%[0-9A-F]{2})*)?)(?:\\?((?:[a-z0-9-._~!$&'()*+,;=:/?@]|%[0-9A-F]{2})*))?(?:#((?:[a-z0-9-._~!$&'()*+,;=:/?@]|%[0-9A-F]{2})*))?$/i";
-
-            if (regcomp(&regex, str, 0) != 0) {
-                MOTION_LOG(ERR, TYPE_STREAM, NO_ERRNO, "Error compiling regex in stream_init");
-                return stm->socket;
-            }
-            if (regexec(&regex, cors_header, 0, NULL, 0) == REG_NOMATCH) {
-                MOTION_LOG(ERR, TYPE_STREAM, NO_ERRNO, "Invalid origin for cors_header in stream_init");
-                return stm->socket;
-            }
-
-        }
 
         size_t size = strlen(cors_header) + 1;
         stm->cors_header = mymalloc(size);

--- a/stream.h
+++ b/stream.h
@@ -31,6 +31,7 @@ struct stream {
     int socket;
     FILE *fwrite;
     struct stream_buffer *tmpbuffer;
+    char *cors_header;
     long filepos;
     int nr;
     unsigned long int last;
@@ -38,7 +39,11 @@ struct stream {
     struct stream *next;
 };
 
-int stream_init(struct stream *, int, int, int);
+int stream_init(struct stream *stm,
+                int port,
+                int localhost,
+                int ipv6_enabled,
+                const char *cors_header);
 void stream_put(struct context *, struct stream *, int *, unsigned char *, int);
 void stream_stop(struct stream *);
 


### PR DESCRIPTION
I recently wanted to make requests to motion from a web client served from a different computer. This doesn't work because motion's response headers don't support cross-origin requests. My changes add a config parameter to motion, stream_cors_header, that inserts an Access-Control-Allow-Origin line into the response header.

The only concern I have with my addition is that I use a static buffer to store the header. stream_cors_header takes a string argument, and if it's too long I log the issue and prevent us from overflowing the buffer. If this isn't a good enough solution, I'd love feedback on how to improve it.