### PR TITLE
Include sys/videoio.h as an alternative to linux/videodev2.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,7 +106,7 @@ if test "x${BKTR}" = "xyes"; then
   fi
 fi
 if test "${V4L2}" = "yes"; then
-  AC_CHECK_HEADERS(linux/videodev2.h,[V4L2="yes"],[V4L2="no"])
+  AC_CHECK_HEADERS(linux/videodev2.h sys/videoio.h,[V4L2="yes";break],[V4L2="no"])
 fi
 
 if test "x${V4L2}" = "xyes"; then

--- a/event.c
+++ b/event.c
@@ -474,7 +474,7 @@ static void event_stream_put(struct context *cnt,
 }
 
 
-#if defined(HAVE_V4L2) && !defined(__FreeBSD__)
+#if defined(HAVE_V4L2) && !defined(BSD)
 static void event_vlp_putpipe(struct context *cnt,
             motion_event type ATTRIBUTE_UNUSED,
             struct image_data *img_data, char *dummy ATTRIBUTE_UNUSED, void *devpipe,
@@ -486,7 +486,7 @@ static void event_vlp_putpipe(struct context *cnt,
                 ,_("Failed to put image into video pipe"));
     }
 }
-#endif /* defined(HAVE_V4L2) && !__FreeBSD__  */
+#endif /* defined(HAVE_V4L2) && !defined(BSD)  */
 
 const char *imageext(struct context *cnt)
 {
@@ -1291,7 +1291,7 @@ struct event_handlers event_handlers[] = {
     EVENT_IMAGE_SNAPSHOT,
     event_image_snapshot
     },
-#if defined(HAVE_V4L2) && !defined(__FreeBSD__)
+#if defined(HAVE_V4L2) && !defined(BSD)
     {
     EVENT_IMAGE,
     event_vlp_putpipe
@@ -1300,7 +1300,7 @@ struct event_handlers event_handlers[] = {
     EVENT_IMAGEM,
     event_vlp_putpipe
     },
-#endif /* defined(HAVE_V4L2) && !__FreeBSD__  */
+#endif /* defined(HAVE_V4L2) && !defined(BSD) */
     {
     EVENT_IMAGE_PREVIEW,
     event_image_preview

--- a/motion.c
+++ b/motion.c
@@ -1394,7 +1394,7 @@ static int motion_init(struct context *cnt)
     /* create a reference frame */
     alg_update_reference_frame(cnt, RESET_REF_FRAME);
 
-    #if defined(HAVE_V4L2) && !defined(__FreeBSD__)
+    #if defined(HAVE_V4L2) && !defined(BSD)
         /* open video loopback devices if enabled */
         if (cnt->conf.video_pipe) {
             MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO
@@ -1423,7 +1423,7 @@ static int motion_init(struct context *cnt)
                 return -1;
             }
         }
-    #endif /* HAVE_V4L2 && !__FreeBSD__ */
+    #endif /* HAVE_V4L2 && !BSD */
 
     retcd = dbse_init(cnt);
     if (retcd != 0) return retcd;

--- a/motion.h
+++ b/motion.h
@@ -53,7 +53,7 @@ struct image_data;
 #include <pthread.h>
 #include <microhttpd.h>
 
-#if defined(BSD)
+#if defined(BSD) && !defined(__APPLE__)
 #include <pthread_np.h>
 #endif
 

--- a/motion.h
+++ b/motion.h
@@ -53,7 +53,7 @@ struct image_data;
 #include <pthread.h>
 #include <microhttpd.h>
 
-#if defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(BSD)
 #include <pthread_np.h>
 #endif
 

--- a/track.c
+++ b/track.c
@@ -10,7 +10,11 @@
 #include "motion.h"
 
 #ifdef HAVE_V4L2
+#if defined(HAVE_LINUX_VIDEODEV2_H)
 #include <linux/videodev2.h>
+#else
+#include <sys/videoio.h>
+#endif
 #include "pwc-ioctl.h"
 #endif
 

--- a/video_v4l2.c
+++ b/video_v4l2.c
@@ -26,7 +26,11 @@
 
 #ifdef HAVE_V4L2
 
+#if defined(HAVE_LINUX_VIDEODEV2_H)
 #include <linux/videodev2.h>
+#else
+#include <sys/videoio.h>
+#endif
 
 #define u8 unsigned char
 #define u16 unsigned short
@@ -113,7 +117,7 @@ static void v4l2_palette_init(palette_item *palette_array){
 
 }
 
-#if defined (__OpenBSD__) || defined (__FreeBSD__)
+#if defined (BSD)
 static int xioctl(src_v4l2_t *vid_source, unsigned long request, void *arg)
 #else
 static int xioctl(src_v4l2_t *vid_source, int request, void *arg)


### PR DESCRIPTION
and check for defined(BSD) instead of defined(__FreeBSD__).
This makes webcams work on OpenBSD.

Resolves #904