### PR TITLE
Watchdog and RTSP time

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -833,7 +833,9 @@ static int ffmpeg_flush_codec(struct ffmpeg *ffmpeg){
     int recv_cd = 0;
     char errstr[128];
 
-    if (ffmpeg->passthrough) return 0;
+    if (ffmpeg->passthrough){
+        return 0;
+    }
 
     retcd = 0;
     recv_cd = 0;
@@ -970,7 +972,7 @@ static int ffmpeg_passthru_put(struct ffmpeg *ffmpeg, struct image_data *img_dat
 
     if ((ffmpeg->rtsp_data->status == RTSP_NOTCONNECTED  ) ||
         (ffmpeg->rtsp_data->status == RTSP_RECONNECTING  ) ){
-        return -1;
+        return 0;
     }
 
     if (ffmpeg->high_resolution){
@@ -1270,13 +1272,14 @@ void ffmpeg_close(struct ffmpeg *ffmpeg){
         if (ffmpeg_flush_codec(ffmpeg) < 0){
             MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, "Error flushing codec");
         }
-
-        if (ffmpeg->tlapse != TIMELAPSE_APPEND) {
-            av_write_trailer(ffmpeg->oc);
-        }
-        if (!(ffmpeg->oc->oformat->flags & AVFMT_NOFILE)) {
+        if (ffmpeg->oc->pb != NULL){
             if (ffmpeg->tlapse != TIMELAPSE_APPEND) {
-                avio_close(ffmpeg->oc->pb);
+                av_write_trailer(ffmpeg->oc);
+            }
+            if (!(ffmpeg->oc->oformat->flags & AVFMT_NOFILE)) {
+                if (ffmpeg->tlapse != TIMELAPSE_APPEND) {
+                    avio_close(ffmpeg->oc->pb);
+                }
             }
         }
         ffmpeg_free_context(ffmpeg);

--- a/motion.c
+++ b/motion.c
@@ -1439,6 +1439,9 @@ static void motion_cleanup(struct context *cnt)
         cnt->mpipe = -1;
     }
 
+    if (cnt->rolling_average_data != NULL) free(cnt->rolling_average_data);
+
+
     /* Cleanup the current time structure */
     free(cnt->currenttime_tm);
     cnt->currenttime_tm = NULL;
@@ -1854,8 +1857,11 @@ static int mlp_capture(struct context *cnt){
          * First missed frame - store timestamp
          * Don't reset time when thread restarts
          */
-        if (cnt->connectionlosttime == 0)
+        if (cnt->connectionlosttime == 0){
+            cnt->makemovie = 1;     /* If we lost connection, end the movie event*/
             cnt->connectionlosttime = cnt->currenttime;
+        }
+
 
         /*
          * Increase missing_frame_counter
@@ -2656,7 +2662,6 @@ static void *motion_loop(void *arg)
     }
 
 err:
-    free(cnt->rolling_average_data);
 
     cnt->lost_connection = 1;
     MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO, "Thread exiting");

--- a/motion.c
+++ b/motion.c
@@ -1858,7 +1858,6 @@ static int mlp_capture(struct context *cnt){
          * Don't reset time when thread restarts
          */
         if (cnt->connectionlosttime == 0){
-            cnt->makemovie = 1;     /* If we lost connection, end the movie event*/
             cnt->connectionlosttime = cnt->currenttime;
         }
 
@@ -3264,7 +3263,9 @@ int main (int argc, char **argv)
                         if (cnt_list[i]->watchdog == 0) {
                             MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO, "Thread %d - Watchdog timeout, trying to do "
                                        "a graceful restart", cnt_list[i]->threadnr);
+                            cnt_list[i]->makemovie = 1; /* Trigger end of event */
                             cnt_list[i]->finish = 1;
+
                         }
 
                         if (cnt_list[i]->watchdog == WATCHDOG_KILL) {


### PR DESCRIPTION
1.  Revert to just capturing time directly rather than in a routine.
2.  Check for null format context pointer before writing trailer.
3.  Terminate movie when lost connection.
4.  Clean up context when failed resize.
5.  Unlock mutex on failed first image.
6.  Fix memory leak when recovering from watchdog timeout.