### PR TITLE
ffmpeg: do bitrate calculation in 64 bits to prevent overflow

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -558,7 +558,7 @@ static int ffmpeg_set_quality(struct ffmpeg *ffmpeg){
         if ((strcmp(ffmpeg->codec->name, "h264_omx") == 0) || (strcmp(ffmpeg->codec->name, "mpeg4_omx") == 0)) {
             // H264 OMX encoder quality can only be controlled via bit_rate
             // bit_rate = ffmpeg->width * ffmpeg->height * ffmpeg->fps * quality_factor
-            ffmpeg->quality = (ffmpeg->width * ffmpeg->height * ffmpeg->fps * ffmpeg->quality) >> 7;
+            ffmpeg->quality = (int)(((int64_t)ffmpeg->width * ffmpeg->height * ffmpeg->fps * ffmpeg->quality) >> 7);
             // Clip bit rate to min
             if (ffmpeg->quality < 4000) // magic number
                 ffmpeg->quality = 4000;


### PR DESCRIPTION
Do video bitrate calculation using int64_t to prevent overflow.