### PR TITLE
OMX: disable zerocopy via AVOption

### DIFF
--- a/ffmpeg.c
+++ b/ffmpeg.c
@@ -589,6 +589,7 @@ static int ffmpeg_codec_is_blacklisted(const char *codec_name){
 
     static const char *blacklisted_codec[] =
     {
+#if (!((LIBAVCODEC_VERSION_MAJOR >= 58) && (LIBAVCODEC_VERSION_MINOR >= 55)))
         /* h264_omx & ffmpeg combination locks up on Raspberry Pi.
          * To use h264_omx encoder and workaround the lock up issue:
          * - disable input_zerocopy in ffmpeg omx.c:omx_encode_init function.
@@ -596,6 +597,7 @@ static int ffmpeg_codec_is_blacklisted(const char *codec_name){
          * More information: https://github.com/Motion-Project/motion/issues/433
          */
         "h264_omx",
+#endif
     };
     size_t i;
 
@@ -709,6 +711,15 @@ static int ffmpeg_set_codec(struct ffmpeg *ffmpeg){
       ffmpeg->ctx_codec->level = 3;
     }
     ffmpeg->ctx_codec->flags |= MY_CODEC_FLAG_GLOBAL_HEADER;
+
+    if ((strcmp(ffmpeg->codec->name, "h264_omx") == 0) ||
+        (strcmp(ffmpeg->codec->name, "mpeg4_omx") == 0)) {
+        /* h264_omx & ffmpeg combination locks up on Raspberry Pi.
+         * To use h264_omx encoder, we need to disable zerocopy.
+         * More information: https://github.com/Motion-Project/motion/issues/433
+         */
+        av_dict_set(&ffmpeg->opts, "zerocopy", "0", 0);
+    }
 
     retcd = ffmpeg_set_quality(ffmpeg);
     if (retcd < 0){


### PR DESCRIPTION
ffmpeg no longer force enable zerocopy on RPi builds. See http://ffmpeg.org/pipermail/ffmpeg-devel/2019-August/248784.html and https://trac.ffmpeg.org/ticket/6586
We can now disable zerocopy via AVOption.