### PR TITLE
remove incorrect escaping

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -19,7 +19,7 @@ msgstr ""
 #: conf.c:1960
 #, c-format
 msgid "Deprecated config option \"%s\" since after version %s:"
-msgstr "L\'option de configuration \"%s\" est dépréciée depuis la version %s:"
+msgstr "L'option de configuration \"%s\" est dépréciée depuis la version %s:"
 
 #: conf.c:1984
 #, c-format


### PR DESCRIPTION
The escaped apostrophe caused the following error when running `make`.

```
Performing the conversion of .po to .mo files
./po/fr.po:22:11: invalid control sequence
msgfmt: found 1 fatal error
```