### PR TITLE
Fix inclusion of videodev2.h/videoio.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,7 +106,7 @@ if test "x${BKTR}" = "xyes"; then
   fi
 fi
 if test "${V4L2}" = "yes"; then
-  AC_CHECK_HEADERS(linux/videodev2.h,[V4L2="yes"],[V4L2="no"])
+  AC_CHECK_HEADERS(linux/videodev2.h sys/videoio.h,[V4L2="yes";break],[V4L2="no"])
 fi
 
 if test "x${V4L2}" = "xyes"; then

--- a/track.c
+++ b/track.c
@@ -10,7 +10,11 @@
 #include "motion.h"
 
 #ifdef HAVE_V4L2
+#if defined(HAVE_LINUX_VIDEODEV2_H)
 #include <linux/videodev2.h>
+#elif defined(HAVE_SYS_VIDEOIO_H)
+#include <sys/videoio.h>
+#endif
 #include "pwc-ioctl.h"
 #endif
 

--- a/video_v4l2.c
+++ b/video_v4l2.c
@@ -26,7 +26,11 @@
 
 #ifdef HAVE_V4L2
 
+#if defined(HAVE_LINUX_VIDEODEV2_H)
 #include <linux/videodev2.h>
+#elif defined(HAVE_SYS_VIDEOIO_H)
+#include <sys/videoio.h>
+#endif
 
 #define u8 unsigned char
 #define u16 unsigned short


### PR DESCRIPTION
This fixes compilation on non-linux systems where `linux/videodev2.h` is absent.