### PR TITLE
Updates despeckle filter link

### DIFF
--- a/doc/motion_config.html
+++ b/doc/motion_config.html
@@ -3621,7 +3621,7 @@
         most of the single pixel noise.
         <p></p>
         A very detailed technical explanation of the despeckle part can be found at the webpage of the author of this
-        feature <a href="http://emit.demon.co.uk/motion/" rel="nofollow" target="_top">Ian McConnell's Webcam: Motion
+        feature <a href="http://aisliverpool.org.uk/motion/" rel="nofollow" target="_top">Ian McConnell's Webcam: Motion
         Web Page</a>
         <p></p>
 


### PR DESCRIPTION
The current link for detailed explanations of the despeckle filter is down. This PR simply changes this URL.

It is important to note that the new URL seems to belong to the same owner as the previous one (it is important to credit the same author). 
Indeed, http://aisliverpool.org.uk redirects to http://www.shipais.com which was also the case for http://emit.demon.co.uk in 2013 (as shown here http://web.archive.org/web/20131013124924/http://emit.demon.co.uk/).