### PR TITLE
fix static linking with webp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -276,7 +276,7 @@ if test "${WEBP}" = "yes"; then
     AC_MSG_RESULT(found)
     AC_DEFINE([HAVE_WEBP], 1, [Define to 1 if WEBP is around])
     HAVE_WEBP="yes"
-    TEMP_LIBS="$TEMP_LIBS -lwebp -lwebpmux"
+    TEMP_LIBS="$TEMP_LIBS -lwebpmux -lwebp"
   else
     AC_MSG_RESULT(not found)
   fi


### PR DESCRIPTION
Static build with webp fails because webp is put before webpmux.

Fixes:
 - http://autobuild.buildroot.org/results/4d4e72808300ba1ff79ca794930112b554eb2533

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>