### PR TITLE
Add camera_name and conversion specifiers to config files

### DIFF
--- a/camera1-dist.conf.in
+++ b/camera1-dist.conf.in
@@ -12,12 +12,17 @@
 # Default: The order when the camera file was read
 # camera_id = 1
 
+# Camera Name
+# This option specifies a camera name to be used in the format specifiers as well as on the web interface.
+# Default: null (empty)
+# camera_name = cam1
+
 # Videodevice to be used for capturing  (default /dev/video0)
-# for FreeBSD default is /dev/bktr0 
+# for FreeBSD default is /dev/bktr0
 videodevice /dev/video0
 
 # The video input to be used (default: -1)
-# Should normally be set to 1 for video/TV cards, and -1 for USB cameras 
+# Should normally be set to 1 for video/TV cards, and -1 for USB cameras
 input -1
 
 # Draw a user defined text on the images using same options as C function strftime(3)
@@ -67,5 +72,4 @@ stream_port 8081
 
 # Command to be executed when a movie file (.mpg|.avi) is closed. (default: none)
 # Filename of movie is appended as an argument for the command.
-#on_movie_end /usr/local/motion-extras/mpegparse2.pl 
-
+#on_movie_end /usr/local/motion-extras/mpegparse2.pl

--- a/camera2-dist.conf.in
+++ b/camera2-dist.conf.in
@@ -12,12 +12,17 @@
 # Default: The order when the camera file was read
 # camera_id = 2
 
+# Camera Name
+# This option specifies a camera name to be used in the format specifiers as well as on the web interface.
+# Default: null (empty)
+# camera_name = cam2
+
 # Videodevice to be used for capturing  (default /dev/video0)
-# for FreeBSD default is /dev/bktr0 
+# for FreeBSD default is /dev/bktr0
 videodevice /dev/video1
 
 # The video input to be used (default: -1)
-# Should normally be set to 1 for video/TV cards, and -1 for USB cameras 
+# Should normally be set to 1 for video/TV cards, and -1 for USB cameras
 input 1
 
 # Draw a user defined text on the images using same options as C function strftime(3)
@@ -67,5 +72,4 @@ stream_port 8082
 
 # Command to be executed when a movie file (.mpg|.avi) is closed. (default: none)
 # Filename of movie is appended as an argument for the command.
-#on_movie_end /usr/local/motion-extras/mpegparse2.pl 
-
+#on_movie_end /usr/local/motion-extras/mpegparse2.pl

--- a/camera3-dist.conf.in
+++ b/camera3-dist.conf.in
@@ -12,12 +12,17 @@
 # Default: The order when the camera file was read
 # camera_id = 3
 
+# Camera Name
+# This option specifies a camera name to be used in the format specifiers as well as on the web interface.
+# Default: null (empty)
+# camera_name = cam3
+
 # Videodevice to be used for capturing  (default /dev/video0)
-# for FreeBSD default is /dev/bktr0 
+# for FreeBSD default is /dev/bktr0
 videodevice /dev/video2
 
 # The video input to be used (default: -1)
-# Should normally be set to 1 for video/TV cards, and -1 for USB cameras 
+# Should normally be set to 1 for video/TV cards, and -1 for USB cameras
 input -1
 
 # Draw a user defined text on the images using same options as C function strftime(3)
@@ -67,5 +72,4 @@ stream_port 8083
 
 # Command to be executed when a movie file (.mpg|.avi) is closed. (default: none)
 # Filename of movie is appended as an argument for the command.
-#on_movie_end /usr/local/motion-extras/mpegparse2.pl 
-
+#on_movie_end /usr/local/motion-extras/mpegparse2.pl

--- a/camera4-dist.conf.in
+++ b/camera4-dist.conf.in
@@ -12,12 +12,17 @@
 # Default: The order when the camera file was read
 # camera_id = 4
 
+# Camera Name
+# This option specifies a camera name to be used in the format specifiers as well as on the web interface.
+# Default: null (empty)
+# camera_name = cam4
+
 # Videodevice to be used for capturing  (default /dev/video0)
-# for FreeBSD default is /dev/bktr0 
+# for FreeBSD default is /dev/bktr0
 videodevice /dev/video3
 
 # The video input to be used (default: -1)
-# Should normally be set to 1 for video/TV cards, and -1 for USB cameras 
+# Should normally be set to 1 for video/TV cards, and -1 for USB cameras
 input -1
 
 # Draw a user defined text on the images using same options as C function strftime(3)
@@ -67,5 +72,4 @@ stream_port 8084
 
 # Command to be executed when a movie file (.mpg|.avi) is closed. (default: none)
 # Filename of movie is appended as an argument for the command.
-#on_movie_end /usr/local/motion-extras/mpegparse2.pl 
-
+#on_movie_end /usr/local/motion-extras/mpegparse2.pl

--- a/motion-dist.conf.in
+++ b/motion-dist.conf.in
@@ -318,6 +318,10 @@ snapshot_interval 0
 # %i and %J = width and height of motion area,
 # %K and %L = X and Y coordinates of motion center
 # %C = value defined by text_event - do not use with text_event!
+# %o = threshold, %Q = Number of labels from despeckle,
+# %$ = camera_name, %{fps} = current frames per second,
+# %{host} = name of computer running motion,
+# %{ver} = version of Motion
 # You can put quotation marks around the text to allow
 # leading spaces
 ############################################################
@@ -377,6 +381,11 @@ text_scale 1
 # %i and %J = width and height of motion area,
 # %K and %L = X and Y coordinates of motion center
 # %C = value defined by text_event
+# %o = threshold, %Q = Number of labels from despeckle,
+# %$ = camera_name, %{fps} = current frames per second,
+# %{host} = name of computer running motion,
+# %{ver} = version of Motion
+# %{dbeventid} = SQL database insert ID for event
 # Quotation marks round string are allowed.
 ############################################################
 
@@ -571,6 +580,11 @@ track_stepsize 40
 # %C = value defined by text_event
 # %f = filename with full path
 # %n = number indicating filetype
+# %o = threshold, %Q = Number of labels from despeckle,
+# %$ = camera_name, %{fps} = current frames per second,
+# %{host} = name of computer running motion,
+# %{ver} = version of Motion
+# %{dbeventid} = SQL database insert ID for event
 # Both %f and %n are only defined for on_picture_save,
 # on_movie_start and on_movie_end
 # Quotation marks round string are allowed.


### PR DESCRIPTION
After doing some digging and a conversation in IRC yesterday, I found that:

1. The ``camera_name`` setting introduced by #158 isn't in the example configuration files anywhere
2. Many of the new conversion specifiers also aren't in the example configuration files anywhere.

This PR attempts to correct that.