### PR TITLE
fix 'for' loop initial declaration in mmalcam.c

### DIFF
--- a/src/mmalcam.c
+++ b/src/mmalcam.c
@@ -225,7 +225,8 @@ static int send_pooled_buffers_to_port(MMAL_POOL_T *pool, MMAL_PORT_T *port)
 {
     int num = mmal_queue_length(pool->queue);
 
-    for (int i = 0; i < num; i++) {
+    int i;
+    for (i = 0; i < num; i++) {
         MMAL_BUFFER_HEADER_T *buffer = mmal_queue_get(pool->queue);
 
         if (!buffer) {


### PR DESCRIPTION
Compiling latest a22b787 without NLS in motioneyeos gives this error:
```
mmalcam.c: In function 'send_pooled_buffers_to_port':
mmalcam.c:228:5: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
     for (int i = 0; i < num; i++) {
     ^
mmalcam.c:228:5: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code
```
I did a quick search in the motion repo and this is the only instance, therefore makes send to change it here instead of adding one of the flags.