### PR TITLE
Generic Tracking

### DIFF
--- a/motion.c
+++ b/motion.c
@@ -265,6 +265,7 @@ static void context_init(struct context *cnt)
     cnt->lastrate = 25;
 
     memcpy(&cnt->track, &track_template, sizeof(struct trackoptions));
+
     cnt->pipe = -1;
     cnt->mpipe = -1;
 
@@ -1355,6 +1356,8 @@ static int motion_init(struct context *cnt)
         cnt->rolling_average_data[indx] = cnt->required_frame_time;
 
 
+    cnt->track_posx = 0;
+    cnt->track_posy = 0;
     if (cnt->track.type)
         cnt->moved = track_center(cnt, cnt->video_dev, 0, 0, 0);
 

--- a/motion.h
+++ b/motion.h
@@ -370,6 +370,8 @@ struct context {
     struct config conf;
     struct images imgs;
     struct trackoptions track;
+    int                 track_posx;
+    int                 track_posy;
 
     enum CAMERA_TYPE      camera_type;
     struct netcam_context *netcam;


### PR DESCRIPTION
1.  Maintain a aggregate count of moves
2.  Send aggregate counts as negative when invoking center.