### PR TITLE
update to reflect correct 'output_pictures' default

### DIFF
--- a/motion_config.html
+++ b/motion_config.html
@@ -3897,7 +3897,7 @@
         <ul>
           <li> Type: Discrete Strings</li>
           <li> Range / Valid values: on, off, first, best</li>
-          <li> Default: on</li>
+          <li> Default: off</li>
         </ul>
         <p></p>
         This option controls the output of the normal image.


### PR DESCRIPTION
The default setting for 'output_pictures' option was changed
from 'on' to 'off', but the docs had not been updated.

The commit that changed the default can be seen here:
https://github.com/Motion-Project/motion/commit/ec9a5f993dbc131b58142515ededbd090c497049#diff-bedf08e0ecf6012344e7d35a645072e4L256

This change brings the docs into agreement with the new default.