### PR TITLE
Web Interface Revisions

### DIFF
--- a/webu.c
+++ b/webu.c
@@ -900,7 +900,7 @@ static void webu_html_style_base(struct webui_ctx *webui) {
         "    body {\n"
         "      padding: 0;\n"
         "      margin: 0;\n"
-        "      font-family: \"Open Sans\", \"Helvetica Neue\", Helvetica, Arial, sans-serif;\n"
+        "      font-family: Arial, Helvetica, sans-serif;\n"
         "      font-size: 16px;\n"
         "      line-height: 1;\n"
         "      color: #606c71;\n"

--- a/webu.c
+++ b/webu.c
@@ -1128,19 +1128,19 @@ static void webu_html_config_notice(struct context **cnt, struct webui_ctx *webu
 
     if (cnt[0]->conf.webcontrol_parms == 0){
         snprintf(response, sizeof (response),
-            "    <h4 id='h4_parm' class='header-center'>webcontrol_parms = %s</h4>\n"
+            "    <h4 id='h4_parm' class='header-center'>webcontrol_parms = 0 (%s)</h4>\n"
             ,_("No Configuration Options"));
     } else if (cnt[0]->conf.webcontrol_parms == 1){
         snprintf(response, sizeof (response),
-            "    <h4 id='h4_parm' class='header-center'>webcontrol_parms = %s</h4>\n"
+            "    <h4 id='h4_parm' class='header-center'>webcontrol_parms = 1 (%s)</h4>\n"
             ,_("Limited Configuration Options"));
     } else if (cnt[0]->conf.webcontrol_parms == 2){
         snprintf(response, sizeof (response),
-            "    <h4 id='h4_parm' class='header-center'>webcontrol_parms = %s</h4>\n"
+            "    <h4 id='h4_parm' class='header-center'>webcontrol_parms = 2 (%s)</h4>\n"
             ,_("Advanced Configuration Options"));
     } else{
         snprintf(response, sizeof (response),
-            "    <h4 id='h4_parm' class='header-center'>webcontrol_parms = %s</h4>\n"
+            "    <h4 id='h4_parm' class='header-center'>webcontrol_parms = 3 (%s)</h4>\n"
             ,_("Restricted Configuration Options"));
     }
     written = webu_write(webui->client_socket, response, strlen(response));

--- a/webu.c
+++ b/webu.c
@@ -1388,6 +1388,8 @@ static void webu_html_script_action(struct context **cnt, struct webui_ctx *webu
         "        http.send(null);\n"
         "      }\n"
         "      document.getElementById('act_btn').style.display=\"none\"; \n"
+        "      document.getElementById('cfg_value').value = '';\n"
+        "      document.getElementById('cfg_parms').value = 'default';\n"
         "    }\n\n");
     written = webu_write(webui->client_socket, response, strlen(response));
 
@@ -1512,6 +1514,8 @@ static void webu_html_script_camera(struct context **cnt, struct webui_ctx *webu
         "      document.getElementById('cfg_form').style.display=\"none\"; \n"
         "      document.getElementById('trk_form').style.display=\"none\"; \n"
         "      document.getElementById('cam_btn').style.display=\"none\"; \n"
+        "      document.getElementById('cfg_value').value = '';\n"
+        "      document.getElementById('cfg_parms').value = 'default';\n"
         "    }\n\n");
     written = webu_write(webui->client_socket, response, strlen(response));
 


### PR DESCRIPTION
1.  Correct parameter values when using multiple cameras.  Closes #691 
2.  Clear configuration boxes when a menu action is performed.
3.  Show actual webcontrol_parm value in header for clarity to user.