### PR TITLE
Fix webu_process_action for a default single camera config

### DIFF
--- a/webu.c
+++ b/webu.c
@@ -1862,14 +1862,14 @@ static void webu_process_action(struct context **cnt, struct webui_ctx *webui) {
 
     indx = 0;
     if (!strcmp(webui->uri_cmd2,"makemovie")){
-        if (thread_nbr == 0) {
+        if (thread_nbr == 0 && webui->cam_threads > 1) {
             while (cnt[++indx])
             cnt[indx]->makemovie = 1;
         } else {
             cnt[thread_nbr]->makemovie = 1;
         }
     } else if (!strcmp(webui->uri_cmd2,"snapshot")){
-        if (thread_nbr == 0) {
+        if (thread_nbr == 0 && webui->cam_threads > 1) {
             while (cnt[++indx])
             cnt[indx]->snapshot = 1;
         } else {
@@ -1904,7 +1904,7 @@ static void webu_process_action(struct context **cnt, struct webui_ctx *webui) {
             cnt[thread_nbr]->finish = 1;
         }
     } else if (!strcmp(webui->uri_cmd2,"start")){
-        if (thread_nbr == 0) {
+        if (thread_nbr == 0 && webui->cam_threads > 1) {
             do {
                 cnt[indx]->pause = 0;
             } while (cnt[++indx]);
@@ -1912,7 +1912,7 @@ static void webu_process_action(struct context **cnt, struct webui_ctx *webui) {
             cnt[thread_nbr]->pause = 0;
         }
     } else if (!strcmp(webui->uri_cmd2,"pause")){
-        if (thread_nbr == 0) {
+        if (thread_nbr == 0 && webui->cam_threads > 1) {
             do {
                 cnt[indx]->pause = 1;
             } while (cnt[++indx]);


### PR DESCRIPTION
> When using the single 'motion.conf' file for a single camera setup, the webu actions are skipping over the only thread due to assuming that thread '0' is just motion and all cameras are subsequent.
> This leaves the webu actions useless to the default single camera, single config setup.
> 
> Fix this by checking that more than one camera thread exists to use the thread loop, using the given thread number ('0') otherwise.

Since `cam_threads` is equal to the number of total threads, we can safely check for it being greater than `1` to know which logic path is required.  
The other areas within `webu.c` utilize for loops with a separate if statement taking care of `indx` starting at `0 or 1`.

### Testing
Quickly tested with `curl -v http://IP:Port/0/action/snapshot` to three config scenarios and got the expected, correct results each time:
- Single config (motion.conf) for a single camera
- Two configs (motion.conf and camera1.conf) for a single camera
- Multiple configs (motion.conf and 3 camera#.conf (using camera_dir)) for 3 cameras.

Did not test the other three actions, as they look to follow the same requirements as snapshot. If I have time yet in the next day or so, I'll run a test on them just to be sure.

Fixes #735 