### PR TITLE
Enhance 'lightswitch' with a config option of ignored frames

### DIFF
--- a/alg.c
+++ b/alg.c
@@ -1258,13 +1258,13 @@ int alg_lightswitch(struct context *cnt, int diffs)
 {
     struct images *imgs = &cnt->imgs;
 
-    if (cnt->conf.lightswitch < 0)
-        cnt->conf.lightswitch = 0;
-    if (cnt->conf.lightswitch > 100)
-        cnt->conf.lightswitch = 100;
+    if (cnt->conf.lightswitch_percent < 0)
+        cnt->conf.lightswitch_percent = 0;
+    if (cnt->conf.lightswitch_percent > 100)
+        cnt->conf.lightswitch_percent = 100;
 
     /* Is lightswitch percent of the image changed? */
-    if (diffs > (imgs->motionsize * cnt->conf.lightswitch / 100))
+    if (diffs > (imgs->motionsize * cnt->conf.lightswitch_percent / 100))
         return 1;
 
     return 0;

--- a/conf.c
+++ b/conf.c
@@ -59,7 +59,8 @@ struct config conf_template = {
     .noise =                           DEF_NOISELEVEL,
     .noise_tune =                      1,
     .minimum_frame_time =              0,
-    .lightswitch =                     0,
+    .lightswitch_percent =             0,
+    .lightswitch_frames =              5,
     .autobright =                      0,
     .vid_control_params =              NULL,
     .roundrobin_frames =               1,
@@ -711,12 +712,22 @@ config_param config_params[] = {
     WEBUI_LEVEL_LIMITED
     },
     {
-    "lightswitch",
+    "lightswitch_percent",
     "# Ignore sudden massive light intensity changes given as a percentage of the picture\n"
     "# area that changed intensity. If set to 1, motion will do some kind of\n"
     "# auto-lightswitch. Valid range: 0 - 100 , default: 0 = disabled",
     0,
-    CONF_OFFSET(lightswitch),
+    CONF_OFFSET(lightswitch_percent),
+    copy_int,
+    print_int,
+    WEBUI_LEVEL_LIMITED
+    },
+    {
+    "lightswitch_frames",
+    "# When lightswitch is detected, ignore this many frames\n"
+    "# Valid range: 1 - 1000 , default: 5",
+    0,
+    CONF_OFFSET(lightswitch_frames),
     copy_int,
     print_int,
     WEBUI_LEVEL_LIMITED
@@ -1799,6 +1810,13 @@ dep_config_param dep_config_params[] = {
     "\"webcontrol_html_output\" replaced with \"webcontrol_interface\" option.",
     CONF_OFFSET(webcontrol_interface),
     copy_html_output
+    },
+    {
+     "lightswitch",
+    "4.1.1",
+    "\"lightswitch\" replaced with \"lightswitch_percent\" and \"lightswitch_frames\" options.",
+    CONF_OFFSET(lightswitch_percent),
+    copy_int
     },
     { NULL, NULL, NULL, 0, NULL}
 };

--- a/conf.h
+++ b/conf.h
@@ -51,7 +51,8 @@ struct config {
     int noise;
     int noise_tune;
     int minimum_frame_time;
-    int lightswitch;
+    int lightswitch_percent;
+    int lightswitch_frames;
     int autobright;
     char *vid_control_params;
     int roundrobin_frames;

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -183,8 +183,13 @@ noise_level 32
 smart_mask_speed 0
 
 # Ignore sudden massive light intensity changes given as a percentage of the picture
-# area that changed intensity. Valid range: 0 - 100 , default: 0 = disabled
-lightswitch 0
+# area that changed intensity. If set to 1, motion will do some kind of
+# auto-lightswitch. Valid range: 0 - 100 , default: 0 = disabled
+lightswitch_percent 0
+
+# When lightswitch is detected, ignore this many frames
+# Valid range: 1 - 1000 , default: 5"
+lightswitch_frames 5
 
 # Picture frames must contain motion at least the specified number of frames
 # in a row before they are detected as true motion. At the default of 1, all

--- a/motion_config.html
+++ b/motion_config.html
@@ -615,7 +615,13 @@
           <td height="17" align="left">lightswitch</td>
           <td align="left">lightswitch</td>
           <td align="left">lightswitch</td>
-          <td align="left"><a href="#lightswitch" >lightswitch</a></td>
+          <td align="left"><a href="#lightswitch_percent" >lightswitch_percent</a></td>
+        </tr>
+        <tr>
+            <td height="17" align="left"></td>
+            <td align="left"></td>
+            <td align="left"></td>
+            <td align="left"><a href="#lightswitch_frames" >lightswitch_frames</a></td>
         </tr>
         <tr>
           <td height="17" align="left">locate</td>
@@ -1503,7 +1509,8 @@
             </tr>
             <tr>
               <td bgcolor="#edf4f9" ><a href="#smart_mask_speed" >smart_mask_speed</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#lightswitch" >lightswitch</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#lightswitch_percent" >lightswitch_percent</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#lightswitch_frames" >lightswitch_frames</a> </td>
               <td bgcolor="#edf4f9" ><a href="#minimum_motion_frames" >minimum_motion_frames</a> </td>
               <td bgcolor="#edf4f9" ><a href="#event_gap" >event_gap</a> </td>
             </tr>
@@ -3437,7 +3444,7 @@
 
         <p></p>
 
-        <h3><a name="lightswitch"></a> lightswitch </h3>
+        <h3><a name="lightswitch_percent"></a> lightswitch_percent </h3>
         <p></p>
         <ul>
           <li> Type: Integer</li>
@@ -3447,8 +3454,19 @@
         <p></p>
         Ignore sudden massive light intensity changes given as a percentage of the picture area that changed intensity.
         The value defines the picture areas in percent that will trigger the lightswitch condition. When lightswitch is
-        detected motion detection is disabled for 5 picture frames. This is to avoid false detection when light conditions
-        change and when a camera changes sensitivity at low light.
+        detected motion detection is disabled for a configured number of frames. This is to avoid false detection when
+        light conditions change and when a camera changes sensitivity at low light.
+        <p></p>
+
+        <h3><a name="lightswitch_frames"></a> lightswitch_frames </h3>
+        <p></p>
+        <ul>
+          <li> Type: Integer</li>
+          <li> Range / Valid values: 1 - 1000</li>
+          <li> Default: 5</li>
+        </ul>
+        <p></p>
+        The number of frames to ignore when the lightswitch condition is triggered (see above).
         <p></p>
 
         <h3><a name="minimum_motion_frames"></a> minimum_motion_frames </h3>


### PR DESCRIPTION
#### Config changes
* `lightswitch` changed to `lightswitch_percent`
* `lightswitch` deprecated and copied to `lightswitch_percent`
* `lightswitch_frames` added

#### Code changes
* No changes to the use of `lightswitch_percent` other than the name of the variable throughout.  
* Declare `lightswitch_frames` as `int` so it can handle incorrect values from the config and forced a range of `1 - 1000` before being cast to `unsigned int` to be compared with `cnt->moved`.
* Default of 5 used for `lightswitch_frames` to match current code for seamless updating

#### Guide/Example Config changes
* Updated `lightswitch` for name change and added the bit about "1 being auto-lightswitch" from `conf.c`.
* Added `lightswitch_frames`

### Testing
* Tested to not crash upon out of range config values
* `lightswitch` condition is still triggered as expected.  
* **Was not** tested to work completely as intended (ie. ignoring more than 5 frames). Would appreciate if some of the community could give this a full function test.

Resolves #686