### PR TITLE
Fixed longest line calculation that caused unneeded scaling of multiline text

### DIFF
--- a/src/draw.c
+++ b/src/draw.c
@@ -1137,6 +1137,7 @@ int draw_text(unsigned char *image, int width, int height, int startx, int start
         if ((end - begin)>txtlen) txtlen = (end - begin);
         num_nl++;
         end += sizeof(NEWLINE)-1;
+        begin = end;
     }
     if (txtlen == 0) txtlen = strlen(text);
 


### PR DESCRIPTION
Line length was calculated from start of text instead of start of current line