### PR TITLE
Guide: replace minimum_gap with minimum_frame_time

### DIFF
--- a/motion_config.html
+++ b/motion_config.html
@@ -3250,7 +3250,7 @@
         Motion will stop storing pictures if the framerate is set to less than 2.
         Set this parameter to the maximum number of images per second that you want
         to store either as images or movies.
-        To set intervals longer than one second use the 'minimum_gap' option instead.
+        To set intervals longer than one second use the 'minimum_frame_time' option instead.
         <p></p>
 
         <h3><a name="minimum_frame_time"></a> minimum_frame_time </h3>
@@ -3846,7 +3846,6 @@
           <li> Some of the tracking features sets the camera back to the center position when an event is over.</li>
         </ul>
 
-        Note that 'event_gap' and 'minimum_gap' have nothing to do with each other.
         <p></p>
 
         <h3><a name="pre_capture"></a> pre_capture </h3>


### PR DESCRIPTION
The former `minimum_gap` option has been replaced by `minimum_frame_time`, if I'm not mistaking. This PR simply updates the guide to reflect this change.