### PR TITLE
Removed semicolon in the Content-type value

### DIFF
--- a/src/webu_stream.c
+++ b/src/webu_stream.c
@@ -325,7 +325,7 @@ int webu_stream_static(struct webui_ctx *webui) {
             , webui->cnt->conf.stream_cors_header);
     }
 
-    MHD_add_response_header (response, MHD_HTTP_HEADER_CONTENT_TYPE, "image/jpeg;");
+    MHD_add_response_header (response, MHD_HTTP_HEADER_CONTENT_TYPE, "image/jpeg");
     snprintf(resp_used, 20, "%9ld\r\n\r\n",(long)webui->resp_used);
     MHD_add_response_header (response, MHD_HTTP_HEADER_CONTENT_LENGTH, resp_used);
 


### PR DESCRIPTION
Semicolon is used to separate extra parameters of the type. Since we do not provide any parameters, the semicolon is not needed and confusing for some parsers

Resolves: https://github.com/Motion-Project/motion/issues/1171