### PR TITLE
ffmpeg: do not encode NAL as the first video frame

### DIFF
--- a/src/ffmpeg.c
+++ b/src/ffmpeg.c
@@ -192,16 +192,17 @@ static void ffmpeg_free_nal(struct ffmpeg *ffmpeg){
     }
 }
 
-static void ffmpeg_encode_nal(struct ffmpeg *ffmpeg){
+static int ffmpeg_encode_nal(struct ffmpeg *ffmpeg){
     // h264_v4l2m2m has NAL units separated from the first frame, which makes
     // some players very unhappy.
     if ((ffmpeg->pkt.pts == 0) && (!(ffmpeg->pkt.flags & AV_PKT_FLAG_KEY))) {
         ffmpeg_free_nal(ffmpeg);
         ffmpeg->nal_info_len = ffmpeg->pkt.size;
         ffmpeg->nal_info = malloc(ffmpeg->nal_info_len);
-        if (ffmpeg->nal_info)
+        if (ffmpeg->nal_info) {
             memcpy(ffmpeg->nal_info, &ffmpeg->pkt.data[0], ffmpeg->nal_info_len);
-        else
+            return 1;
+        } else
             ffmpeg->nal_info_len = 0;
     } else if (ffmpeg->nal_info) {
         int old_size = ffmpeg->pkt.size;
@@ -210,6 +211,7 @@ static void ffmpeg_encode_nal(struct ffmpeg *ffmpeg){
         memcpy(&ffmpeg->pkt.data[0], ffmpeg->nal_info, ffmpeg->nal_info_len);
         ffmpeg_free_nal(ffmpeg);
     }
+    return 0;
 }
 
 static int ffmpeg_timelapse_exists(const char *fname){
@@ -463,7 +465,10 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
     }
 
     if (ffmpeg->preferred_codec == USER_CODEC_V4L2M2M){
-        ffmpeg_encode_nal(ffmpeg);
+        if (ffmpeg_encode_nal(ffmpeg)) {
+            // Throw special return code
+            return -2;
+        }
     }
 
     return 0;
@@ -489,7 +494,10 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
 
     /* This kills compiler warnings.  Nal setting is only for recent ffmpeg versions*/
     if (ffmpeg->preferred_codec == USER_CODEC_V4L2M2M){
-        ffmpeg_encode_nal(ffmpeg);
+        if (ffmpeg_encode_nal(ffmpeg)) {
+            // Throw special return code
+            return -2;
+        }
     }
 
     return 0;
@@ -529,7 +537,10 @@ static int ffmpeg_encode_video(struct ffmpeg *ffmpeg){
 
     /* This kills compiler warnings.  Nal setting is only for recent ffmpeg versions*/
     if (ffmpeg->preferred_codec == USER_CODEC_V4L2M2M){
-        ffmpeg_encode_nal(ffmpeg);
+        if (ffmpeg_encode_nal(ffmpeg)) {
+            // Throw special return code
+            return -2;
+        }
     }
 
     return 0;


### PR DESCRIPTION
The first packet that comes out of `h264_v4l2m2m` video encoder only contains NAL unit. There is no frame inside the packet. Motion currently detects this NAL packet and stores it away, but writes the NAL packet (to file) as the first frame anyway (PTS zero). When we get the first real encoded frame, motion writes the frame to file with PTS zero again, which causes playback problem in some players.
`ffprobe` sometimes gives a warning on such files, like so:
>st: 0 edit list: 1 Missing key frame while searching for timestamp: 0 
no frame

This PR stops motion from writing the NAL packet to file.