### PR TITLE
Add support for Movidius NC stick

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -37,16 +37,16 @@ CFLAGS       = @CFLAGS@ -Wall \
 	 -Dsysconfdir=\"$(sysconfdir)\"  \
 	 -DLOCALEDIR=\"$(DESTDIR)$(localedir)\"    \
 	 -DMOTIONDOCDIR=\"$(DESTDIR)$(docdir)\"    \
-	 @FFMPEG_CFLAGS@ @MMAL_CFLAGS@
+	 @FFMPEG_CFLAGS@ @MMAL_CFLAGS@ @MVNC_CFLAGS@
 LDFLAGS      = @LDFLAGS@
-LIBS         = @LIBS@  @MMAL_LIBS@ @FFMPEG_LIBS@
+LIBS         = @LIBS@  @MMAL_LIBS@ @FFMPEG_LIBS@ @MVNC_LIBS@
 OBJ          = motion.o logger.o conf.o draw.o jpegutils.o \
 			   video_loopback.o video_v4l2.o video_common.o video_bktr.o \
 			   netcam.o netcam_http.o netcam_ftp.o netcam_jpeg.o netcam_wget.o \
 			   track.o alg.o event.o picture.o rotate.o translate.o \
 			   webu.o webu_html.o webu_text.o webu_stream.o \
-			   stream.o md5.o netcam_rtsp.o ffmpeg.o movidius.o \
-			   @MMAL_OBJ@ @SQLITE_OBJ@
+			   stream.o md5.o netcam_rtsp.o ffmpeg.o \
+			   @MMAL_OBJ@ @SQLITE_OBJ@ @MVNC_OBJ@
 SRC          = $(foreach obj,$(OBJ:.o=.c),@top_srcdir@/$(obj))
 DOC          = CHANGELOG COPYING CREDITS README.md  \
 			   motion_guide.html motion_stylesheet.css \

--- a/Makefile.in
+++ b/Makefile.in
@@ -58,12 +58,6 @@ EXAMPLES_BIN = motion.init-Debian motion.init-FreeBSD.sh
 PROGS        = motion
 DEPEND_FILE  = .depend
 LANGCDS      = @LANGCDS@
-SSD_MOBILENET_CAFFEMODEL   = MobileNetSSD_deploy.caffemodel
-SSD_MOBILENET_PROTOTXT     = MobileNetSSD_deploy.prototxt
-SSD_MOBILENET_GRAPH        = @MVNC_GRAPH@
-SSD_MOBILENET_PROTOTXT_URL = https://raw.githubusercontent.com/chuanqi305/MobileNet-SSD/923b3128f25262b5010cef67e4fb9e4b6728ae7b/voc/MobileNetSSD_deploy.prototxt
-SSD_MOBILENET_CAFFEMODEL_GOOGLEDOC_ID = 0B3gersZ2cHIxRm5PMWRoTkdHdHc
-SSD_MOBILENET_CAFFEMODEL_URL = https://docs.google.com/uc?export=download&id=$(SSD_MOBILENET_CAFFEMODEL_GOOGLEDOC_ID)
 
 ################################################################################
 # ALL and PROGS build Motion and, possibly, Motion-control.                    #
@@ -131,26 +125,6 @@ pre-mobject-info:
 	@echo "--------------------------------------------------------------------------------"
 
 ################################################################################
-# Compile MobileNetSSD.graph for Movidius NCS                                  #
-################################################################################
-$(SSD_MOBILENET_PROTOTXT):
-	@echo "Downloading MobileNet SSD Prototxt file"
-	@wget -P . -O $(SSD_MOBILENET_PROTOTXT) https://raw.githubusercontent.com/chuanqi305/MobileNet-SSD/923b3128f25262b5010cef67e4fb9e4b6728ae7b/voc/MobileNetSSD_deploy.prototxt
-
-$(SSD_MOBILENET_CAFFEMODEL):
-	@touch /tmp/cookies.txt
-	@wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate $(SSD_MOBILENET_CAFFEMODEL_URL) -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=$(SSD_MOBILENET_CAFFEMODEL_GOOGLEDOC_ID)" -O ${SSD_MOBILENET_CAFFEMODEL}
-	@rm -f /tmp/cookies.txt
-
-$(SSD_MOBILENET_GRAPH): $(SSD_MOBILENET_CAFFEMODEL) $(SSD_MOBILENET_PROTOTXT)
-	@echo "Compiling the trained MobileNet SSD model..."
-	@echo "--------------------------------------------------------------------------------"
-	@mvNCCompile -w $(SSD_MOBILENET_CAFFEMODEL) -o $(SSD_MOBILENET_GRAPH) -s 12 $(SSD_MOBILENET_PROTOTXT)
-	@echo "--------------------------------------------------------------------------------"
-	@echo "Trained MobileNet SSD model has been compiled."
-	@echo
-
-################################################################################
 # Define the compile command for C files.                                      #
 ################################################################################
 %.o: @top_srcdir@/%.c
@@ -204,7 +178,6 @@ help:
 	@echo "make dev-git            Build motion with dev flags for git"
 	@echo "make build-commit       Build last version of motion and prepare to commit to svn"
 	@echo "make build-commit-git   Build last version of motion and prepare to commit to git"
-	@echo "make $(SSD_MOBILENET_GRAPH) Download and compile MobileNetSSD to graph"
 	@echo "make clean              Clean objects"
 	@echo "make distclean          Clean everything"
 	@echo "make install            Install binary , examples , docs and config files"
@@ -296,7 +269,6 @@ endif
 clean: pre-build-info
 	@echo "Removing compiled files and binaries..."
 	@rm -f *~ *.o $(PROGS) combine $(DEPEND_FILE)
-	@rm -f $(SSD_MOBILENET_GRAPH) $(SSD_MOBILENET_CAFFEMODEL) $(SSD_MOBILENET_PROTOTXT)
 	@rm -f ./po/*.mo
 
 ################################################################################

--- a/Makefile.in
+++ b/Makefile.in
@@ -45,7 +45,7 @@ OBJ          = motion.o logger.o conf.o draw.o jpegutils.o \
 			   netcam.o netcam_http.o netcam_ftp.o netcam_jpeg.o netcam_wget.o \
 			   track.o alg.o event.o picture.o rotate.o translate.o \
 			   webu.o webu_html.o webu_text.o webu_stream.o \
-			   stream.o md5.o netcam_rtsp.o ffmpeg.o \
+			   stream.o md5.o netcam_rtsp.o ffmpeg.o movidius.o \
 			   @MMAL_OBJ@ @SQLITE_OBJ@
 SRC          = $(foreach obj,$(OBJ:.o=.c),@top_srcdir@/$(obj))
 DOC          = CHANGELOG COPYING CREDITS README.md  \

--- a/Makefile.in
+++ b/Makefile.in
@@ -58,6 +58,12 @@ EXAMPLES_BIN = motion.init-Debian motion.init-FreeBSD.sh
 PROGS        = motion
 DEPEND_FILE  = .depend
 LANGCDS      = @LANGCDS@
+SSD_MOBILENET_CAFFEMODEL   = MobileNetSSD_deploy.caffemodel
+SSD_MOBILENET_PROTOTXT     = MobileNetSSD_deploy.prototxt
+SSD_MOBILENET_GRAPH        = @MVNC_GRAPH@
+SSD_MOBILENET_PROTOTXT_URL = https://raw.githubusercontent.com/chuanqi305/MobileNet-SSD/923b3128f25262b5010cef67e4fb9e4b6728ae7b/voc/MobileNetSSD_deploy.prototxt
+SSD_MOBILENET_CAFFEMODEL_GOOGLEDOC_ID = 0B3gersZ2cHIxRm5PMWRoTkdHdHc
+SSD_MOBILENET_CAFFEMODEL_URL = https://docs.google.com/uc?export=download&id=$(SSD_MOBILENET_CAFFEMODEL_GOOGLEDOC_ID)
 
 ################################################################################
 # ALL and PROGS build Motion and, possibly, Motion-control.                    #
@@ -125,6 +131,26 @@ pre-mobject-info:
 	@echo "--------------------------------------------------------------------------------"
 
 ################################################################################
+# Compile MobileNetSSD.graph for Movidius NCS                                  #
+################################################################################
+$(SSD_MOBILENET_PROTOTXT):
+	@echo "Downloading MobileNet SSD Prototxt file"
+	@wget -P . -O $(SSD_MOBILENET_PROTOTXT) https://raw.githubusercontent.com/chuanqi305/MobileNet-SSD/923b3128f25262b5010cef67e4fb9e4b6728ae7b/voc/MobileNetSSD_deploy.prototxt
+
+$(SSD_MOBILENET_CAFFEMODEL):
+	@touch /tmp/cookies.txt
+	@wget --load-cookies /tmp/cookies.txt "https://docs.google.com/uc?export=download&confirm=$(wget --quiet --save-cookies /tmp/cookies.txt --keep-session-cookies --no-check-certificate $(SSD_MOBILENET_CAFFEMODEL_URL) -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1\n/p')&id=$(SSD_MOBILENET_CAFFEMODEL_GOOGLEDOC_ID)" -O ${SSD_MOBILENET_CAFFEMODEL}
+	@rm -f /tmp/cookies.txt
+
+$(SSD_MOBILENET_GRAPH): $(SSD_MOBILENET_CAFFEMODEL) $(SSD_MOBILENET_PROTOTXT)
+	@echo "Compiling the trained MobileNet SSD model..."
+	@echo "--------------------------------------------------------------------------------"
+	@mvNCCompile -w $(SSD_MOBILENET_CAFFEMODEL) -o $(SSD_MOBILENET_GRAPH) -s 12 $(SSD_MOBILENET_PROTOTXT)
+	@echo "--------------------------------------------------------------------------------"
+	@echo "Trained MobileNet SSD model has been compiled."
+	@echo
+
+################################################################################
 # Define the compile command for C files.                                      #
 ################################################################################
 %.o: @top_srcdir@/%.c
@@ -172,16 +198,17 @@ set-version:
 
 help:
 	@echo "--------------------------------------------------------------------------------"
-	@echo "make                   Build motion from local copy in your computer"
-	@echo "make current           Build last version of motion from svn"
-	@echo "make dev               Build motion with dev flags"
-	@echo "make dev-git           Build motion with dev flags for git"
-	@echo "make build-commit      Build last version of motion and prepare to commit to svn"
-	@echo "make build-commit-git  Build last version of motion and prepare to commit to git"
-	@echo "make clean             Clean objects"
-	@echo "make distclean         Clean everything"
-	@echo "make install           Install binary , examples , docs and config files"
-	@echo "make uninstall         Uninstall all installed files"
+	@echo "make                    Build motion from local copy in your computer"
+	@echo "make current            Build last version of motion from svn"
+	@echo "make dev                Build motion with dev flags"
+	@echo "make dev-git            Build motion with dev flags for git"
+	@echo "make build-commit       Build last version of motion and prepare to commit to svn"
+	@echo "make build-commit-git   Build last version of motion and prepare to commit to git"
+	@echo "make $(SSD_MOBILENET_GRAPH) Download and compile MobileNetSSD to graph"
+	@echo "make clean              Clean objects"
+	@echo "make distclean          Clean everything"
+	@echo "make install            Install binary , examples , docs and config files"
+	@echo "make uninstall          Uninstall all installed files"
 	@echo "--------------------------------------------------------------------------------"
 	@echo
 
@@ -269,6 +296,7 @@ endif
 clean: pre-build-info
 	@echo "Removing compiled files and binaries..."
 	@rm -f *~ *.o $(PROGS) combine $(DEPEND_FILE)
+	@rm -f $(SSD_MOBILENET_GRAPH) $(SSD_MOBILENET_CAFFEMODEL) $(SSD_MOBILENET_PROTOTXT)
 	@rm -f ./po/*.mo
 
 ################################################################################

--- a/Makefile.in
+++ b/Makefile.in
@@ -172,16 +172,16 @@ set-version:
 
 help:
 	@echo "--------------------------------------------------------------------------------"
-	@echo "make                    Build motion from local copy in your computer"
-	@echo "make current            Build last version of motion from svn"
-	@echo "make dev                Build motion with dev flags"
-	@echo "make dev-git            Build motion with dev flags for git"
-	@echo "make build-commit       Build last version of motion and prepare to commit to svn"
-	@echo "make build-commit-git   Build last version of motion and prepare to commit to git"
-	@echo "make clean              Clean objects"
-	@echo "make distclean          Clean everything"
-	@echo "make install            Install binary , examples , docs and config files"
-	@echo "make uninstall          Uninstall all installed files"
+	@echo "make                   Build motion from local copy in your computer"
+	@echo "make current           Build last version of motion from svn"
+	@echo "make dev               Build motion with dev flags"
+	@echo "make dev-git           Build motion with dev flags for git"
+	@echo "make build-commit      Build last version of motion and prepare to commit to svn"
+	@echo "make build-commit-git  Build last version of motion and prepare to commit to git"
+	@echo "make clean             Clean objects"
+	@echo "make distclean         Clean everything"
+	@echo "make install           Install binary , examples , docs and config files"
+	@echo "make uninstall         Uninstall all installed files"
 	@echo "--------------------------------------------------------------------------------"
 	@echo
 

--- a/alg.c
+++ b/alg.c
@@ -18,7 +18,8 @@
 #define MAX3(x, y, z) ((x) > (y) ? ((x) > (z) ? (x) : (z)) : ((y) > (z) ? (y) : (z)))
 
 
-void alg_inference_box_to_coord(struct movidius_result *result, int width, int height, struct coord *cent)
+#ifdef HAVE_MVNC
+void alg_inference_box_to_coord(struct mvnc_result *result, int width, int height, struct coord *cent)
 {
     cent->minx = result->box_left * width;
     cent->maxx = result->box_right * width;
@@ -37,6 +38,7 @@ void alg_inference_box_to_coord(struct movidius_result *result, int width, int h
     cent->width = cent->maxx - cent->minx;
     cent->height = cent->maxy - cent->miny;
 }
+#endif
 
 /**
  * alg_locate_center_size

--- a/alg.c
+++ b/alg.c
@@ -17,6 +17,27 @@
 #define MAX2(x, y) ((x) > (y) ? (x) : (y))
 #define MAX3(x, y, z) ((x) > (y) ? ((x) > (z) ? (x) : (z)) : ((y) > (z) ? (y) : (z)))
 
+
+void alg_inference_box_to_coord(struct movidius_result *result, int width, int height, struct coord *cent)
+{
+    cent->minx = result->box_left * width;
+    cent->maxx = result->box_right * width;
+    cent->miny = result->box_top * height;
+    cent->maxy = result->box_bottom * height;
+
+    cent->x = (cent->minx + cent->maxx) / 2;
+    cent->y = (cent->miny + cent->maxy) / 2;
+
+    /* Align for better locate box handling */
+    cent->minx += cent->minx % 2;
+    cent->miny += cent->miny % 2;
+    cent->maxx -= cent->maxx % 2;
+    cent->maxy -= cent->maxy % 2;
+
+    cent->width = cent->maxx - cent->minx;
+    cent->height = cent->maxy - cent->miny;
+}
+
 /**
  * alg_locate_center_size
  *      Locates the center and size of the movement.

--- a/alg.h
+++ b/alg.h
@@ -11,7 +11,9 @@
 #define _INCLUDE_ALG_H
 
 #include "motion.h"
+#ifdef HAVE_MVNC
 #include "movidius.h"
+#endif
 
 struct coord {
     int x;
@@ -32,7 +34,9 @@ struct segment {
     int count;
 };
 
-void alg_inference_box_to_coord(struct movidius_result *result, int width, int height, struct coord *cent);
+#ifdef HAVE_MVNC
+void alg_inference_box_to_coord(struct mvnc_result *result, int width, int height, struct coord *cent);
+#endif
 void alg_locate_center_size(struct images *, int width, int height, struct coord *);
 void alg_draw_location(struct coord *, struct images *, int width, unsigned char *, int, int, int);
 void alg_draw_red_location(struct coord *, struct images *, int width, unsigned char *, int, int, int);

--- a/alg.h
+++ b/alg.h
@@ -11,6 +11,7 @@
 #define _INCLUDE_ALG_H
 
 #include "motion.h"
+#include "movidius.h"
 
 struct coord {
     int x;
@@ -31,6 +32,7 @@ struct segment {
     int count;
 };
 
+void alg_inference_box_to_coord(struct movidius_result *result, int width, int height, struct coord *cent);
 void alg_locate_center_size(struct images *, int width, int height, struct coord *);
 void alg_draw_location(struct coord *, struct images *, int width, unsigned char *, int, int, int);
 void alg_draw_red_location(struct coord *, struct images *, int width, unsigned char *, int, int, int);

--- a/conf.c
+++ b/conf.c
@@ -89,6 +89,10 @@ struct config conf_template = {
 
     /* Motion detection configuration parameters */
     .emulate_motion =                  FALSE,
+    .mvnc_enable =                     FALSE,
+    .mvnc_graph_path =                 DEF_MVNC_GRAPH_PATH,
+    .mvnc_classification =             "person",
+    .mvnc_threshold =                  DEF_CONFIDENCE,
     .threshold =                       DEF_CHANGES,
     .threshold_maximum =               0,
     .threshold_tune =                  FALSE,
@@ -645,6 +649,42 @@ config_param config_params[] = {
     CONF_OFFSET(emulate_motion),
     copy_bool,
     print_bool,
+    WEBUI_LEVEL_LIMITED
+    },
+    {
+    "mvnc_enable",
+    "# Use Movidius NC with MobileNetSSD to detect object.",
+    0,
+    CONF_OFFSET(mvnc_enable),
+    copy_bool,
+    print_bool,
+    WEBUI_LEVEL_RESTRICTED
+    },
+    {
+    "mvnc_graph_path",
+    "# MobileNetSSD graph path",
+    0,
+    CONF_OFFSET(mvnc_graph_path),
+    copy_string,
+    print_string,
+    WEBUI_LEVEL_LIMITED
+    },
+    {
+    "mvnc_classification",
+    "# Objects to be classified by Movidius, e.g. person,cat,dog.",
+    0,
+    CONF_OFFSET(mvnc_classification),
+    copy_string,
+    print_string,
+    WEBUI_LEVEL_LIMITED
+    },
+    {
+    "mvnc_threshold",
+    "# Threshold for inference confidence in percentage to be considered valid.",
+    0,
+    CONF_OFFSET(mvnc_threshold),
+    copy_int,
+    print_int,
     WEBUI_LEVEL_LIMITED
     },
     {
@@ -3194,6 +3234,10 @@ static void config_parms_intl(){
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","text_scale",_("text_scale"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","text_event",_("text_event"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","emulate_motion",_("emulate_motion"));
+        MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","mvnc_enable",_("mvnc_enable"));
+        MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","mvnc_graph_path",_("mvnc_graph_path"));
+        MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","mvnc_classification",_("mvnc_classification"));
+        MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","mvnc_threshold",_("mvnc_threshold"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","threshold",_("threshold"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","threshold_maximum",_("threshold_maximum"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","threshold_tune",_("threshold_tune"));

--- a/conf.h
+++ b/conf.h
@@ -74,6 +74,10 @@ struct config {
 
     /* Motion detection configuration parameters */
     int             emulate_motion;
+    int             mvnc_enable;
+    const char      *mvnc_graph_path;
+    const char      *mvnc_classification;
+    int             mvnc_threshold;
     int             threshold;
     int             threshold_maximum;
     int             threshold_tune;

--- a/configure.ac
+++ b/configure.ac
@@ -411,7 +411,6 @@ if test "${WITHOUT_MVNC}" = "no"; then
     MVNC_OBJ="movidius.o"
     MVNC_CFLAGS="-DHAVE_MVNC -I${MVNC_HEADERS}"
     MVNC_LIBS="-lmvnc"
-    MVNC_GRAPH="MobileNetSSD.graph"
     AC_DEFINE([HAVE_MVNC], 1, [Define to 1 if we want MVNC])
   ])
 fi
@@ -836,7 +835,6 @@ if test "${HAVE_MVNC}" = "yes"; then
     echo " ... MVNC_CFLAGS: $MVNC_CFLAGS"
     echo " ... MVNC_OBJ: $MVNC_OBJ"
     echo " ... MVNC_LIBS: $MVNC_LIBS"
-    echo " ... MVNC_GRAPH: $MVNC_GRAPH"
 elif test "${WITHOUT_MVNC}" = "yes"; then
     echo "MVNC support:        disabled"
 else

--- a/configure.ac
+++ b/configure.ac
@@ -407,7 +407,6 @@ if test "${WITHOUT_MVNC}" = "no"; then
     AC_SUBST(MVNC_CFLAGS)
     AC_SUBST(MVNC_OBJ)
     AC_SUBST(MVNC_LIBS)
-    AC_SUBST(MVNC_GRAPH)
     MVNC_OBJ="movidius.o"
     MVNC_CFLAGS="-DHAVE_MVNC -I${MVNC_HEADERS}"
     MVNC_LIBS="-lmvnc"

--- a/configure.ac
+++ b/configure.ac
@@ -335,47 +335,6 @@ if test "${WITHOUT_MMAL}" = "no"; then
 fi
 
 ##############################################################################
-###  Movidius NCS
-##############################################################################
-WITHOUT_MVNC="no"
-AC_ARG_WITH([mvnc],
-  AS_HELP_STRING([--without-mvnc],
-    [Compile without Movidius nc support]),
-  WITHOUT_MVNC="yes",
-  WITHOUT_MVNC="no")
-
-AC_ARG_WITH([mvnc-lib],
-  AS_HELP_STRING([--with-mvnc-lib[=DIR]],
-    [Use this command to tell configure where mvnc libs directory is.]),
-  MVNC_LIBS_DIR="$withval",
-  MVNC_LIBS_DIR="/usr/local/lib/"
-)
-
-AC_ARG_WITH([mvnc-include],
-  AS_HELP_STRING([--with-mvnc-include[=DIR]],
-    [Use this command to tell configure where mvnc include installation root directory is.]),
-  MVNC_HEADERS="$withval",
-  MVNC_HEADERS="/usr/local/include/"
-)
-
-if test "${WITHOUT_MVNC}" = "no"; then
-  HAVE_MVNC=""
-  if test -d ${MVNC_HEADERS}/mvnc2; then
-       HAVE_MVNC="yes"
-  fi
-
-  AS_IF([test "${HAVE_MVNC}" = "yes" ], [
-    AC_SUBST(MVNC_CFLAGS)
-    AC_SUBST(MVNC_OBJ)
-    AC_SUBST(MVNC_LIBS)
-    MVNC_OBJ="movidius.o"
-    MVNC_CFLAGS="-DHAVE_MVNC -I${MVNC_HEADERS}"
-    MVNC_LIBS="-lmvnc"
-    AC_DEFINE([HAVE_MVNC], 1, [Define to 1 if we want MVNC])
-  ])
-fi
-
-##############################################################################
 ###  ffmpeg
 ##############################################################################
 AC_ARG_WITH([ffmpeg],
@@ -408,6 +367,49 @@ AS_IF([test "x$with_ffmpeg" != "xno"], [
 AS_IF([test "${HAVE_FFMPEG}" = "yes" ], [
        AC_DEFINE([HAVE_FFMPEG], 1, [Define to 1 if FFMPEG is around])
 ])
+
+##############################################################################
+###  Movidius NCS (requires ffmpeg)
+##############################################################################
+WITHOUT_MVNC="no"
+AC_ARG_WITH([mvnc],
+  AS_HELP_STRING([--without-mvnc],
+    [Compile without Movidius nc support]),
+  WITHOUT_MVNC="yes",
+  WITHOUT_MVNC="no")
+
+AC_ARG_WITH([mvnc-lib],
+  AS_HELP_STRING([--with-mvnc-lib[=DIR]],
+    [Use this command to tell configure where mvnc libs directory is.]),
+  MVNC_LIBS_DIR="$withval",
+  MVNC_LIBS_DIR="/usr/local/lib/"
+)
+
+AC_ARG_WITH([mvnc-include],
+  AS_HELP_STRING([--with-mvnc-include[=DIR]],
+    [Use this command to tell configure where mvnc include installation root directory is.]),
+  MVNC_HEADERS="$withval",
+  MVNC_HEADERS="/usr/local/include/"
+)
+
+if test "${WITHOUT_MVNC}" = "no"; then
+  HAVE_MVNC=""
+  AS_IF([test "${HAVE_FFMPEG}" = "yes" ], [
+    if test -d ${MVNC_HEADERS}/mvnc2; then
+         HAVE_MVNC="yes"
+    fi
+  ])
+
+  AS_IF([test "${HAVE_MVNC}" = "yes" ], [
+    AC_SUBST(MVNC_CFLAGS)
+    AC_SUBST(MVNC_OBJ)
+    AC_SUBST(MVNC_LIBS)
+    MVNC_OBJ="movidius.o"
+    MVNC_CFLAGS="-DHAVE_MVNC -I${MVNC_HEADERS}"
+    MVNC_LIBS="-lmvnc"
+    AC_DEFINE([HAVE_MVNC], 1, [Define to 1 if we want MVNC])
+  ])
+fi
 
 ##############################################################################
 ###  Check SQLITE3
@@ -816,6 +818,14 @@ else
     echo " ... libraspberrypi-dev package not installed"
 fi
 
+if test "${HAVE_FFMPEG}" = "yes"; then
+    echo "FFmpeg support:      Yes"
+    echo " ... FFMPEG_CFLAGS: $FFMPEG_CFLAGS"
+    echo " ... FFMPEG_LIBS: $FFMPEG_LIBS"
+else
+    echo "FFmpeg support:      No"
+fi
+
 if test "${HAVE_MVNC}" = "yes"; then
     echo "MVNC support:        Yes"
     echo " ... MVNC_CFLAGS: $MVNC_CFLAGS"
@@ -826,14 +836,6 @@ elif test "${WITHOUT_MVNC}" = "yes"; then
 else
     echo "MVNC support:        No"
     echo " ... ncsdk not installed"
-fi
-
-if test "${HAVE_FFMPEG}" = "yes"; then
-    echo "FFmpeg support:      Yes"
-    echo " ... FFMPEG_CFLAGS: $FFMPEG_CFLAGS"
-    echo " ... FFMPEG_LIBS: $FFMPEG_LIBS"
-else
-    echo "FFmpeg support:      No"
 fi
 
 if test "${SQLITE3_SUPPORT}" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -407,9 +407,11 @@ if test "${WITHOUT_MVNC}" = "no"; then
     AC_SUBST(MVNC_CFLAGS)
     AC_SUBST(MVNC_OBJ)
     AC_SUBST(MVNC_LIBS)
+    AC_SUBST(MVNC_GRAPH)
     MVNC_OBJ="movidius.o"
     MVNC_CFLAGS="-DHAVE_MVNC -I${MVNC_HEADERS}"
     MVNC_LIBS="-lmvnc"
+    MVNC_GRAPH="MobileNetSSD.graph"
     AC_DEFINE([HAVE_MVNC], 1, [Define to 1 if we want MVNC])
   ])
 fi
@@ -834,6 +836,7 @@ if test "${HAVE_MVNC}" = "yes"; then
     echo " ... MVNC_CFLAGS: $MVNC_CFLAGS"
     echo " ... MVNC_OBJ: $MVNC_OBJ"
     echo " ... MVNC_LIBS: $MVNC_LIBS"
+    echo " ... MVNC_GRAPH: $MVNC_GRAPH"
 elif test "${WITHOUT_MVNC}" = "yes"; then
     echo "MVNC support:        disabled"
 else

--- a/configure.ac
+++ b/configure.ac
@@ -335,6 +335,47 @@ if test "${WITHOUT_MMAL}" = "no"; then
 fi
 
 ##############################################################################
+###  Movidius NCS
+##############################################################################
+WITHOUT_MVNC="no"
+AC_ARG_WITH([mvnc],
+  AS_HELP_STRING([--without-mvnc],
+    [Compile without Movidius nc support]),
+  WITHOUT_MVNC="yes",
+  WITHOUT_MVNC="no")
+
+AC_ARG_WITH([mvnc-lib],
+  AS_HELP_STRING([--with-mvnc-lib[=DIR]],
+    [Use this command to tell configure where mvnc libs directory is.]),
+  MVNC_LIBS_DIR="$withval",
+  MVNC_LIBS_DIR="/usr/local/lib/"
+)
+
+AC_ARG_WITH([mvnc-include],
+  AS_HELP_STRING([--with-mvnc-include[=DIR]],
+    [Use this command to tell configure where mvnc include installation root directory is.]),
+  MVNC_HEADERS="$withval",
+  MVNC_HEADERS="/usr/local/include/"
+)
+
+if test "${WITHOUT_MVNC}" = "no"; then
+  HAVE_MVNC=""
+  if test -d ${MVNC_HEADERS}/mvnc2; then
+       HAVE_MVNC="yes"
+  fi
+
+  AS_IF([test "${HAVE_MVNC}" = "yes" ], [
+    AC_SUBST(MVNC_CFLAGS)
+    AC_SUBST(MVNC_OBJ)
+    AC_SUBST(MVNC_LIBS)
+    MVNC_OBJ="movidius.o"
+    MVNC_CFLAGS="-DHAVE_MVNC -I${MVNC_HEADERS}"
+    MVNC_LIBS="-lmvnc"
+    AC_DEFINE([HAVE_MVNC], 1, [Define to 1 if we want MVNC])
+  ])
+fi
+
+##############################################################################
 ###  ffmpeg
 ##############################################################################
 AC_ARG_WITH([ffmpeg],
@@ -773,6 +814,18 @@ elif test "${WITHOUT_MMAL}" = "yes"; then
 else
     echo "MMAL support:        No"
     echo " ... libraspberrypi-dev package not installed"
+fi
+
+if test "${HAVE_MVNC}" = "yes"; then
+    echo "MVNC support:        Yes"
+    echo " ... MVNC_CFLAGS: $MVNC_CFLAGS"
+    echo " ... MVNC_OBJ: $MVNC_OBJ"
+    echo " ... MVNC_LIBS: $MVNC_LIBS"
+elif test "${WITHOUT_MVNC}" = "yes"; then
+    echo "MVNC support:        disabled"
+else
+    echo "MVNC support:        No"
+    echo " ... ncsdk not installed"
 fi
 
 if test "${HAVE_FFMPEG}" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -394,11 +394,14 @@ AC_ARG_WITH([mvnc-include],
 
 if test "${WITHOUT_MVNC}" = "no"; then
   HAVE_MVNC=""
-  AS_IF([test "${HAVE_FFMPEG}" = "yes" ], [
+  MVNC_MISSING_FFMPEG=""
+  if test "${HAVE_FFMPEG}" = "yes"; then
     if test -d ${MVNC_HEADERS}/mvnc2; then
          HAVE_MVNC="yes"
     fi
-  ])
+  else
+    MVNC_MISSING_FFMPEG="yes"
+  fi
 
   AS_IF([test "${HAVE_MVNC}" = "yes" ], [
     AC_SUBST(MVNC_CFLAGS)
@@ -835,7 +838,11 @@ elif test "${WITHOUT_MVNC}" = "yes"; then
     echo "MVNC support:        disabled"
 else
     echo "MVNC support:        No"
-    echo " ... ncsdk not installed"
+    if test "${MVNC_MISSING_FFMPEG}" = "yes"; then
+      echo " ... ffmpeg dependency not found"
+    else
+      echo " ... ncsdk not installed"
+    fi
 fi
 
 if test "${SQLITE3_SUPPORT}" = "yes"; then

--- a/motion.c
+++ b/motion.c
@@ -19,9 +19,6 @@
 #include "picture.h"
 #include "rotate.h"
 #include "webu.h"
-#ifdef HAVE_MVNC
-#include "movidius.h"
-#endif
 
 #define IMAGE_BUFFER_FLUSH ((unsigned int)-1)
 

--- a/motion.c
+++ b/motion.c
@@ -301,6 +301,7 @@ static void context_destroy(struct context *cnt)
             free(cnt->mvnc_class_ids);
             cnt->mvnc_class_ids = NULL;
         }
+        cnt->num_mvnc_class_ids = 0;
 #endif
         if (config_params[j].copy == copy_string ||
             config_params[j].copy == copy_uri ||

--- a/motion.c
+++ b/motion.c
@@ -2172,7 +2172,7 @@ static void mlp_detection(struct context *cnt){
 
     /***** MOTION LOOP - MOTION DETECTION SECTION *****/
 
-    movidius_infer_image(cnt->imgs.img_motion.image_norm, cnt->imgs.width, cnt->imgs.height);
+    movidius_infer_image(cnt->imgs.image_virgin.image_norm, cnt->imgs.width, cnt->imgs.height);
 
 #if 0
     /*

--- a/motion.c
+++ b/motion.c
@@ -2444,11 +2444,10 @@ static void mlp_actions(struct context *cnt){
 
     /***** MOTION LOOP - ACTIONS AND EVENT CONTROL SECTION *****/
 
-    float *resultData = NULL;
-    int resultDataLength = 0;
-    if (movidius_get_results(&resultData, &resultDataLength) == 0)
+    struct movidius_output *resultData = NULL;
+    if (movidius_get_results(&resultData) == 0)
     {
-        float probability = movidius_get_person_probability(resultData, resultDataLength);
+        float score = movidius_get_highest_person_score(resultData);
         // TODO: flag this image if probability of person is higher than some threshold
         //cnt->current_image->flags |= IMAGE_MOTION;
         movidius_free_results(&resultData);

--- a/motion.c
+++ b/motion.c
@@ -2207,11 +2207,12 @@ static void mlp_detection(struct context *cnt){
 
 #ifdef HAVE_MVNC
     if (cnt->conf.mvnc_enable)
+    {
         mvnc_infer_image(&cnt->mvnc_dev, cnt->imgs.image_virgin.image_norm, cnt->imgs.width, cnt->imgs.height);
-    else
+        return;
+    }
 #endif
 
-    {
     /*
      * The actual motion detection takes place in the following
      * diffs is the number of pixels detected as changed
@@ -2325,7 +2326,6 @@ static void mlp_detection(struct context *cnt){
         cnt->current_image->diffs = 0;
     }
 
-    }
 }
 
 static void mlp_tuning(struct context *cnt){
@@ -2516,14 +2516,14 @@ static void mlp_actions(struct context *cnt){
     else
 #endif
     {
-
-    if ((cnt->current_image->diffs > cnt->threshold) &&
-        (cnt->current_image->diffs < cnt->threshold_maximum)) {
-        /* flag this image, it have motion */
-        cnt->current_image->flags |= IMAGE_MOTION;
-        cnt->lightswitch_framecounter++; /* micro lightswitch */
-    } else {
-        cnt->lightswitch_framecounter = 0;
+        if ((cnt->current_image->diffs > cnt->threshold) &&
+            (cnt->current_image->diffs < cnt->threshold_maximum)) {
+            /* flag this image, it have motion */
+            cnt->current_image->flags |= IMAGE_MOTION;
+            cnt->lightswitch_framecounter++; /* micro lightswitch */
+        } else {
+            cnt->lightswitch_framecounter = 0;
+        }
     }
 
     /*
@@ -2672,7 +2672,6 @@ static void mlp_actions(struct context *cnt){
     /* Save/send to movie some images */
     process_image_ring(cnt, 2);
 
-    }
 }
 
 static void mlp_setupmode(struct context *cnt){

--- a/motion.c
+++ b/motion.c
@@ -2445,10 +2445,10 @@ static void mlp_actions(struct context *cnt){
     /***** MOTION LOOP - ACTIONS AND EVENT CONTROL SECTION *****/
 
     float *resultData = NULL;
-    int numResults = 0;
-    if (movidius_get_results(&resultData, &numResults) == 0)
+    int resultDataLength = 0;
+    if (movidius_get_results(&resultData, &resultDataLength) == 0)
     {
-        float probability = movidius_get_person_probability(resultData, numResults);
+        float probability = movidius_get_person_probability(resultData, resultDataLength);
         // TODO: flag this image if probability of person is higher than some threshold
         //cnt->current_image->flags |= IMAGE_MOTION;
         movidius_free_results(&resultData);

--- a/motion.c
+++ b/motion.c
@@ -20,6 +20,7 @@
 #include "rotate.h"
 #include "webu.h"
 
+
 #define IMAGE_BUFFER_FLUSH ((unsigned int)-1)
 
 /**
@@ -2221,7 +2222,6 @@ static void mlp_detection(struct context *cnt){
      * is called.
      */
     if (cnt->process_thisframe) {
-
         if (cnt->threshold && !cnt->pause) {
             /*
              * If we've already detected motion and we want to see if there's

--- a/motion.c
+++ b/motion.c
@@ -2401,6 +2401,7 @@ static void mlp_tuning(struct context *cnt){
         cnt->previous_location_y = cnt->current_image->location.y;
     }
 
+
 }
 
 static void mlp_overlay(struct context *cnt){
@@ -2668,6 +2669,7 @@ static void mlp_actions(struct context *cnt){
 
     /* Save/send to movie some images */
     process_image_ring(cnt, 2);
+
 
 }
 

--- a/motion.h
+++ b/motion.h
@@ -107,6 +107,7 @@ struct image_data;
 #define DEF_HEIGHT             480
 #define DEF_QUALITY             75
 #define DEF_CHANGES           1500
+#define DEF_CONFIDENCE          75
 
 #define DEF_MAXFRAMERATE        15
 #define DEF_NOISELEVEL          32
@@ -141,6 +142,8 @@ struct image_data;
 #define DEF_IMAGEPATH           "%v-%Y%m%d%H%M%S-%q"
 #define DEF_MOVIEPATH           "%v-%Y%m%d%H%M%S"
 #define DEF_TIMEPATH            "%Y%m%d-timelapse"
+
+#define DEF_MVNC_GRAPH_PATH     "MobileNetSSD.graph"
 
 #define DEF_TIMELAPSE_MODE      "daily"
 
@@ -394,7 +397,13 @@ struct context {
     struct image_data *current_image;       /* Pointer to a structure where the image, diffs etc is stored */
     unsigned int new_img;
 
-    struct movidius_output *inference_result;
+#ifdef HAVE_MVNC
+    int mvnc_device_index;
+    int mvnc_threshold;
+    int *mvnc_class_ids;
+    int num_mvnc_class_ids;
+    struct mvnc_device_t mvnc_dev;
+#endif
 
     int locate_motion_mode;
     int locate_motion_style;

--- a/motion.h
+++ b/motion.h
@@ -70,6 +70,8 @@ struct image_data;
 #include "mmalcam.h"
 #endif
 
+#include "movidius.h"
+
 
 /**
  * ATTRIBUTE_UNUSED:
@@ -391,6 +393,8 @@ struct context {
 
     struct image_data *current_image;       /* Pointer to a structure where the image, diffs etc is stored */
     unsigned int new_img;
+
+    struct movidius_output *inference_result;
 
     int locate_motion_mode;
     int locate_motion_style;

--- a/motion.h
+++ b/motion.h
@@ -70,7 +70,9 @@ struct image_data;
 #include "mmalcam.h"
 #endif
 
+#ifdef HAVE_MVNC
 #include "movidius.h"
+#endif
 
 
 /**

--- a/movidius.c
+++ b/movidius.c
@@ -1,0 +1,391 @@
+/*
+ * movidius.c
+ *
+ *    Neural network based person detection using Movidius.
+ *
+ *    Copyright 2018 by Joo Aun Saw
+ *    This software is distributed under the GNU public license version 2
+ *    See also the file 'COPYING'.
+ *
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <libavutil/imgutils.h>
+#include <libavutil/parseutils.h>
+#include <libswscale/swscale.h>
+#include <mvnc.h>
+
+#include "motion.h"
+#include "movidius.h"
+
+
+// TODO: move this into a struct
+static struct ncDeviceHandle_t* deviceHandle = NULL;
+static struct ncGraphHandle_t* graphHandle = NULL;
+static struct ncFifoHandle_t* inputFIFO = NULL;
+static struct ncFifoHandle_t* outputFIFO = NULL;
+static const char *labels[] = {"background",
+                               "aeroplane", "bicycle", "bird", "boat",
+                               "bottle", "bus", "car", "cat", "chair",
+                               "cow", "diningtable", "dog", "horse",
+                               "motorbike", "person", "pottedplant",
+                               "sheep", "sofa", "train", "tvmonitor"};
+
+
+static float *scale_image(unsigned char *src_img, int width, int height)
+{
+/*
+    unsigned char *image;
+    image = img_data->image_norm;
+    AVFrame *picture;
+    // Setup pointers and line widths.
+    picture->data[0] = image;
+    picture->data[1] = image + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height);
+    picture->data[2] = picture->data[1] + ((ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height) / 4);
+
+    //// Allocate the opencv mat and store its stride in a 1-element array
+    //if (image.rows != height || image.cols != width || image.type() != CV_8UC3) image = Mat(height, width, CV_8UC3);
+    //int cvLinesizes[1];
+    //cvLinesizes[0] = image.step1();
+
+    // Convert the colour format and write directly to the opencv matrix
+    SwsContext* conversion = sws_getContext(width, height, (AVPixelFormat) frame->format, width, height, PIX_FMT_BGR24, SWS_FAST_BILINEAR, NULL, NULL, NULL);
+    sws_scale(conversion, frame->data, frame->linesize, 0, height, &image.data, cvLinesizes);
+    sws_freeContext(conversion);
+*/
+
+
+
+
+    uint8_t *src_data[4];
+    uint8_t *dst_data[4];
+    int src_linesize[4];
+    int dst_linesize[4];
+    int src_w = width;
+    int src_h = height;
+    int dst_w = 300;
+    int dst_h = 300;
+    enum AVPixelFormat src_pix_fmt = AV_PIX_FMT_YUV420P;
+    enum AVPixelFormat dst_pix_fmt = AV_PIX_FMT_BGR24;
+    struct SwsContext *sws_ctx = NULL;
+    float *processed_img = NULL;
+    int i;
+
+    memset(dst_data, 0, sizeof(dst_data[0])*4);
+    memset(src_data, 0, sizeof(src_data[0])*4);
+    memset(dst_linesize, 0, sizeof(dst_linesize[0])*4);
+    memset(src_linesize, 0, sizeof(src_linesize[0])*4);
+
+    src_data[0] = src_img;
+    src_data[1] = src_img + (src_w * src_h);
+    src_data[2] = src_data[1] + ((src_w * src_h) / 4);
+    src_linesize[0] = width;
+    src_linesize[1] = width / 2;
+    src_linesize[2] = width / 2;
+    
+    // linesize is size in bytes for each picture line.
+    // It contains stride(Image Stride) for the i-th plane
+    // For example, for frame with 640*480 which has format is YUV420P (planar).
+    // It contains pointer to Y plane, data[1] and data[2] contains pointers to
+    // U and V plans.
+    // In this case linesize[0] = 640, linesize[1] = linesize[2] = 640:2 = 320
+    // (because the U and V plane equal a half of Y – what is YUV?).
+    // With RGB24, there is only one plane
+    // data[0] = linesize[0] = width*channels = 640*3(R, G, B).
+
+    // create scaling context
+    sws_ctx = sws_getContext(src_w, src_h, src_pix_fmt,
+                             dst_w, dst_h, dst_pix_fmt,
+                             SWS_FAST_BILINEAR, NULL, NULL, NULL);
+    if (!sws_ctx)
+    {
+        fprintf(stderr,
+                "Impossible to create scale context for the conversion "
+                "fmt:%s s:%dx%d -> fmt:%s s:%dx%d\n",
+                av_get_pix_fmt_name(src_pix_fmt), src_w, src_h,
+                av_get_pix_fmt_name(dst_pix_fmt), dst_w, dst_h);
+        //ret = AVERROR(EINVAL);
+        goto end;
+    }
+    
+    // buffer is float format, align to float size
+    if (av_image_alloc(dst_data, dst_linesize,
+                       dst_w, dst_h, dst_pix_fmt, 1) < 0)
+    {
+        fprintf(stderr, "Could not allocate destination image\n");
+        goto end;
+    }
+    //dst_bufsize = ret;
+
+    // convert to destination format
+    sws_scale(sws_ctx, (const uint8_t * const*)src_data,
+              src_linesize, 0, src_h, dst_data, dst_linesize);
+
+    processed_img = malloc(dst_w * dst_h * 3 * sizeof(float));
+    if (processed_img == NULL)
+    {
+        fprintf(stderr, "Failed to allocate memory\n");
+        goto end;
+    }
+    // scale BGR range from 0-255 to -1.0 to 1.0
+    for (i = 0; i < dst_w * dst_h * 3; i++)
+    {
+        float value = dst_data[0][i];
+        processed_img[i] = (value - 127.5) * 0.007843;
+    }
+
+end:
+    av_freep(&dst_data[0]);
+    if (sws_ctx)
+        sws_freeContext(sws_ctx);
+    return processed_img;
+}
+
+
+void movidius_infer_image(unsigned char *image, int width, int height)
+{
+    float *processed_img = NULL;
+    unsigned int processed_img_len = 300 * 300 * 3 * sizeof(float);
+    ncStatus_t retCode;
+
+    // check write fifo level == 0 before writing new image
+    int writefifolevel = 0;
+    unsigned int optionSize = sizeof(writefifolevel);
+    retCode = ncFifoGetOption(inputFIFO,  NC_RO_FIFO_WRITE_FILL_LEVEL,
+                              &writefifolevel, &optionSize);
+    if (retCode != NC_OK) {
+        printf("Error [%d]: Could not get the input FIFO level.\n", retCode);
+        return;
+    }
+
+    if (writefifolevel > 0)
+        return;
+
+    processed_img = scale_image(image, width, height);
+    // Write the tensor to the input FIFO and queue an inference
+    retCode = ncGraphQueueInferenceWithFifoElem(
+                graphHandle, inputFIFO, outputFIFO, processed_img,
+                &processed_img_len, NULL);
+    if (retCode != NC_OK) {
+        printf("Error [%d]: Could not write to the input FIFO and queue an inference.\n", retCode);
+    }
+
+    if (processed_img)
+        free(processed_img);
+
+    //printf("Queued image for inference\n");
+}
+
+
+// returns zero if result is available, otherwise negative number.
+// free resultData after use
+int movidius_get_results(float **resultData, int *numResults)
+{
+    // check read fifo level > 0 first before reading so we don't block
+    ncStatus_t retCode;
+    int readfifolevel = 0;
+    unsigned int optionSize = sizeof(readfifolevel);
+    retCode = ncFifoGetOption(outputFIFO,  NC_RO_FIFO_READ_FILL_LEVEL,
+                              &readfifolevel, &optionSize);
+    if (retCode != NC_OK) {
+        printf("Error [%d]: Could not get the output FIFO level.\n", retCode);
+        return -1;
+    }
+
+    if (readfifolevel > 0)
+    {
+        //printf("readfifolevel: %d\n", readfifolevel);
+        // Get the size of the output tensor
+        unsigned int outFifoElemSize = 0;
+        optionSize = sizeof(outFifoElemSize);
+        retCode = ncFifoGetOption(outputFIFO,  NC_RO_FIFO_ELEMENT_DATA_SIZE,
+                                  &outFifoElemSize, &optionSize);
+        if (retCode != NC_OK) {
+            printf("Error [%d]: Could not get the output FIFO element data size.\n", retCode);
+            return -1;
+        }
+
+        //printf("outFifoElemSize: %d\n", outFifoElemSize);
+
+        // Get the output tensor
+        *resultData = (float *)malloc(outFifoElemSize);
+        if (*resultData == NULL) {
+            printf("Error: Could not allocate memory for result.\n");
+            return -1;
+        }
+        void *userParam;  // this will be set to point to the user-defined data that you passed into ncGraphQueueInferenceWithFifoElem() with this tensor
+        retCode = ncFifoReadElem(outputFIFO, *resultData, &outFifoElemSize, &userParam);
+        if (retCode != NC_OK) {
+            printf("Error [%d]: Could not read the result from the ouput FIFO.\n", retCode);
+            movidius_free_results(resultData);
+            return -1;
+        }
+
+        *numResults = outFifoElemSize / sizeof(float);
+
+        //printf("*numResults: %d\n", *numResults);
+
+        return 0;
+    }
+    return -1;
+}
+
+
+float movidius_get_person_probability(float *resultData, int numResults)
+{
+    float maxResult = 0.0;
+    int maxIndex = -1;
+    int index;
+
+    for (index = 0; index < numResults; index++)
+    {
+        if (resultData[index] > maxResult)
+        {
+            maxResult = resultData[index];
+            maxIndex = index;
+        }
+    }
+    printf("Index %d: probability %f\n", maxIndex, resultData[maxIndex]);
+    return 0; // FIXME: return person's probability
+}
+
+
+void movidius_free_results(float **resultData)
+{
+    if (*resultData)
+    {
+        free(*resultData);
+        *resultData = NULL;
+    }
+}
+
+
+static int movidius_read_graph_file(char *graph_path, char **graph_buffer, unsigned int *graph_length)
+{
+    FILE *file;
+    *graph_length = 0;
+
+    //Open file
+    file = fopen(graph_path, "rb");
+    if (!file)
+    {
+        fprintf(stderr, "Unable to open file %s", graph_path);
+        return -1;
+    }
+
+    //Get file length
+    fseek(file, 0, SEEK_END);
+    *graph_length = ftell(file);
+    fseek(file, 0, SEEK_SET);
+
+    //Allocate memory
+    *graph_buffer = (char *)malloc(*graph_length + 1);
+    if (*graph_buffer == NULL)
+    {
+        fprintf(stderr, "Unable to allocate memory");
+        fclose(file);
+        return -1;
+    }
+
+    //Read file contents into graph_buffer
+    fread(*graph_buffer, *graph_length, 1, file);
+    fclose(file);
+    return 0;
+}
+
+
+int movidius_init(void)
+{
+    char *graph_path = "/home/pi/motion/MobileNetSSD.graph";
+    char *graph_buffer = NULL;
+    unsigned int graph_length = 0;
+    int ret = 0;
+    ncStatus_t retCode;
+
+    // Create a device handle for the first device found (index 0)
+    retCode = ncDeviceCreate(0, &deviceHandle);
+    if (retCode != NC_OK) {
+        printf("Error [%d]: Could not create a neural compute device handle.\n", retCode);
+        ret = -1;
+        goto cleanup;
+    }
+    // Boot the device and open communication
+    retCode = ncDeviceOpen(deviceHandle);
+    if (retCode != NC_OK) {
+        printf("Error [%d]: Could not open the neural compute device.\n", retCode);
+        ret = -1;
+        goto cleanup;
+    }
+    // Load a graph from file
+    if (movidius_read_graph_file(graph_path, &graph_buffer, &graph_length))
+    {
+        printf("Error: Failed to load graph.\n");
+        ret = -1;
+        goto cleanup;
+    }
+    // Initialize a graph handle
+    retCode = ncGraphCreate("MobileNetSSD", &graphHandle);
+    if (retCode != NC_OK) {
+        printf("Error [%d]: Could not create a graph handle.\n", retCode);
+        ret = -1;
+        goto cleanup;
+    }
+
+    //printf("*** deviceHandle 0x%x, graphHandle 0x%x, graph_buffer 0x%x, graph_length %d\n",
+    //       (unsigned int)deviceHandle, (unsigned int)graphHandle,
+    //       (unsigned int)graph_buffer, graph_length);
+
+    // Allocate the graph to the device and create input and output FIFOs with default options
+    retCode = ncGraphAllocateWithFifos(deviceHandle, graphHandle, graph_buffer,
+                                       graph_length, &inputFIFO, &outputFIFO);
+    if (retCode != NC_OK) {
+        printf("Error [%d]: Could not allocate graph with FIFOs.\n", retCode);
+        ret = -1;
+        goto cleanup;
+    }
+    // Success !
+    if (graph_buffer)
+    {
+        free(graph_buffer);
+        graph_buffer = NULL;
+    }
+    return ret;
+
+
+cleanup:
+    movidius_close();
+    if (graph_buffer)
+    {
+        free(graph_buffer);
+        graph_buffer = NULL;
+    }
+    return ret;
+}
+
+
+void movidius_close(void)
+{
+    if (inputFIFO)
+    {
+        ncFifoDestroy(&inputFIFO);
+        inputFIFO = NULL;
+    }
+    if (outputFIFO)
+    {
+        ncFifoDestroy(&outputFIFO);
+        outputFIFO = NULL;
+    }
+    if (graphHandle)
+    {
+        ncGraphDestroy(&graphHandle);
+        graphHandle = NULL;
+    }
+    if (deviceHandle)
+    {
+        ncDeviceClose(deviceHandle);
+        ncDeviceDestroy(&deviceHandle);
+        deviceHandle = NULL;
+    }
+}

--- a/movidius.c
+++ b/movidius.c
@@ -189,6 +189,7 @@ static inline void clip_box_location(float *box_loc)
 int mvnc_get_results(struct mvnc_device_t *dev)
 {
     // check read fifo level > 0 first before reading so we don't block
+    int num_valid_detections = 0;
     float *tensor_output = NULL;
     ncStatus_t retCode;
     int readfifolevel = 0;
@@ -251,7 +252,6 @@ int mvnc_get_results(struct mvnc_device_t *dev)
         if ((outFifoElemSize > 1) && (tensor_output))
         {
             int num_detections = (int)tensor_output[0];
-            int num_valid_detections = 0;
             int i;
 
             if (outFifoElemSize >= num_detections*7*sizeof(float)+7*sizeof(float))
@@ -311,7 +311,7 @@ int mvnc_get_results(struct mvnc_device_t *dev)
 
         free(tensor_output);
 
-        return dev->num_results;
+        return num_valid_detections;
     }
     return -1;
 }
@@ -546,12 +546,10 @@ void mvnc_close(struct mvnc_device_t *dev)
     }
     if (dev->deviceHandle)
     {
-        MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO,
-            _("Closing mvnc device ..."));
+        MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO, _("Closing mvnc device ..."));
         ncDeviceClose(dev->deviceHandle);
         ncDeviceDestroy(&dev->deviceHandle);
         dev->deviceHandle = NULL;
-        MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO,
-            _("Closing mvnc device: success"));
+        MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO, _("Closing mvnc device: success"));
     }
 }

--- a/movidius.c
+++ b/movidius.c
@@ -365,6 +365,33 @@ unsigned movidius_person_detected(movidius_output *resultData, float score_thres
 }
 
 
+// returns -1 if no result found
+int movidius_get_max_person_index(movidius_output *resultData, float score_threshold)
+{
+    float max_score = 0;
+    int max_score_index = -1;
+    int person_class_id = 15;
+    int i;
+
+    if (resultData)
+    {
+        for (i = 0; i < resultData->num_objects; i++)
+        {
+            if (resultData->object[i].class_id == person_class_id)
+            {
+                if ((resultData->object[i].score > score_threshold) &&
+                    (resultData->object[i].score > max_score))
+                {
+                    max_score = resultData->object[i].score;
+                    max_score_index = i;
+                }
+            }
+        }
+    }
+    return max_score_index;
+}
+
+
 void movidius_free_results(movidius_output **resultData)
 {
     if (*resultData)

--- a/movidius.c
+++ b/movidius.c
@@ -133,6 +133,13 @@ end:
 
 void mvnc_infer_image(struct mvnc_device_t *dev, unsigned char *image, int width, int height)
 {
+    // Setting min_fifo_level to zero feeds the FIFO only when it is empty,
+    // giving us 5.5 fps throughput.
+    // Setting min_fifo_level to one ensures the NC stick is not starved from
+    // data, giving us 11 fps throughput, but NC stick may overheat. There
+    // should be thermal throttling built into the silicon that puts the device
+    // to sleep for a short time.
+    const int min_fifo_level = 0;
     float *processed_img = NULL;
     unsigned int processed_img_len = 0;
     ncStatus_t retCode;
@@ -149,7 +156,7 @@ void mvnc_infer_image(struct mvnc_device_t *dev, unsigned char *image, int width
         return;
     }
 
-    if (writefifolevel > 0)
+    if (writefifolevel > min_fifo_level)
         return;
 
     processed_img = scale_image(image, width, height, &processed_img_len);

--- a/movidius.h
+++ b/movidius.h
@@ -11,10 +11,29 @@
 #ifndef MOVIDIUS_H_
 #define MOVIDIUS_H_
 
+
+typedef struct movidius_result {
+    int class_id;       // index into MobileNet_labels
+    float score;        // probability in percentage
+    float box_left;     // object location within image, range 0.0 to 1.0
+    float box_top;      // object location within image, range 0.0 to 1.0
+    float box_right;    // object location within image, range 0.0 to 1.0
+    float box_bottom;   // object location within image, range 0.0 to 1.0
+} movidius_result;
+
+
+typedef struct movidius_output {
+    struct movidius_result *object;
+    int num_objects;
+} movidius_output;
+
+
+
 void movidius_infer_image(unsigned char *image, int width, int height);
-int movidius_get_results(float **resultData, int *resultDataLength);
-float movidius_get_person_probability(float *resultData, int resultDataLength);
-void movidius_free_results(float **resultData);
+int movidius_get_results(movidius_output **resultData);
+float movidius_get_highest_person_score(movidius_output *resultData);
+const char *movidius_get_class_label(int class_id);
+void movidius_free_results(movidius_output **resultData);
 
 int movidius_init(void);
 void movidius_close(void);

--- a/movidius.h
+++ b/movidius.h
@@ -32,6 +32,7 @@ typedef struct movidius_output {
 void movidius_infer_image(unsigned char *image, int width, int height);
 int movidius_get_results(movidius_output **resultData);
 unsigned movidius_person_detected(movidius_output *resultData, float score_threshold);
+int movidius_get_max_person_index(movidius_output *resultData, float score_threshold);
 const char *movidius_get_class_label(int class_id);
 void movidius_free_results(movidius_output **resultData);
 

--- a/movidius.h
+++ b/movidius.h
@@ -12,8 +12,8 @@
 #define MOVIDIUS_H_
 
 void movidius_infer_image(unsigned char *image, int width, int height);
-int movidius_get_results(float **resultData, int *numResults);
-float movidius_get_person_probability(float *resultData, int numResults);
+int movidius_get_results(float **resultData, int *resultDataLength);
+float movidius_get_person_probability(float *resultData, int resultDataLength);
 void movidius_free_results(float **resultData);
 
 int movidius_init(void);

--- a/movidius.h
+++ b/movidius.h
@@ -11,33 +11,41 @@
 #ifndef MOVIDIUS_H_
 #define MOVIDIUS_H_
 
+#include <mvnc.h>
 
-typedef struct movidius_result {
+
+typedef struct mvnc_result {
     int class_id;       // index into MobileNet_labels
     float score;        // probability in percentage
     float box_left;     // object location within image, range 0.0 to 1.0
     float box_top;      // object location within image, range 0.0 to 1.0
     float box_right;    // object location within image, range 0.0 to 1.0
     float box_bottom;   // object location within image, range 0.0 to 1.0
-} movidius_result;
+} mvnc_result;
 
 
-typedef struct movidius_output {
-    struct movidius_result *object;
-    int num_objects;
-} movidius_output;
+typedef struct mvnc_device_t {
+    struct ncDeviceHandle_t* deviceHandle;
+    struct ncGraphHandle_t* graphHandle;
+    struct ncFifoHandle_t* inputFIFO;
+    struct ncFifoHandle_t* outputFIFO;
+    struct mvnc_result *results;
+    int num_results;
+} mvnc_device_t;
 
 
+void mvnc_infer_image(struct mvnc_device_t *dev, unsigned char *image, int width, int height);
+int mvnc_get_results(struct mvnc_device_t *dev);
+unsigned mvnc_objects_detected(struct mvnc_device_t *dev, int *class_ids,
+                               int num_class_ids, float score_threshold);
+int mvnc_get_max_score_index(struct mvnc_device_t *dev, int *class_ids,
+                             int num_class_ids, float score_threshold);
+int mvnc_get_class_id_from_string(const char *label_string);
+const char *mvnc_get_class_label(int class_id);
+void mvnc_free_results(struct mvnc_device_t *dev);
 
-void movidius_infer_image(unsigned char *image, int width, int height);
-int movidius_get_results(movidius_output **resultData);
-unsigned movidius_person_detected(movidius_output *resultData, float score_threshold);
-int movidius_get_max_person_index(movidius_output *resultData, float score_threshold);
-const char *movidius_get_class_label(int class_id);
-void movidius_free_results(movidius_output **resultData);
-
-int movidius_init(void);
-void movidius_close(void);
+int mvnc_init(struct mvnc_device_t *dev, int dev_index, const char *graph_path);
+void mvnc_close(struct mvnc_device_t *dev);
 
 
 #endif /* MOVIDIUS_H_ */

--- a/movidius.h
+++ b/movidius.h
@@ -31,7 +31,7 @@ typedef struct movidius_output {
 
 void movidius_infer_image(unsigned char *image, int width, int height);
 int movidius_get_results(movidius_output **resultData);
-float movidius_get_highest_person_score(movidius_output *resultData);
+unsigned movidius_person_detected(movidius_output *resultData, float score_threshold);
 const char *movidius_get_class_label(int class_id);
 void movidius_free_results(movidius_output **resultData);
 

--- a/movidius.h
+++ b/movidius.h
@@ -11,7 +11,13 @@
 #ifndef MOVIDIUS_H_
 #define MOVIDIUS_H_
 
+#include <time.h>
 #include <mvnc.h>
+
+
+#define HAVE_MVNC_PROFILE
+
+#define MVNC_PROFILE_AVERAGE_LENGTH     16
 
 
 typedef struct mvnc_result {
@@ -31,6 +37,11 @@ typedef struct mvnc_device_t {
     struct ncFifoHandle_t* outputFIFO;
     struct mvnc_result *results;
     int num_results;
+    unsigned int thermal_buffer_size;
+#ifdef HAVE_MVNC_PROFILE
+    struct timespec profile_ts[MVNC_PROFILE_AVERAGE_LENGTH];
+    unsigned int profile_ts_index;
+#endif
 } mvnc_device_t;
 
 
@@ -41,8 +52,16 @@ unsigned mvnc_objects_detected(struct mvnc_device_t *dev, int *class_ids,
 int mvnc_get_max_score_index(struct mvnc_device_t *dev, int *class_ids,
                              int num_class_ids, float score_threshold);
 int mvnc_get_class_id_from_string(const char *label_string);
+int mvnc_get_temperature_log(struct mvnc_device_t *dev, float **temperature_log,
+                             unsigned *temperature_log_length);
+float mvnc_get_max_temperature(struct mvnc_device_t *dev);
+int mvnc_get_thermal_throttle_level(struct mvnc_device_t *dev);
 const char *mvnc_get_class_label(int class_id);
 void mvnc_free_results(struct mvnc_device_t *dev);
+
+#ifdef HAVE_MVNC_PROFILE
+double mvnc_profile_get_fps(struct mvnc_device_t *dev);
+#endif
 
 int mvnc_init(struct mvnc_device_t *dev, int dev_index, const char *graph_path);
 void mvnc_close(struct mvnc_device_t *dev);

--- a/movidius.h
+++ b/movidius.h
@@ -1,0 +1,23 @@
+/*
+ * movidius.h
+ *
+ *    Include file for movidius.c
+ *
+ *    Copyright 2013 by Nicholas Tuckett
+ *    This software is distributed under the GNU public license version 2
+ *    See also the file 'COPYING'.
+ */
+
+#ifndef MOVIDIUS_H_
+#define MOVIDIUS_H_
+
+void movidius_infer_image(unsigned char *image, int width, int height);
+int movidius_get_results(float **resultData, int *numResults);
+float movidius_get_person_probability(float *resultData, int numResults);
+void movidius_free_results(float **resultData);
+
+int movidius_init(void);
+void movidius_close(void);
+
+
+#endif /* MOVIDIUS_H_ */


### PR DESCRIPTION
Original issue here: https://github.com/Motion-Project/motion/issues/826

This series of patches add support for Movidius NC (MVNC) stick for more reliable person/cat/dog/car detection. New configuration items are introduced:
- `mvnc_enable <on|off>` : Original motion detection algorithm is used when this is disabled. When enabled, MVNC will be used instead.
- `mvnc_graph_path <path to MobileNetSSD graph>` : This must point to MobileNetSSD graph file. Other neural net models are **not** supported.
- `mvnc_classification <person,cat,dog,car>` : A comma separated classes of objects to detect.
- `mvnc_threshold <0 to 100>` : Inference confidence level for a detection to be considered valid.

Multiple camera streams will either:
- require multiple Movidius NC sticks, one stick per camera stream.
- or enable `mvnc_enable` on one stream only, all other streams use original detection method.