### PR TITLE
Warn high framerates on mmal cams

### DIFF
--- a/mmalcam.c
+++ b/mmalcam.c
@@ -94,6 +94,11 @@ static void set_video_port_format(mmalcam_context_ptr mmalcam, MMAL_ES_FORMAT_T 
     set_port_format(mmalcam, format);
     format->es->video.frame_rate.num = mmalcam->framerate;
     format->es->video.frame_rate.den = VIDEO_FRAME_RATE_DEN;
+    if (mmalcam->framerate > 30){
+        /* The pi noir camera could not determine autoexpose at high frame rates */
+        MOTION_LOG(WRN, TYPE_VIDEO, NO_ERRNO, _("A high frame rate can cause problems with exposure of images"));
+        MOTION_LOG(WRN, TYPE_VIDEO, NO_ERRNO, _("If autoexposure is not working, try a lower frame rate."));
+    }
 }
 
 static int create_camera_component(mmalcam_context_ptr mmalcam, const char *mmalcam_name)


### PR DESCRIPTION
Warn users that use of high frame rates could impact exposure of images.  Closes #679