### PR TITLE
MMAL libs 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -217,7 +217,8 @@ AS_IF([test "${MMAL}" = "no"], [
     AC_MSG_CHECKING(for MMAL)
     AS_IF([pkg-config mmal], [
         TEMP_CFLAGS="$TEMP_CFLAGS -Irasppicam "`pkg-config --cflags mmal`
-        TEMP_LIBS="$TEMP_LIBS "`pkg-config --libs mmal`
+        #pkg config parm does not provide --no-as-needed variant that buildroot requires
+        TEMP_LIBS="$TEMP_LIBS -lmmal_core -lmmal_util -Wl,--push-state,--no-as-needed -lmmal_vc_client -Wl,--pop-state -lvcos -lvchostif -lvchiq_arm"
         AC_MSG_RESULT([yes])
         AC_DEFINE([HAVE_MMAL], [1], [Define to 1 if MMAL is around])
       ],[


### PR DESCRIPTION
Buildroot requires the use of the `--no-as-needed` for some libs.  This re-implements the previous configure.ac libs specification for mmal allowing for mmal on Buildroot.
