### PR TITLE
Support h264_v4l2m2m video encoder

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -811,12 +811,14 @@ static int ffmpeg_alloc_video_buffer(AVFrame *frame, int align)
     frame->buf[0] = av_buffer_alloc(ret + 4*plane_padding);
     if (!frame->buf[0]) {
         ret = AVERROR(ENOMEM);
-        goto fail;
+        av_frame_unref(frame);
+        return ret;
     }
     frame->buf[1] = av_buffer_alloc(ret + 4*plane_padding);
     if (!frame->buf[1]) {
         ret = AVERROR(ENOMEM);
-        goto fail;
+        av_frame_unref(frame);
+        return ret;
     }
 
     frame->data[0] = frame->buf[0]->data;

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -179,18 +179,40 @@ int my_copy_packet(AVPacket *dest_pkt, AVPacket *src_pkt){
 #endif
 }
 /*********************************************/
-void my_free_nal_info(struct ffmpeg *ffmpeg){
+
+/****************************************************************************
+ ****************************************************************************
+ ****************************************************************************/
+/*********************************************/
+void ffmpeg_free_nal(struct ffmpeg *ffmpeg){
     if (ffmpeg->nal_info) {
         free(ffmpeg->nal_info);
         ffmpeg->nal_info = NULL;
         ffmpeg->nal_info_len = 0;
     }
 }
-/*********************************************/
 
-/****************************************************************************
- ****************************************************************************
- ****************************************************************************/
+static void ffmpeg_encode_nal(struct ffmpeg *ffmpeg){
+    // h264_v4l2m2m has NAL units separated from the first frame, which makes
+    // some players very unhappy.
+    if ((ffmpeg->pkt.pts == 0) && (!(ffmpeg->pkt.flags & AV_PKT_FLAG_KEY))) {
+        ffmpeg_free_nal(ffmpeg);
+        ffmpeg->nal_info_len = ffmpeg->pkt.size;
+        ffmpeg->nal_info = malloc(ffmpeg->nal_info_len);
+        if (ffmpeg->nal_info)
+            memcpy(ffmpeg->nal_info, &ffmpeg->pkt.data[0], ffmpeg->nal_info_len);
+        else
+            ffmpeg->nal_info_len = 0;
+    } else if (ffmpeg->nal_info) {
+        int old_size = ffmpeg->pkt.size;
+        av_grow_packet(&ffmpeg->pkt, ffmpeg->nal_info_len);
+        memmove(&ffmpeg->pkt.data[ffmpeg->nal_info_len], &ffmpeg->pkt.data[0], old_size);
+        memcpy(&ffmpeg->pkt.data[0], ffmpeg->nal_info, ffmpeg->nal_info_len);
+        ffmpeg_free_nal(ffmpeg);
+    }
+
+}
+
 static int ffmpeg_timelapse_exists(const char *fname){
     FILE *file;
     file = fopen(fname, "r");
@@ -417,25 +439,10 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
         return -1;
     }
 
-    if (ffmpeg->nal_info_separated) {
-        // h264_v4l2m2m has NAL units separated from the first frame, which makes
-        // some players very unhappy.
-        if ((ffmpeg->pkt.pts == 0) && (!(ffmpeg->pkt.flags & AV_PKT_FLAG_KEY))) {
-            my_free_nal_info(ffmpeg);
-            ffmpeg->nal_info_len = ffmpeg->pkt.size;
-            ffmpeg->nal_info = malloc(ffmpeg->nal_info_len);
-            if (ffmpeg->nal_info)
-                memcpy(ffmpeg->nal_info, &ffmpeg->pkt.data[0], ffmpeg->nal_info_len);
-            else
-                ffmpeg->nal_info_len = 0;
-        } else if (ffmpeg->nal_info) {
-            int old_size = ffmpeg->pkt.size;
-            av_grow_packet(&ffmpeg->pkt, ffmpeg->nal_info_len);
-            memmove(&ffmpeg->pkt.data[ffmpeg->nal_info_len], &ffmpeg->pkt.data[0], old_size);
-            memcpy(&ffmpeg->pkt.data[0], ffmpeg->nal_info, ffmpeg->nal_info_len);
-            my_free_nal_info(ffmpeg);
-        }
+    if (ffmpeg->preferred_codec == USER_CODEC_V4L2M2M){
+        ffmpeg_encode_nal(ffmpeg);
     }
+
     return 0;
 
 #elif (LIBAVFORMAT_VERSION_MAJOR >= 55) || ((LIBAVFORMAT_VERSION_MAJOR == 54) && (LIBAVFORMAT_VERSION_MINOR > 6))
@@ -586,10 +593,13 @@ static int ffmpeg_set_quality(struct ffmpeg *ffmpeg){
             ffmpeg->quality = 45; // default to 45% quality
         av_dict_set(&ffmpeg->opts, "preset", "ultrafast", 0);
         av_dict_set(&ffmpeg->opts, "tune", "zerolatency", 0);
-        if ((strcmp(ffmpeg->codec->name, "h264_omx") == 0) ||
-           (strcmp(ffmpeg->codec->name, "mpeg4_omx") == 0) ||
-           (strcmp(ffmpeg->codec->name, "h264_v4l2m2m") == 0)) {
-            // H264 OMX encoder quality can only be controlled via bit_rate
+        /* This next if statement needs validation.  Are mpeg4omx
+         * and v4l2m2m even MY_CODEC_ID_H264 or MY_CODEC_ID_HEVC
+         * such that it even would be possible to be part of this
+         * if block to start with? */
+        if ((ffmpeg->preferred_codec == USER_CODEC_H264OMX) ||
+            (ffmpeg->preferred_codec == USER_CODEC_MPEG4OMX) ||
+            (ffmpeg->preferred_codec == USER_CODEC_V4L2M2M)) {
             // bit_rate = ffmpeg->width * ffmpeg->height * ffmpeg->fps * quality_factor
             ffmpeg->quality = (int)(((int64_t)ffmpeg->width * ffmpeg->height * ffmpeg->fps * ffmpeg->quality) >> 7);
             // Clip bit rate to min
@@ -639,11 +649,7 @@ static int ffmpeg_codec_is_blacklisted(const char *codec_name){
     return 0;
 }
 
-static int ffmpeg_set_codec(struct ffmpeg *ffmpeg){
-
-    int retcd;
-    char errstr[128];
-    int chkrate;
+static int ffmpeg_set_codec_preferred(struct ffmpeg *ffmpeg){
     size_t codec_name_len = strcspn(ffmpeg->codec_name, ":");
 
     ffmpeg->codec = NULL;
@@ -671,8 +677,39 @@ static int ffmpeg_set_codec(struct ffmpeg *ffmpeg){
         ffmpeg_free_context(ffmpeg);
         return -1;
     }
+
+    if (strcmp(ffmpeg->codec->name, "h264_v4l2m2m") == 0){
+        #if (LIBAVFORMAT_VERSION_MAJOR >= 58) || ((LIBAVFORMAT_VERSION_MAJOR == 57) && (LIBAVFORMAT_VERSION_MINOR >= 41))
+            ffmpeg->preferred_codec = USER_CODEC_V4L2M2M;
+        #else
+            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO
+                ,_("FFMpeg version is too old for codec %s"), ffmpeg->codec_name);
+            ffmpeg_free_context(ffmpeg);
+            return -1;
+        #endif
+    } else if (strcmp(ffmpeg->codec->name, "h264_omx") == 0){
+        ffmpeg->preferred_codec = USER_CODEC_H264OMX;
+    } else if (strcmp(ffmpeg->codec->name, "mpeg4_omx") == 0){
+        ffmpeg->preferred_codec = USER_CODEC_MPEG4OMX;
+    } else {
+        ffmpeg->preferred_codec = USER_CODEC_DEFAULT;
+    }
+
     if (ffmpeg->codec_name[codec_name_len])
         MOTION_LOG(NTC, TYPE_ENCODER, NO_ERRNO,_("Using codec %s"), ffmpeg->codec->name);
+
+    return 0;
+
+}
+
+static int ffmpeg_set_codec(struct ffmpeg *ffmpeg){
+
+    int retcd;
+    char errstr[128];
+    int chkrate;
+
+    retcd = ffmpeg_set_codec_preferred(ffmpeg);
+    if (retcd != 0) return retcd;
 
 #if (LIBAVFORMAT_VERSION_MAJOR >= 58) || ((LIBAVFORMAT_VERSION_MAJOR == 57) && (LIBAVFORMAT_VERSION_MINOR >= 41))
     //If we provide the codec to this, it results in a memory leak.  ffmpeg ticket: 5714
@@ -735,20 +772,17 @@ static int ffmpeg_set_codec(struct ffmpeg *ffmpeg){
     ffmpeg->ctx_codec->height        = ffmpeg->height;
     ffmpeg->ctx_codec->time_base.num = 1;
     ffmpeg->ctx_codec->time_base.den = ffmpeg->fps;
-    if (strcmp(ffmpeg->codec->name, "h264_v4l2m2m") == 0)
+    if (ffmpeg->preferred_codec == USER_CODEC_V4L2M2M){
         ffmpeg->ctx_codec->pix_fmt   = AV_PIX_FMT_NV21;
-    else
+    } else {
         ffmpeg->ctx_codec->pix_fmt   = MY_PIX_FMT_YUV420P;
+    }
     ffmpeg->ctx_codec->max_b_frames  = 0;
     if (strcmp(ffmpeg->codec_name, "ffv1") == 0){
       ffmpeg->ctx_codec->strict_std_compliance = -2;
       ffmpeg->ctx_codec->level = 3;
     }
     ffmpeg->ctx_codec->flags |= MY_CODEC_FLAG_GLOBAL_HEADER;
-    // h264_v4l2m2m has NAL units separated from the first frame. We need to deal
-    // with it appriopriately later
-    if (strcmp(ffmpeg->codec->name, "h264_v4l2m2m") == 0)
-        ffmpeg->nal_info_separated = 1;
 
     retcd = ffmpeg_set_quality(ffmpeg);
     if (retcd < 0){
@@ -808,7 +842,7 @@ static int ffmpeg_set_stream(struct ffmpeg *ffmpeg){
 
 }
 
-
+/*Special allocation of video buffer for v4l2m2m codec*/
 static int ffmpeg_alloc_video_buffer(AVFrame *frame, int align)
 {
     const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(frame->format);
@@ -890,8 +924,7 @@ static int ffmpeg_set_picture(struct ffmpeg *ffmpeg){
     ffmpeg->picture->width  = ffmpeg->ctx_codec->width;
     ffmpeg->picture->height = ffmpeg->ctx_codec->height;
 
-    // h264_v4l2m2m encoder expects video buffer to be allocated
-    if (strcmp(ffmpeg->codec->name, "h264_v4l2m2m") == 0) {
+    if (ffmpeg->preferred_codec == USER_CODEC_V4L2M2M) {
         retcd = ffmpeg_alloc_video_buffer(ffmpeg->picture, 32);
         if (retcd) {
             av_strerror(retcd, errstr, sizeof(errstr));
@@ -1457,7 +1490,7 @@ void ffmpeg_close(struct ffmpeg *ffmpeg){
             }
         }
         ffmpeg_free_context(ffmpeg);
-        my_free_nal_info(ffmpeg);
+        ffmpeg_free_nal(ffmpeg);
     }
 
 #else
@@ -1465,11 +1498,53 @@ void ffmpeg_close(struct ffmpeg *ffmpeg){
 #endif // HAVE_FFMPEG
 }
 
+static void ffmpeg_put_pix_nv21(struct ffmpeg *ffmpeg, struct image_data *img_data){
+    unsigned char *image,*imagecr, *imagecb;
+    int cr_len, x, y;
+
+    if (ffmpeg->high_resolution){
+        image = img_data->image_high;
+    } else {
+        image = img_data->image_norm;
+    }
+
+    cr_len = ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height / 4;
+    imagecr = image + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height);
+    imagecb = image + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height) + cr_len;
+
+    memcpy(ffmpeg->picture->data[0], image, ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height);
+    for (y = 0; y < ffmpeg->ctx_codec->height; y++) {
+        for (x = 0; x < ffmpeg->ctx_codec->width/4; x++) {
+            ffmpeg->picture->data[1][y*ffmpeg->ctx_codec->width/2 + x*2] = *imagecb;
+            ffmpeg->picture->data[1][y*ffmpeg->ctx_codec->width/2 + x*2 + 1] = *imagecr;
+            imagecb++;
+            imagecr++;
+        }
+    }
+
+}
+
+static void ffmpeg_put_pix_yuv420(struct ffmpeg *ffmpeg, struct image_data *img_data){
+    unsigned char *image;
+
+    if (ffmpeg->high_resolution){
+        image = img_data->image_high;
+    } else {
+        image = img_data->image_norm;
+    }
+
+    // Usual setup for image pointers
+    ffmpeg->picture->data[0] = image;
+    ffmpeg->picture->data[1] = image + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height);
+    ffmpeg->picture->data[2] = ffmpeg->picture->data[1] + ((ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height) / 4);
+
+}
+
 int ffmpeg_put_image(struct ffmpeg *ffmpeg, struct image_data *img_data, const struct timeval *tv1){
 #ifdef HAVE_FFMPEG
     int retcd = 0;
     int cnt = 0;
-    unsigned char *image;
+
 
     if (ffmpeg->passthrough) {
         retcd = ffmpeg_passthru_put(ffmpeg, img_data);
@@ -1477,34 +1552,11 @@ int ffmpeg_put_image(struct ffmpeg *ffmpeg, struct image_data *img_data, const s
     }
 
     if (ffmpeg->picture) {
-        if (ffmpeg->high_resolution){
-            image = img_data->image_high;
-        } else {
-            image = img_data->image_norm;
-        }
 
-        /* Setup pointers and line widths. */
-        if (strcmp(ffmpeg->codec->name, "h264_v4l2m2m") == 0) {
-            // assume NV21 format
-            int cr_len = ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height / 4;
-            unsigned char *imagecr = image + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height);
-            unsigned char *imagecb = image + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height) + cr_len;
-            int x;
-            int y;
-            memcpy(ffmpeg->picture->data[0], image, ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height);
-            for (y = 0; y < ffmpeg->ctx_codec->height; y++) {
-                for (x = 0; x < ffmpeg->ctx_codec->width/4; x++) {
-                    ffmpeg->picture->data[1][y*ffmpeg->ctx_codec->width/2 + x*2] = *imagecb;
-                    ffmpeg->picture->data[1][y*ffmpeg->ctx_codec->width/2 + x*2 + 1] = *imagecr;
-                    imagecb++;
-                    imagecr++;
-                }
-            }
+        if (ffmpeg->preferred_codec == USER_CODEC_V4L2M2M) {
+            ffmpeg_put_pix_nv21(ffmpeg, img_data);
         } else {
-            // assume YUV420P format
-            ffmpeg->picture->data[0] = image;
-            ffmpeg->picture->data[1] = image + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height);
-            ffmpeg->picture->data[2] = ffmpeg->picture->data[1] + ((ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height) / 4);
+            ffmpeg_put_pix_yuv420(ffmpeg, img_data);
         }
 
         ffmpeg->gop_cnt ++;

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -964,11 +964,16 @@ static int ffmpeg_flush_codec(struct ffmpeg *ffmpeg){
                     my_packet_unref(ffmpeg->pkt);
                     return -1;
                 }
-                retcd = av_write_frame(ffmpeg->oc, &ffmpeg->pkt);
-                if (retcd < 0) {
-                    MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO
-                        ,_("Error writing draining video frame"));
-                    return -1;
+                // v4l2_m2m encoder uses pts 0 and size 0 to indicate AVERROR_EOF
+                if ((ffmpeg->pkt.pts > 0) && (ffmpeg->pkt.size > 0)) {
+                    retcd = av_write_frame(ffmpeg->oc, &ffmpeg->pkt);
+                    if (retcd < 0) {
+                        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO
+                            ,_("Error writing draining video frame"));
+                        return -1;
+                    }
+                } else {
+                    recv_cd = AVERROR_EOF;
                 }
             }
             my_packet_unref(ffmpeg->pkt);

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -512,7 +512,11 @@ static int ffmpeg_set_pts(struct ffmpeg *ffmpeg, const struct timeval *tv1){
             ffmpeg_reset_movie_start_time(ffmpeg, tv1);
             pts_interval = 0;
         }
-        ffmpeg->picture->pts = av_rescale_q(pts_interval,(AVRational){1, 1000000L},ffmpeg->video_st->time_base) + ffmpeg->base_pts;
+        if (ffmpeg->last_pts < 0) {
+            // This is the very first frame, ensure PTS is zero
+            ffmpeg->picture->pts = 0;
+        } else
+            ffmpeg->picture->pts = av_rescale_q(pts_interval,(AVRational){1, 1000000L},ffmpeg->video_st->time_base) + ffmpeg->base_pts;
 
         if (ffmpeg->test_mode == TRUE){
             MOTION_LOG(INF, TYPE_ENCODER, NO_ERRNO

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -969,15 +969,16 @@ static int ffmpeg_flush_codec(struct ffmpeg *ffmpeg){
                     return -1;
                 }
                 // v4l2_m2m encoder uses pts 0 and size 0 to indicate AVERROR_EOF
-                if ((ffmpeg->pkt.pts > 0) && (ffmpeg->pkt.size > 0)) {
-                    retcd = av_write_frame(ffmpeg->oc, &ffmpeg->pkt);
-                    if (retcd < 0) {
-                        MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO
-                            ,_("Error writing draining video frame"));
-                        return -1;
-                    }
-                } else {
+                if ((ffmpeg->pkt.pts == 0) || (ffmpeg->pkt.size == 0)) {
                     recv_cd = AVERROR_EOF;
+                    my_packet_unref(ffmpeg->pkt);
+                    continue;
+                }
+                retcd = av_write_frame(ffmpeg->oc, &ffmpeg->pkt);
+                if (retcd < 0) {
+                    MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO
+                        ,_("Error writing draining video frame"));
+                    return -1;
                 }
             }
             my_packet_unref(ffmpeg->pkt);

--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -555,7 +555,9 @@ static int ffmpeg_set_quality(struct ffmpeg *ffmpeg){
             ffmpeg->quality = 45; // default to 45% quality
         av_dict_set(&ffmpeg->opts, "preset", "ultrafast", 0);
         av_dict_set(&ffmpeg->opts, "tune", "zerolatency", 0);
-        if ((strcmp(ffmpeg->codec->name, "h264_omx") == 0) || (strcmp(ffmpeg->codec->name, "mpeg4_omx") == 0)) {
+        if ((strcmp(ffmpeg->codec->name, "h264_omx") == 0) ||
+           (strcmp(ffmpeg->codec->name, "mpeg4_omx") == 0) ||
+           (strcmp(ffmpeg->codec->name, "h264_v4l2m2m") == 0)) {
             // H264 OMX encoder quality can only be controlled via bit_rate
             // bit_rate = ffmpeg->width * ffmpeg->height * ffmpeg->fps * quality_factor
             ffmpeg->quality = (int)(((int64_t)ffmpeg->width * ffmpeg->height * ffmpeg->fps * ffmpeg->quality) >> 7);
@@ -702,7 +704,10 @@ static int ffmpeg_set_codec(struct ffmpeg *ffmpeg){
     ffmpeg->ctx_codec->height        = ffmpeg->height;
     ffmpeg->ctx_codec->time_base.num = 1;
     ffmpeg->ctx_codec->time_base.den = ffmpeg->fps;
-    ffmpeg->ctx_codec->pix_fmt       = MY_PIX_FMT_YUV420P;
+    if (strcmp(ffmpeg->codec->name, "h264_v4l2m2m") == 0)
+        ffmpeg->ctx_codec->pix_fmt   = AV_PIX_FMT_NV21;
+    else
+        ffmpeg->ctx_codec->pix_fmt   = MY_PIX_FMT_YUV420P;
     ffmpeg->ctx_codec->max_b_frames  = 0;
     if (strcmp(ffmpeg->codec_name, "ffv1") == 0){
       ffmpeg->ctx_codec->strict_std_compliance = -2;
@@ -768,6 +773,65 @@ static int ffmpeg_set_stream(struct ffmpeg *ffmpeg){
 
 }
 
+
+static int alloc_video_buffer(AVFrame *frame, int align)
+{
+    const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(frame->format);
+    int ret, i, padded_height;
+    int plane_padding = FFMAX(16 + 16/*STRIDE_ALIGN*/, align);
+
+    if (!desc)
+        return AVERROR(EINVAL);
+
+    if ((ret = av_image_check_size(frame->width, frame->height, 0, NULL)) < 0)
+        return ret;
+
+    if (!frame->linesize[0]) {
+        if (align <= 0)
+            align = 32; /* STRIDE_ALIGN. Should be av_cpu_max_align() */
+
+        for(i=1; i<=align; i+=i) {
+            ret = av_image_fill_linesizes(frame->linesize, frame->format,
+                                          FFALIGN(frame->width, i));
+            if (ret < 0)
+                return ret;
+            if (!(frame->linesize[0] & (align-1)))
+                break;
+        }
+
+        for (i = 0; i < 4 && frame->linesize[i]; i++)
+            frame->linesize[i] = FFALIGN(frame->linesize[i], align);
+    }
+
+    padded_height = FFALIGN(frame->height, 32);
+    if ((ret = av_image_fill_pointers(frame->data, frame->format, padded_height,
+                                      NULL, frame->linesize)) < 0)
+        return ret;
+
+    frame->buf[0] = av_buffer_alloc(ret + 4*plane_padding);
+    if (!frame->buf[0]) {
+        ret = AVERROR(ENOMEM);
+        goto fail;
+    }
+    frame->buf[1] = av_buffer_alloc(ret + 4*plane_padding);
+    if (!frame->buf[1]) {
+        ret = AVERROR(ENOMEM);
+        goto fail;
+    }
+
+    frame->data[0] = frame->buf[0]->data;
+    frame->data[1] = frame->buf[1]->data;
+    frame->data[2] = frame->data[1] + ((frame->width * padded_height) / 4);
+
+    frame->extended_data = frame->data;
+
+    return 0;
+fail:
+    av_frame_unref(frame);
+    return ret;
+}
+
+
 static int ffmpeg_set_picture(struct ffmpeg *ffmpeg){
 
     ffmpeg->picture = my_frame_alloc();
@@ -788,6 +852,15 @@ static int ffmpeg_set_picture(struct ffmpeg *ffmpeg){
     ffmpeg->picture->format = ffmpeg->ctx_codec->pix_fmt;
     ffmpeg->picture->width  = ffmpeg->ctx_codec->width;
     ffmpeg->picture->height = ffmpeg->ctx_codec->height;
+
+    // h264_v4l2m2m encoder expects video buffer to be allocated
+    if (strcmp(ffmpeg->codec->name, "h264_v4l2m2m") == 0) {
+        if (alloc_video_buffer(ffmpeg->picture, 32)) {
+            MOTION_LOG(ERR, TYPE_ENCODER, NO_ERRNO, _("could not alloc buffers"));
+            ffmpeg_free_context(ffmpeg);
+            return -1;
+        }
+    }
 
     return 0;
 
@@ -1365,9 +1438,38 @@ int ffmpeg_put_image(struct ffmpeg *ffmpeg, struct image_data *img_data, const s
         }
 
         /* Setup pointers and line widths. */
-        ffmpeg->picture->data[0] = image;
-        ffmpeg->picture->data[1] = image + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height);
-        ffmpeg->picture->data[2] = ffmpeg->picture->data[1] + ((ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height) / 4);
+        // Some encoders look for the image in ffmpeg->picture->buf
+        if (ffmpeg->picture->buf[0] == NULL)
+            ffmpeg->picture->data[0] = image;
+        else
+            memcpy(ffmpeg->picture->data[0], image, ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height);
+
+        if (ffmpeg->picture->buf[1] == NULL) {
+            // assume YUV420P format
+            ffmpeg->picture->data[1] = image + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height);
+            ffmpeg->picture->data[2] = ffmpeg->picture->data[1] + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height / 4);
+        } else {
+            int cr_len = ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height / 4;
+            int cb_len = cr_len;
+            unsigned char *imagecr = image + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height);
+            unsigned char *imagecb = image + (ffmpeg->ctx_codec->width * ffmpeg->ctx_codec->height) + cr_len;
+            if (ffmpeg->ctx_codec->pix_fmt == AV_PIX_FMT_NV21) {
+                int x;
+                int y;
+                for (y = 0; y < ffmpeg->ctx_codec->height; y++) {
+                    for (x = 0; x < ffmpeg->ctx_codec->width/4; x++) {
+                        ffmpeg->picture->data[1][y*ffmpeg->ctx_codec->width/2 + x*2] = *imagecb;
+                        ffmpeg->picture->data[1][y*ffmpeg->ctx_codec->width/2 + x*2 + 1] = *imagecr;
+                        imagecb++;
+                        imagecr++;
+                    }
+                }
+            } else {
+                // assume YUV420P format
+                memcpy(&ffmpeg->picture->data[1][0], imagecr, cr_len);
+                memcpy(&ffmpeg->picture->data[1][cr_len], imagecb, cb_len);
+            }
+        }
 
         ffmpeg->gop_cnt ++;
         if (ffmpeg->gop_cnt == ffmpeg->ctx_codec->gop_size ){

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -15,6 +15,14 @@ enum TIMELAPSE_TYPE {
     TIMELAPSE_NEW           /* Use create new file version of timelapse */
 };
 
+/* Enumeration of the user requested codecs that need special handling */
+enum USER_CODEC {
+    USER_CODEC_V4L2M2M,    /* Requested codec for movie is h264_v4l2m2m */
+    USER_CODEC_H264OMX,    /* Requested h264_omx */
+    USER_CODEC_MPEG4OMX,   /* Requested mpeg4_omx */
+    USER_CODEC_DEFAULT     /* All other default codecs */
+};
+
 #ifdef HAVE_FFMPEG
 
 #include <errno.h>
@@ -61,9 +69,9 @@ struct ffmpeg {
     int            high_resolution;
     int            motion_images;
     int            passthrough;
-    int nal_info_separated;
+    enum USER_CODEC     preferred_codec;
     char *nal_info;
-    int nal_info_len;
+    int  nal_info_len;
 };
 #else
 struct ffmpeg {

--- a/ffmpeg.h
+++ b/ffmpeg.h
@@ -61,6 +61,9 @@ struct ffmpeg {
     int            high_resolution;
     int            motion_images;
     int            passthrough;
+    int nal_info_separated;
+    char *nal_info;
+    int nal_info_len;
 };
 #else
 struct ffmpeg {


### PR DESCRIPTION
This PR adds support for h264_v4l2m2m hardware accelerated encoder. This encoder expects the input image to be in NV21 format stored in multi-planar buffers `ffmpeg->picture->buf[n]`.

I have only tested this on Odroid XU4 running Armbian kernel 4.14.127-odroidxu4, ffmpeg version 4.1.4, but I want to get this PR out early for code review and feedback from you guys.
