### PR TITLE
Avoid using word semicolon to refer to :

### DIFF
--- a/motion_config.html
+++ b/motion_config.html
@@ -4376,7 +4376,7 @@
         <p></p>
         Note that certain containers can handle different codecs than the defaults indicated above.  For example, the
         mkv container can handle virtually any codec.  Motion can optionally take an additional specification with this
-        parameter.  By specifying the container (mkv) and then appending a semicolon and the ffmpeg codec name Motion
+        parameter.  By specifying the container (mkv) and then appending a colon and the ffmpeg codec name Motion
         will attempt to use the specified codec for the container.  This permits options such as encoding the h265 codec
         into a mkv container instead of mp4 by specifying the option as <code>mkv:libx265</code>
         <p></p>


### PR DESCRIPTION
Because it's actually a colon.