### PR TITLE
Fix format warnings

### DIFF
--- a/src/netcam_http.c
+++ b/src/netcam_http.c
@@ -25,20 +25,19 @@
 /* These strings are used for the HTTP connection. */
 static const char *connect_req;
 
-static const char *connect_req_http10 = "GET %s HTTP/1.0\r\n"
-                                        "Host: %s\r\n"
-                                        "User-Agent: Motion-netcam/" VERSION "\r\n";
+#define connect_req_http10 "GET %s HTTP/1.0\r\n" \
+                           "Host: %s\r\n" \
+                           "User-Agent: Motion-netcam/" VERSION "\r\n"
 
-static const char *connect_req_http11 = "GET %s HTTP/1.1\r\n"
-                                        "Host: %s\r\n"
-                                        "User-Agent: Motion-netcam/" VERSION "\r\n";
+#define connect_req_http11 "GET %s HTTP/1.1\r\n" \
+                           "Host: %s\r\n" \
+                           "User-Agent: Motion-netcam/" VERSION "\r\n"
 
-static const char *connect_req_close = "Connection: close\r\n";
+#define connect_req_close "Connection: close\r\n"
 
-static const char *connect_req_keepalive = "Connection: Keep-Alive\r\n";
+#define connect_req_keepalive "Connection: Keep-Alive\r\n"
 
-static const char *connect_auth_req = "Authorization: Basic %s\r\n";
-
+#define connect_auth_req "Authorization: Basic %s\r\n"
 
 tfile_context *file_new_context(void);
 void file_free_context(tfile_context* ctxt);

--- a/src/stream.c
+++ b/src/stream.c
@@ -106,20 +106,20 @@ static int read_http_request(int sock, char* buffer, int buflen, char* uri, int 
     char url[512] = {'\0'};
     char protocol[10] = {'\0'};
 
-    static const char *bad_request_response_raw =
-        "HTTP/1.0 400 Bad Request\r\n"
-        "Content-type: text/plain\r\n\r\n"
-        "Bad Request\n";
+#define bad_request_response_raw \
+        "HTTP/1.0 400 Bad Request\r\n" \
+        "Content-type: text/plain\r\n\r\n" \
+        "Bad Request\n"
 
-    static const char *bad_method_response_template_raw =
-        "HTTP/1.0 501 Method Not Implemented\r\n"
-        "Content-type: text/plain\r\n\r\n"
-        "Method Not Implemented\n";
+#define bad_method_response_template_raw \
+        "HTTP/1.0 501 Method Not Implemented\r\n" \
+        "Content-type: text/plain\r\n\r\n" \
+        "Method Not Implemented\n"
 
-    static const char *timeout_response_template_raw =
-        "HTTP/1.0 408 Request Timeout\r\n"
-        "Content-type: text/plain\r\n\r\n"
-        "Request Timeout\n";
+#define timeout_response_template_raw \
+        "HTTP/1.0 408 Request Timeout\r\n" \
+        "Content-type: text/plain\r\n\r\n" \
+        "Request Timeout\n"
 
     buffer[0] = '\0';
 
@@ -178,7 +178,7 @@ static int read_http_request(int sock, char* buffer, int buflen, char* uri, int 
          * uses other method, report the failure.
          */
         char response[1024];
-        snprintf(response, sizeof(response), bad_method_response_template_raw, method);
+        snprintf(response, sizeof(response), bad_method_response_template_raw);
         ret = write(sock, response, strlen (response));
 
         return 0;


### PR DESCRIPTION
Removed _(""). GCC considers that to not be a proper format string
and does not bother checking it.

Replaced several static const chars with defines. GCC cannot check
const char * as it is a variable, not a constant expression. C
unfortunately does not support constexpr.

Discovered with -Wformat=2.