### PR TITLE
Fix memory leak from read_camera_dir()

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -166,7 +166,6 @@ static void malloc_strings(struct context *);
 static struct context **copy_bool(struct context **, const char *, int);
 static struct context **copy_int(struct context **, const char *, int);
 static struct context **config_camera(struct context **cnt, const char *str, int val);
-static struct context **read_camera_dir(struct context **cnt, const char *str, int val);
 static struct context **copy_vid_ctrl(struct context **, const char *, int);
 static struct context **copy_text_double(struct context **, const char *, int);
 static struct context **copy_html_output(struct context **, const char *, int);
@@ -2834,8 +2833,7 @@ static const char *print_camera(struct context **cnt, char **str,
  *     When found calls config_camera
  */
 
-static struct context **read_camera_dir(struct context **cnt, const char *str,
-                                            int val)
+struct context **read_camera_dir(struct context **cnt, const char *str, int val)
 {
     DIR *dp;
     struct dirent *ep;

--- a/conf.h
+++ b/conf.h
@@ -187,6 +187,7 @@ struct context **conf_load(struct context **);
 struct context **copy_string(struct context **, const char *, int);
 struct context **copy_uri(struct context **, const char *, int);
 struct context **conf_cmdparse(struct context **, const char *, const char *);
+struct context **read_camera_dir(struct context **, const char *, int);
 void conf_output_parms(struct context **cnt);
 const char *config_type(config_param *);
 void conf_print(struct context **);

--- a/motion.c
+++ b/motion.c
@@ -290,7 +290,8 @@ static void context_destroy(struct context *cnt)
     /* Free memory allocated for config parameters */
     for (j = 0; config_params[j].param_name != NULL; j++) {
         if (config_params[j].copy == copy_string ||
-            config_params[j].copy == copy_uri) {
+            config_params[j].copy == copy_uri ||
+            config_params[j].copy == read_camera_dir) {
             void **val;
             val = (void *)((char *)cnt+(int)config_params[j].conf_value);
             if (*val) {


### PR DESCRIPTION
In commit da556d7 (store the value of 'camera_dir'), a memory leak
was introduced due to not freeing this memory in context_destroy().
I followed the advice in PR #639 to correct this.
Valgrind was used to find this leak and test for successful fixing.
Config included a 'camera_dir' with two camera config files.
Command ran: valgrind --leak-check=full ./bin/motion -n

Before:
HEAP SUMMARY:
    in use at exit: 91,538 bytes in 13 blocks
  total heap usage: 4,227 allocs, 4,214 frees, 20,448,321 bytes allocated

126 bytes in 3 blocks are definitely lost in loss record 8 of 11
   at 0x4C2FB55: calloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
   by 0x406A6D: mymalloc (motion.c:3401)
   by 0x40D0CF: mystrdup (conf.c:2687)
   by 0x40D30C: mystrcpy (conf.c:2664)
   by 0x40D30C: copy_string (conf.c:2470)
   by 0x40D565: read_camera_dir (conf.c:2883)
   by 0x40CA10: conf_process (conf.c:2034)
   by 0x40D850: conf_load (conf.c:2236)
   by 0x407063: cntlist_create (motion.c:2876)
   by 0x407063: motion_startup (motion.c:2930)
   by 0x4052B7: main (motion.c:3128)

LEAK SUMMARY:
   definitely lost: 126 bytes in 3 blocks
   indirectly lost: 0 bytes in 0 blocks
     possibly lost: 0 bytes in 0 blocks
   still reachable: 91,412 bytes in 10 blocks
        suppressed: 0 bytes in 0 blocks

After:
HEAP SUMMARY:
    in use at exit: 91,412 bytes in 10 blocks
  total heap usage: 4,201 allocs, 4,191 frees, 20,447,579 bytes allocated

LEAK SUMMARY:
   definitely lost: 0 bytes in 0 blocks
   indirectly lost: 0 bytes in 0 blocks
     possibly lost: 0 bytes in 0 blocks
   still reachable: 91,412 bytes in 10 blocks
        suppressed: 0 bytes in 0 blocks