### PR TITLE
Add netcam_params

### DIFF
--- a/doc/motion_config.html
+++ b/doc/motion_config.html
@@ -424,11 +424,11 @@
       <p></p>
       <p></p>
         camera0.conf:
-        <br /><code> videodevice /dev/video0</code>
+        <br /><code> video_device /dev/video0</code>
       <p></p>
       <p></p>
         camera1.conf:
-        <br /><code> videodevice /dev/video1</code>
+        <br /><code> video_device /dev/video1</code>
       <p></p>
       <p></p>
       <p></p>
@@ -549,9 +549,9 @@
       <p></p>
       <style>
         @media screen and (max-width: 48em) {
-          .tblalpha td:nth-of-type(1):before {content: "v3.2"; padding-right: 10px;}
-          .tblalpha td:nth-of-type(2):before {content: "v4.0"; padding-right: 10px;}
-          .tblalpha td:nth-of-type(3):before {content: "v4.1"; padding-right: 10px;}
+          .tblalpha td:nth-of-type(1):before {content: "v4.0"; padding-right: 10px;}
+          .tblalpha td:nth-of-type(2):before {content: "v4.1"; padding-right: 10px;}
+          .tblalpha td:nth-of-type(3):before {content: "v4.3"; padding-right: 10px;}
           .tblalpha td:nth-of-type(4):before {content: "Cur."; padding-right: 10px;}
         }
       </style>
@@ -682,22 +682,10 @@
           <td align="left"><a href="#framerate" >framerate</a></td>
         </tr>
         <tr>
-          <td align="left">frequency</td>
-          <td align="left">frequency</td>
-          <td align="left">frequency</td>
-          <td align="left"><a href="#frequency" >frequency</a></td>
-        </tr>
-        <tr>
           <td align="left">height</td>
           <td align="left">height</td>
           <td align="left">height</td>
           <td align="left"><a href="#height" >height</a></td>
-        </tr>
-        <tr>
-          <td align="left">input</td>
-          <td align="left">input</td>
-          <td align="left">input</td>
-          <td align="left"><a href="#input" >input</a></td>
         </tr>
         <tr>
           <td align="left"></td>
@@ -766,16 +754,16 @@
           <td align="left"><a href="#minimum_motion_frames" >minimum_motion_frames</a></td>
         </tr>
         <tr>
-          <td align="left">mmalcam_control_params</td>
-          <td align="left">mmalcam_control_params</td>
-          <td align="left">mmalcam_control_params</td>
-          <td align="left"><a href="#mmalcam_control_params" >mmalcam_control_params</a></td>
-        </tr>
-        <tr>
           <td align="left">mmalcam_name</td>
           <td align="left">mmalcam_name</td>
           <td align="left">mmalcam_name</td>
           <td align="left"><a href="#mmalcam_name" >mmalcam_name</a></td>
+        </tr>
+        <tr>
+          <td align="left">mmalcam_control_params</td>
+          <td align="left">mmalcam_control_params</td>
+          <td align="left">mmalcam_control_params</td>
+          <td align="left"><a href="#mmalcam_params" >mmalcam_params</a></td>
         </tr>
         <tr>
           <td align="left">ffmpeg_bps</td>
@@ -853,55 +841,43 @@
           <td align="left"></td>
           <td align="left"></td>
           <td align="left"></td>
-          <td align="left"><a href="#netcam_decoder" >netcam_decoder</a></td>
+          <td align="left"><a href="#netcam_high_params" >netcam_high_params</a></td>
         </tr>
         <tr>
           <td align="left"></td>
           <td align="left">netcam_highres</td>
           <td align="left">netcam_highres</td>
-          <td align="left"><a href="#netcam_highres" >netcam_highres</a></td>
+          <td align="left"><a href="#netcam_high_url" >netcam_high_url</a></td>
         </tr>
         <tr>
           <td align="left">netcam_keepalive</td>
           <td align="left">netcam_keepalive</td>
           <td align="left">netcam_keepalive</td>
-          <td align="left"><a href="#netcam_keepalive" >netcam_keepalive</a></td>
+          <td align="left"><a href="#netcam_params" >netcam_params</a></td>
         </tr>
         <tr>
           <td align="left">netcam_proxy</td>
           <td align="left">netcam_proxy</td>
           <td align="left">netcam_proxy</td>
-          <td align="left"><a href="#netcam_proxy" >netcam_proxy</a></td>
-        </tr>
-        <tr>
-          <td align="left"></td>
-          <td align="left"></td>
-          <td align="left"></td>
-          <td align="left"><a href="#netcam_rate" >netcam_rate</a></td>
-        </tr>
-        <tr>
-          <td align="left"></td>
-          <td align="left"></td>
-          <td align="left"></td>
-          <td align="left"><a href="#netcam_ratehigh" >netcam_ratehigh</a></td>
+          <td align="left"><a href="#netcam_params" >netcam_params</a></td>
         </tr>
         <tr>
           <td align="left">netcam_tolerant_check</td>
           <td align="left">netcam_tolerant_check</td>
           <td align="left">netcam_tolerant_check</td>
-          <td align="left"><a href="#netcam_tolerant_check" >netcam_tolerant_check</a></td>
+          <td align="left"><a href="#netcam_params" >netcam_params</a></td>
+        </tr>
+        <tr>
+          <td align="left">rtsp_uses_tcp<br /></td>
+          <td align="left">rtsp_uses_tcp</td>
+          <td align="left">netcam_use_tcp</td>
+          <td align="left"><a href="#netcam_params" >netcam_params</a></td>
         </tr>
         <tr>
           <td align="left">netcam_url</td>
           <td align="left">netcam_url</td>
           <td align="left">netcam_url</td>
           <td align="left"><a href="#netcam_url" >netcam_url</a></td>
-        </tr>
-        <tr>
-          <td align="left">rtsp_uses_tcp<br /></td>
-          <td align="left">rtsp_uses_tcp</td>
-          <td align="left">netcam_use_tcp</td>
-          <td align="left"><a href="#netcam_use_tcp" >netcam_use_tcp</a></td>
         </tr>
         <tr>
           <td align="left">netcam_userpass</td>
@@ -920,12 +896,6 @@
           <td align="left">noise_tune</td>
           <td align="left">noise_tune</td>
           <td align="left"><a href="#noise_tune" >noise_tune</a></td>
-        </tr>
-        <tr>
-          <td align="left">norm</td>
-          <td align="left">norm</td>
-          <td align="left">norm</td>
-          <td align="left"><a href="#norm" >norm</a></td>
         </tr>
         <tr>
           <td align="left">on_area_detected</td>
@@ -1381,43 +1351,73 @@
           <td align="left">tunerdevice</td>
           <td align="left">tunerdevice</td>
           <td align="left">tunerdevice</td>
-          <td align="left"><a href="#tunerdevice" >tunerdevice</a></td>
+          <td align="left"><a href="#tuner_device" >tuner_device</a></td>
+        </tr>
+        <tr>
+          <td align="left">frequency</td>
+          <td align="left">frequency</td>
+          <td align="left">frequency</td>
+          <td align="left"><a href="#video_params" >video_params</a></td>
+        </tr>
+        <tr>
+          <td align="left">input</td>
+          <td align="left">input</td>
+          <td align="left">input</td>
+          <td align="left"><a href="#video_params" >video_params</a></td>
+        </tr>
+	      <tr>
+          <td align="left">norm</td>
+          <td align="left">norm</td>
+          <td align="left">norm</td>
+          <td align="left"><a href="#video_params" >video_params</a></td>
         </tr>
         <tr>
           <td align="left">v4l2_palette</td>
           <td align="left">v4l2_palette</td>
           <td align="left">v4l2_palette</td>
-          <td align="left"><a href="#v4l2_palette" >v4l2_palette</a></td>
+          <td align="left"><a href="#video_params" >video_params</a></td>
         </tr>
         <tr>
           <td align="left">brightness</td>
           <td align="left">brightness</td>
           <td align="left">vid_control_params</td>
-          <td align="left"><a href="#vid_control_params" >vid_control_params</a></td>
+          <td align="left"><a href="#video_params" >video_params</a></td>
         </tr>
         <tr>
           <td align="left">contrast</td>
           <td align="left">contrast</td>
           <td align="left">vid_control_params</td>
-          <td align="left"><a href="#vid_control_params" >vid_control_params</a></td>
+          <td align="left"><a href="#video_params" >video_params</a></td>
         </tr>
         <tr>
           <td align="left">hue</td>
           <td align="left">hue</td>
           <td align="left">vid_control_params</td>
-          <td align="left"><a href="#vid_control_params" >vid_control_params</a></td>
+          <td align="left"><a href="#video_params" >video_params</a></td>
         </tr>
         <tr>
           <td align="left">power_line_frequency</td>
           <td align="left">power_line_frequency</td>
           <td align="left">vid_control_params</td>
-          <td align="left"><a href="#vid_control_params" >vid_control_params</a></td>
+          <td align="left"><a href="#video_params" >video_params</a></td>
         </tr>
         <tr>
           <td align="left">saturation</td>
           <td align="left">saturation</td>
           <td align="left">vid_control_params</td>
-          <td align="left"><a href="#vid_control_params" >vid_control_params</a></td>
+          <td align="left"><a href="#video_params" >video_params</a></td>
+        </tr>
+        <tr>
+          <td align="left"></td>
+          <td align="left"></td>
+          <td align="left">vid_control_params</td>
+          <td align="left"><a href="#video_params" >video_params</a></td>
+        </tr>
+        <tr>
+          <td align="left">videodevice</td>
+          <td align="left">videodevice</td>
+          <td align="left">videodevice</td>
+          <td align="left"><a href="#video_device" >video_device</a></td>
         </tr>
         <tr>
           <td align="left">video_pipe</td>
@@ -1430,12 +1430,6 @@
           <td align="left">motion_video_pipe</td>
           <td align="left">video_pipe_motion</td>
           <td align="left"><a href="#video_pipe_motion" >video_pipe_motion</a></td>
-        </tr>
-        <tr>
-          <td align="left">videodevice</td>
-          <td align="left">videodevice</td>
-          <td align="left">videodevice</td>
-          <td align="left"><a href="#videodevice" >videodevice</a></td>
         </tr>
         <tr>
           <td align="left"></td>
@@ -1593,16 +1587,10 @@
           </colgroup>
           <tbody>
             <tr>
-              <td bgcolor="#edf4f9" ><a href="#videodevice" >videodevice</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#vid_control_params" >vid_control_params</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#v4l2_palette" >v4l2_palette</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#input" >input</a> </td>
-            </tr>
-            <tr>
-              <td bgcolor="#edf4f9" ><a href="#norm" >norm</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#frequency" >frequency</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#video_device" >video_device</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#video_params" >video_params</a> </td>
               <td bgcolor="#edf4f9" ><a href="#auto_brightness" >auto_brightness</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#tunerdevice" >tunerdevice</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#tuner_device" >tuner_device</a> </td>
             </tr>
             <tr>
               <td bgcolor="#edf4f9" ><a href="#roundrobin_frames" >roundrobin_frames</a> </td>
@@ -1629,19 +1617,12 @@
           <tbody>
             <tr>
               <td bgcolor="#edf4f9" ><a href="#netcam_url" >netcam_url</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#netcam_highres" >netcam_highres</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#netcam_params" >netcam_params</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#netcam_high_url" >netcam_high_url</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#netcam_high_params" >netcam_high_params</a> </td>
+            </tr>
+            <tr>
               <td bgcolor="#edf4f9" ><a href="#netcam_userpass" >netcam_userpass</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#netcam_decoder" >netcam_decoder</a> </td>
-            </tr>
-            <tr>
-              <td bgcolor="#edf4f9" ><a href="#netcam_keepalive" >netcam_keepalive</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#netcam_proxy" >netcam_proxy</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#netcam_rate" >netcam_rate</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#netcam_ratehigh" >netcam_ratehigh</a> </td>
-            </tr>
-            <tr>
-              <td bgcolor="#edf4f9" ><a href="#netcam_tolerant_check" >netcam_tolerant_check</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#netcam_use_tcp" >netcam_use_tcp</a> </td>
             </tr>
           </tbody>
         </table>
@@ -1663,7 +1644,7 @@
           <tbody>
             <tr>
               <td bgcolor="#edf4f9" ><a href="#mmalcam_name" >mmalcam_name</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#mmalcam_control_params" >mmalcam_control_params</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#mmalcam_params" >mmalcam_params</a> </td>
             </tr>
           </tbody>
         </table>
@@ -2399,7 +2380,7 @@
         <p></p>
         Please refer to the <a href="#Basic_Setup">Basic Setup</a> section of this guide for an additional discussion
         of Video4Linux devices and how to test and specify them correctly for Motion.
-        <h3><a name="videodevice"></a> videodevice </h3>
+        <h3><a name="video_device"></a> video_device </h3>
         <p></p>
         <ul>
           <li> Type: String</li>
@@ -2411,12 +2392,12 @@
         See the <a href="#Basic_Setup">Basic Setup</a>
         section of this guide for an additional discussion of this option.
         <p></p>
-        This option is the preferred way to specify the video4linux device name. If the camera does
-        not work when specifying the device with this option, it is also possible to specify the device
+        This option is the usual method to specify the video4linux device name. If the camera does
+        not work when specifying it with this option, it is also possible to specify the device
         in the <a href="#netcam_url" >netcam_url</a>  with the v4l2 prefix option.  The
         <a href="#netcam_url" >netcam_url</a> option uses an alternative method to open and operate the
-        device but has fewer options available. If the <a href="#netcam_url" >netcam_url</a> is used for
-        either this alternative method or for a normal network camera, the videodevice option is ignored.
+        device which may work with this option fails.  If the <a href="#netcam_url" >netcam_url</a> is used for
+        either this alternative method or for a normal network camera, the video_device option is ignored.
         <p></p>
         Since the exact device number is set by the kernel upon boot, when there is more than one video device
         it is possible that the particular cameras that were assigned to /dev/video0 and /dev/video1 may switch. In
@@ -2440,7 +2421,7 @@
         <p></p>
 
 
-        <h3><a name="vid_control_params"></a>vid_control_params</h3>
+        <h3><a name="video_params"></a>video_params</h3>
         <p></p>
         <ul>
          <li> Type: String</li>
@@ -2448,30 +2429,35 @@
           <li> Default:  Not defined</li>
          </ul>
         <p></p>
-        For v4l2 and bktr devices, most of the configuration options are automatic.  However most devices also allow
-        the user to change certain settings to suit their needs.  The options which the camera manufacturer permits
-        the user to change are called "controls".
+        For most devices the configuration options are automatically assigned but devices also usually allow
+        the user to change certain settings to suit their needs.  The options that the camera manufacturer permits
+        the user to change are called "controls".  The <a href="#video_params" >video_params</a> option allows users
+        to specify values for these controls when Motion runs.
         <p></p>
-        The <a href="#vid_control_params" >vid_control_params</a> option allows users of Motion to change any of these
-        controls.  The specific controls that can be changed is however entirely dependent upon the device.
+        The <a href="#video_params" >video_params</a> option also allows users to specify some Motion specific
+        parameters that are used to open the camera.  In previous versions of Motion, these options were the
+        frequency, input, norm and v4l2_palette options.  These options have now been embedded into the
+        <a href="#video_params" >video_params</a> option to provide consistency.
         <p></p>
-        This option replaces the previous configuration options for:
+        The following is the list of previous Motion options that have now been replaced by the
+        <a href="#video_params" >video_params</a> option.
         <ul>
           <li> brightness</li>
           <li> contrast</li>
           <li> hue</li>
           <li> power_line_frequency</li>
           <li> saturation</li>
+          <li> frequency</li>
+          <li> input</li>
+          <li> norm</li>
+          <li> v4l2_palette</li>
         </ul>
-        <p></p>
-        This option permits the V4l2 users of Motion to change the value of any control that is available
-        to the device rather than being limited to only the 5 listed above.  For FreeBSD users with BKTR devices,
-        the options are limited to brightness, contrast, hue and saturation due to the limitations of the driver.
         <p></p>
         While it always recommended that users remove older configuration options and only use the new options,
         if users have within the configuration file any of the depreciated options list above, Motion will
-        continue to read those values and upgrade them into the new vid_control_params option.  The resulting
-        pictures from the device may however may not be comparable due to different interpretations of the values.
+        continue to read those values and upgrade them into the new <a href="#video_params" >video_params</a>
+        option.  The resulting pictures from the device may however may not be comparable due to different
+        interpretations of the values.
         <p></p>
         It is therefore highly recommended that users remove the old configuration values and calibrate their devices
         only using this new configuration option.
@@ -2481,12 +2467,11 @@
         of multiple controls can be specified by separating them with a comma.
         <p></p>
         Since the name of some controls can include a comma or spaces, names can also be specified by enclosing them
-        in double quotes.
+        in double quotes.  To help users know which controls are available for their device, the Motion log will
+        report the available controls, associated IDs and minimum/maximum values permitted when the
+        <a href="#log_level" >log_level</a> is specified as INF or higher.
         <p></p>
-        Finally, to help users know which controls are available for their device, the Motion log will report all the
-        available controls, associated IDs and minimum/maximum values permitted at the
-        <a href="#log_level" >log_level</a> of INF.
-        <p></p>
+
         e.g.  Change the <a href="#log_level" >log_level</a>
         to INF, start up Motion with the device attached and specified, let it report items to the log and then
         shut Motion down.  Within the Motion log, it will list which controls the device has that can be adjusted.
@@ -2531,19 +2516,19 @@
         <p></p>
         Example 1:  Set the gain to manual, then the gain to 50 and the brightness to 30
         <p></p>
-        <code>vid_control_params "Gain, Automatic"=1,ID09963795=50, brightness=30</code>
+        <code>video_params "Gain, Automatic"=1,ID09963795=50, brightness=30</code>
         <p></p>
         a equally valid alternative method for specifying this example would be
         <p></p>
-        <code>vid_control_params ID09963794=1,ID09963795=50, ID09963776=30</code>
+        <code>video_params ID09963794=1,ID09963795=50, ID09963776=30</code>
         <p></p>
         or another way of specifying it could be
         <p></p>
-        <code>vid_control_params ID09963794=1,"Gain"=50, "brightness"=30</code>
+        <code>video_params ID09963794=1,"Gain"=50, "brightness"=30</code>
         <p></p>
         Example 2:  Set the saturation to 50 and the contrast to 100
         <p></p>
-        <code>vid_control_params saturation=50,contrast=100</code>
+        <code>video_params saturation=50,contrast=100</code>
         <p></p>
         As can be seen in these examples, the specification can use either the control ID or the name of the
         control.  If the control name has embedded blanks or commas, then it must be enclosed in quotes.  Special
@@ -2552,21 +2537,20 @@
         delimits the end of the name for the Motion log.
         <p></p>
 
-
-        <h3><a name="v4l2_palette"></a> v4l2_palette </h3>
-        <p></p>
+        <h4> palette </h4>
         <ul>
           <li> Type: Integer</li>
-          <li> Range / Valid values: 0 - 21</li>
+          <li> Range / Valid values: 0 - 20</li>
           <li> Default: 17</li>
         </ul>
         <p></p>
-        The v4l2_palette allows the user to choose a palette to be use by Motion.  This
-        is only the <u>preferred</u> option.  If the video device does not support this preferred format,
-        Motion will loop through the available palettes to try to find one that is supported by both Motion
-        and the device.
-        Motion will report the supported palettes of the device when Motion starts when the log_level
-        is specified as NTC or higher.
+        The palette option is specified in the <a href="#video_params" >video_params</a> option and
+        allows the user to specify the preferred palette for Motion to use.  If the video device does not
+        support this preferred format, Motion will loop through the available palettes to try to find one
+        that is supported by both Motion and the device.
+        <p></p>
+        Motion will report the supported palettes of the device when Motion starts when the
+        <a href="#log_level" >log_level</a> is specified as NTC or higher.
         <p></p>
         The default of 17 is highly preferred over <u>all</u> other formats since this the native
         format that Motion uses internally.
@@ -2692,70 +2676,55 @@
               <td bgcolor="#edf4f9" align="center" >GREY</li>
               <td bgcolor="#edf4f9" align="center" >20</td>
             </tr>
-            <tr>
-              <td bgcolor="#edf4f9" align="left" > V4L2_PIX_FMT_H264</td>
-              <td bgcolor="#edf4f9" align="center" >H264</li>
-              <td bgcolor="#edf4f9" align="center" >21</td>
-            </tr>
           </tbody>
         </table>
         </div>
         <p></p>
         It is possible that after looping through all of the palette options for the camera, Motion will not
-        find a palette that is acceptable for processing.  In this situation, it is possible to use the
-        <a href="#netcam_url" >netcam_url</a> option with the v4l2 prefix.  When using the
-        <a href="#netcam_url" >netcam_url</a> option, the v4l2_palette option can be used to specify the
-        V4L2_PIX_FMT_MJPEG and V4L2_PIX_FMT_H264 options ONLY.  If any of the other palette options
-        are specified when using the <a href="#netcam_url" >netcam_url</a> the v4l2_palette option
-        is ignored and the camera default is used.
-
-        <p></p>
-        The V4L2_PIX_FMT_H264(21) option is valid ONLY when using the <a href="#netcam_url" >netcam_url</a> option.
-        When V4L2_PIX_FMT_H264(21) is specified using the videodevice, Motion will change the v4l2_palette option to the
-        default of V4L2_PIX_FMT_YUV420 (17)
+        find a palette that is acceptable for processing.  In this situation, it may be possible to be the
+        camera to work using the <a href="#netcam_url" >netcam_url</a> option with the v4l2 prefix.
         <p></p>
 
-        <h3><a name="input"></a> input </h3>
-        <p></p>
+        <h4> input </h4>
         <ul>
           <li> Type: Integer</li>
-          <li> Range / Valid values: -1, 0 - 7</li>
+          <li> Range / Valid values: -1, 0 - ? </li>
           <li> Default: -1 </li>
         </ul>
         <p></p>
-        Input channel to use expressed as an integer number starting from 0.
-        This option should normally be set to 1 for video/TV cards, and -1 for USB cameras.
-        This parameter is used only with video capture cards that have more than one input.
-        If you set the input number to values other than -1 USB cameras Motion will report
-        an error message back. For video capture cards with tuners or multiple inputs such as
-        S-VHS or Composite you may need to use this option to specify the correct input for
-        the camera. Using a external application such as VLC which allows for easier specification
-        of the input associated with the camera can assist  in determining the correct value for Motion.
+        The input option is specified in the <a href="#video_params" >video_params</a> option and
+        allows the user to specify the input channel to use for the device.
+        <p></p>
+        For USB cameras, the input option should specify -1.
+        <p></p>
+        For other devices such as capture cards, the input option is device dependent but usually starts
+        with zero.  Using an external application such as VLC can allow for easier specification
+        of the input associated with the camera.
         <p></p>
 
-        <h3><a name="norm"></a> norm </h3>
-        <p></p>
+        <h4> norm </h4>
         <ul>
           <li> Type: Integer</li>
           <li> Range / Valid values: 0 (PAL), 1 (NTSC), 2 (SECAM), 3 (PAL NC no colour)</li>
           <li> Default: 0 (PAL) </li>
         </ul>
         <p></p>
-        Select the video norm of the device. Values: 0 (PAL), 1 (NTSC), 2 (SECAM), 3 (PAL NC no colour). Default: 0 (PAL)
-        This value is only used for capture cards using the BTTV driver.
+        The norm option is specified in the <a href="#video_params" >video_params</a> option and
+        allows the user to specify the television norm to use for the device.
         <p></p>
 
-        <h3><a name="frequency"></a> frequency </h3>
-        <p></p>
+        <h4>frequency </h4>
         <ul>
           <li> Type: Integer</li>
           <li> Range / Valid values: 0 - 999999</li>
           <li> Default: 0 (Not set)</li>
         </ul>
         <p></p>
-        The frequency to set the tuner to (kHz) per the tuner specifications.  The default is 0 meaning
-        not set.  This option is only relevant if you have a TV tuner card where you can select the tuner frequency.
-        Your tuner card must support this feature.
+        The frequency option is specified in the <a href="#video_params" >video_params</a> option and
+        allows the user to specify the frequency to use for the device.
+        <p></p>
+        The default is 0 meaning it is not set.  This option is only relevant if the device is a TV tuner
+        card where the frequency can be set.
         <p></p>
 
         <h3><a name="auto_brightness"></a> auto_brightness </h3>
@@ -2776,7 +2745,7 @@
         being adjusted.  (See methods available below)
         <p></p>
         Users can specify a different target value by specifying a value for the control in
-        the <a href="#vid_control_params">vid_control_params</a> option.
+        the <a href="#video_params">video_params</a> option.
         <p></p>
         Motion allows for three possible methods for adjusting the brightness.
         <ul>
@@ -2786,7 +2755,7 @@
         </ul>
         <p></p>
 
-        <h3><a name="tunerdevice"></a> tunerdevice </h3>
+        <h3><a name="tuner_device"></a> tuner_device </h3>
         <p></p>
         <ul>
           <li> Type: String</li>
@@ -2864,7 +2833,7 @@
         Turns the switch filter on or off. The filter can distinguish between most switching noise and real motion. With this
         you can even set roundrobin_skip to 1 without generating much false detection.
         This is a round robin related feature used when you have a capture card with multiple inputs (controlled by the
-        'input' option) on the same videodevice.
+        'input' option) on the same video_device.
         <p></p>
         <p></p>
       </ul>
@@ -2980,13 +2949,6 @@
             A sample format for the netcam_url would be <code>v4l2:///dev/video0</code>  Internally, this
             is equivalent to running the following from the command line <code>ffplay -f v4l2 /dev/video0</code>
             <p></p>
-            Since this is not the preferred method of specifying a v4l2 device, many of the usual v4l2 controls such as
-            <a href="#vid_control_params">vid_control_params</a> are ignored.
-            The options <a href="#width">width</a>, <a href="#height">height</a> as well as two of
-            the <a href="#v4l2_palette">v4l2_palette</a> can be used.  The two options
-            for <a href="#v4l2_palette">v4l2_palette</a> which can be used are option 8 (V4L2_PIX_FMT_MJPEG) and
-            option 21 (V4L2_PIX_FMT_H264).  If any other option is selected for the <a href="#v4l2_palette">v4l2_palette</a>
-            Motion will revert to the camera default.
         </ul>
         <p></p>
 
@@ -3005,7 +2967,180 @@
 
         </ul>
 
-        <h3><a name="netcam_highres"></a> netcam_highres </h3>
+        <h3><a name="netcam_params"></a> netcam_params </h3>
+        <p></p>
+        <ul>
+          <li> Type: String</li>
+          <li> Range / Valid values: Max 4095 characters</li>
+          <li> Default: varies by camera type</li>
+        </ul>
+        <p></p>
+        This option allows for specification of parameters to the network camera.  The format for specifying
+        parameters and values is the same as what is given in the examples for video_params.  The parameters are
+        delimited by commas and provided in the format of parameter_name = parameter_value.
+        <p></p>
+        For cameras that use the url prefix of http, ftp, mjpg, and jpeg the options permitted are limited
+        to keepalive, proxy and tolerant_check.  These parameters correspond to the options provided in previous
+        versions of Motion.
+        <p></p>
+        For cameras that use other url prefixes, the parameters permitted are those available from the
+        ffmpeg library plus a some that are specific to Motion as specified below.
+        The options of keepalive, proxy, tolerant_check are not applicable to these cameras.
+        <p></p>
+        The following summarizes some of the options.  Full descriptions of all the ffmpeg options
+        will be contained in the documentation for ffmpeg.
+        <p></p>
+
+        <h4>keepalive </h4>
+        <ul>
+          <li> Type: String</li>
+          <li> Range / Valid values: Max 4095 characters</li>
+          <li> Default: off</li>
+        </ul>
+        <p></p>
+        The keepalive option is specified in the <a href="#netcam_params" >netcam_params</a> option.
+        <p></p>
+        The setting for keep-alive of network socket, should improve performance on compatible net cameras.
+        <ul>
+        <li> off:   The historical implementation using HTTP/1.0, closing the socket after each http request.</li>
+        <li> force: Use HTTP/1.0 requests with keep alive header to reuse the same connection.</li>
+        <li> on:    Use HTTP/1.1 requests that support keep alive as default.</li>
+        </ul>
+        <p></p>
+
+        <h4>proxy </h4>
+        <ul>
+          <li> Type: String</li>
+          <li> Range / Valid values: Max 4095 characters</li>
+          <li> Default: Not defined</li>
+        </ul>
+        <p></p>
+        The proxy option is specified in the <a href="#netcam_params" >netcam_params</a> option.
+        <p></p>
+        URL to use for a netcam proxy server, if required. The syntax is
+        <a href="http://myproxy:portnumber" rel="nofollow" target="_top">http://myproxy:portnumber</a>
+        Use this if you need to connect to a network camera through a proxy server.
+        Example of syntax: "http://myproxy.mydomain.com:1024
+        If the proxy port number is 80 you can omit the port number. Then the syntax is use "http://myproxy.mydomain.com" .
+        Leave this option undefined if you do not use a proxy server.
+        <p></p>
+
+        <h4>tolerant_check </h4>
+        <ul>
+          <li> Type: Boolean</li>
+          <li> Range / Valid values: on, off</li>
+          <li> Default: off</li>
+        </ul>
+        <p></p>
+        The tolerant_check option is specified in the <a href="#netcam_params" >netcam_params</a> option.
+        <p></p>
+        Use less strict jpeg checks for network cameras
+        <p></p>
+
+        <h4>decoder</h4>
+        <ul>
+          <li> Type: String</li>
+          <li> Range / Valid values: Max 4095 characters</li>
+          <li> Default: Not defined</li>
+        </ul>
+        <p></p>
+        The decoder option is specified in the <a href="#netcam_params" >netcam_params</a> option.
+        <p></p>
+        This option is specific to the Motion software and allows for specifying a user requested decoder for the camera.
+        Motion will try to open the camera using the decoder specified by this parameter. If it not successful, it
+        will fall back to the default decoder.  This option may improve performance in certain situations for
+        certain platforms and cameras.
+        <p></p>
+        Users can find the names of the decoders on their system by going to a command prompt and
+        typing <code>ffmpeg -decoders</code> and looking for the name of the decoder with a 'D' next
+        to it and correlating this with the type of image provided from the camera.  The list of decoders
+        will correspond with how the distro built ffmpeg.  Additional decoders could also be available
+        if ffmpeg is compiled from source.
+        <p></p>
+        Additional different decoder options may also be found by reviewing the Motion log.  These
+        decoders will be shown as "available" in log when <a href="#log_level">log_level</a> is
+        specified at the INF level or higher.
+        <p></p>
+        Note that not all decoders will work with all cameras even if they are indicated as
+        available.  If the camera does not open using the requested decoder, specify a different
+        decoder or leave this parameter empty to use the default.
+        <p></p>
+
+        <h4>capture_rate </h4>
+        <ul>
+          <li> Type: int</li>
+          <li> Range / Valid values: Integer</li>
+          <li> Default: <a href="#framerate">framerate</a></li>
+        </ul>
+        <p></p>
+        The capture_rate option is specified in the <a href="#netcam_params" >netcam_params</a> option.
+        <p></p>
+        This option allows for the user to request a specific frame per second (FPS) capture rate for
+        the network camera.  This is needed at times so that the rate Motion is capturing images is in
+        sync with what the camera is sending.
+        <p></p>
+        When this value is used, it makes a slight distinction from
+        the usual interpretation of <a href="#framerate">framerate</a>.  The capture_rate will specify
+        how fast images are <u>captured and decoded</u> and the <a href="#framerate">framerate</a>
+        will specify the rate at which they are <u>processed for motion</u>.
+        <p></p>
+        For example, if the capture_rate were set to be 10 and the
+        <a href="#framerate">framerate</a> was set to be 20, what would happen is that each captured image
+        would end up going through the Motion detection / processing routines twice because that loop is
+        processing at twice the speed of the capture loop.  Conversely, if the capture_rate was set
+        to 20 and the <a href="#framerate">framerate</a> is specified as 10, then Motion will be detecting
+        and processing every other image captured.
+        <p></p>
+        The reason that the capture_rate is not systematically set to the <a href="#framerate">framerate</a>
+        within Motion has to with the camera.  Each camera will provide a stream of images usually in some
+        compression format such as H264 or H265 and provide those images at a particular FPS.  If the
+        capture and decoding FPS of Motion is set to a rate lower than the camera, decoding and disconnection
+        errors will occur.
+        <p></p>
+        To avoid the decoding and disconnection errors, it is recommended that the FPS of the camera be
+        adjusted where possible.  Generally, it is preferable to have the FPS of the camera be slightly
+        lower than the capture_rate of Motion.  This allows for the decoder to perform better and reduce
+        decode errors.  For example if the capture_rate is set at 5 and the camera is sending images at
+        30 FPS, the resulting images, processing latency, etc is going to be extremely "poor".  But if
+        the camera FPS is set at 4 instead, the results will be much better.
+        <p></p>
+        Reviews of the Motion log at the INF level can assist in determining whether a higher capture_rate is
+        required.  In particular, look for the following:
+        <ul>
+          <li> Log messages indicating what the netcam capture rate is versus the log entry
+          for the camera FPS.</li>
+          <li> The network camera is disconnecting and reconnecting frequently.</li>
+          <li> A significant number of ffmpeg_avcodec_log messages</li>
+        </ul>
+        <p></p>
+
+        <h4>rtsp_transport</h4>
+        <ul>
+          <li> Range / Valid values: tcp, udp, see ffmpeg documentation</li>
+          <li> Default: tcp</li>
+        </ul>
+        <p></p>
+        The rtsp_transport option is specified in the <a href="#netcam_params" >netcam_params</a> option.  This option
+        is from the ffmpeg libraries.
+        <p></p>
+        The rtsp_transport value of tcp is highly preferred because
+        without this option the rtsp/rtmp images are frequently corrupted and result in many false positive values and
+        images that appear to be smeared.
+        <p></p>
+
+        <h4>input_format</h4>
+        <ul>
+          <li> Range / Valid values: mjpeg, h264, see ffmpeg documentation</li>
+          <li> Default: tcp</li>
+        </ul>
+        <p></p>
+        The input_format option is specified in the <a href="#netcam_params" >netcam_params</a> option.  This option
+        is from the ffmpeg libraries.  This option is used for specifying the palette format of the camera when
+        using the v4l2 via netcam option.  The values of mjpeg and h264 correspond to the values assigned in
+        previous versions of Motion using the v4l2_palette option.
+        <p></p>
+
+        <h3><a name="netcam_high_url"></a> netcam_high_url </h3>
         <p></p>
         <ul>
           <li> Type: String</li>
@@ -3031,6 +3166,18 @@
         only as normal resolution and the privacy mask will not be overlaid on to the high resolution images.
         <p></p>
 
+        <h3><a name="netcam_high_params"></a> netcam_params </h3>
+        <p></p>
+        <ul>
+          <li> Type: String</li>
+          <li> Range / Valid values: Max 4095 characters</li>
+          <li> Default: varies by camera type</li>
+        </ul>
+        <p></p>
+        This option is the same as <a href="#netcam_params" >netcam_params</a> option except this option applies
+        the parameters to the high resolution camera.
+        <p></p>
+
         <h3><a name="netcam_userpass"></a> netcam_userpass </h3>
         <p></p>
         <ul>
@@ -3044,156 +3191,6 @@
         To use no authentication simply remove this option.  Digest authentication is only available for rtsp/rtmp cameras.
         <p></p>
 
-        <h3><a name="netcam_decoder"></a> netcam_decoder </h3>
-        <p></p>
-        <ul>
-          <li> Type: String</li>
-          <li> Range / Valid values: Max 4095 characters</li>
-          <li> Default: Not defined</li>
-        </ul>
-        <p></p>
-        The user requested decoder to use for rtsp/rtmp cameras.  Motion will try to open the camera using the decoder
-        specified by this parameter. If it not successful, it will usually fall back to the default decoder.  This
-        option may improve performance in certain situations for certain platforms and cameras.
-        <p></p>
-        Users can find the names of the decoders on their system by going to a command prompt and
-        typing <code>ffmpeg -decoders</code> and looking for the name of the decoder with a 'D' next
-        to it and correlating this with the type of image provided from the camera.  The list of decoders
-        will correspond with how the distro built ffmpeg.  Additional decoders could also be available
-        if ffmpeg is compiled from source.
-        <p></p>
-        Additional different decoder options may also be found by reviewing the Motion log.  These
-        decoders will be shown as "available" in log when <a href="#log_level">log_level</a> is
-        specified at the INF level or higher.
-        <p></p>
-        Note that not all decoders will work with all cameras even if they are indicated as
-        available.  If the camera does not open using the requested decoder, specify a different
-        decoder or leave this parameter empty to use the default.
-        <p></p>
-        <p></p>
-
-        <h3><a name="netcam_keepalive"></a> netcam_keepalive </h3>
-        <p></p>
-        <ul>
-          <li> Type: String</li>
-          <li> Range / Valid values: Max 4095 characters</li>
-          <li> Default: off</li>
-        </ul>
-        <p></p>
-        The setting for keep-alive of network socket, should improve performance on compatible net cameras.
-        <ul>
-        <li> off:   The historical implementation using HTTP/1.0, closing the socket after each http request.</li>
-        <li> force: Use HTTP/1.0 requests with keep alive header to reuse the same connection.</li>
-        <li> on:    Use HTTP/1.1 requests that support keep alive as default.</li>
-        </ul>
-        <p></p>
-            Motion will ignore this option for rtsp/rtmp cameras.
-        <p></p>
-
-        <h3><a name="netcam_proxy"></a> netcam_proxy </h3>
-        <p></p>
-        <ul>
-          <li> Type: String</li>
-          <li> Range / Valid values: Max 4095 characters</li>
-          <li> Default: Not defined</li>
-        </ul>
-        <p></p>
-        URL to use for a netcam proxy server, if required. The syntax is
-        <a href="http://myproxy:portnumber" rel="nofollow" target="_top">http://myproxy:portnumber</a>
-        Use this if you need to connect to a network camera through a proxy server.
-        Example of syntax: "http://myproxy.mydomain.com:1024
-        If the proxy port number is 80 you can omit the port number. Then the syntax is use "http://myproxy.mydomain.com" .
-        Leave this option undefined if you do not use a proxy server.
-        <p></p>
-            Motion will ignore this option for rtsp/rtmp cameras.
-        <p></p>
-
-        <h3><a name="netcam_rate"></a> netcam_rate </h3>
-        <p></p>
-        <ul>
-          <li> Type: Int</li>
-          <li> Range / Valid values: Integer</li>
-          <li> Default: <a href="#framerate">framerate</a></li>
-        </ul>
-        <p></p>
-        This option allows for the user to request a specific frame per second (FPS) capture rate for
-        the network camera.  This is needed
-        at times so that the rate Motion is capturing images is in sync with what the camera is sending.
-        <p></p>
-        When this value is used, it makes a slight distinction from
-        the usual interpretation of <a href="#framerate">framerate</a>.  The netcam_rate will specify
-        how fast images are <u>captured and decoded</u> and the <a href="#framerate">framerate</a>
-        will specify the rate at which they are <u>processed for motion</u>.
-        <p></p>
-        For example, if the netcam_rate were set to be 10 and the
-        <a href="#framerate">framerate</a> was set to be 20, what would happen is that each captured image
-        would end up going through the Motion detection / processing routines twice because that loop is
-        processing at twice the speed of the capture loop.  Conversely, if the netcam_rate was set
-        to 20 and the <a href="#framerate">framerate</a> is specified as 10, then Motion will be detecting
-        and processing every other image captured.
-        <p></p>
-        The reason that the netcam_rate is not systematically set to the <a href="#framerate">framerate</a>
-        within Motion has to with the camera.  Each camera will provide a stream of images usually in some
-        compression format such as H264/H265 and provide those images at a particular FPS.  If the
-        capture and decoding FPS of Motion is set to a rate lower than the camera, decoding and disconnection
-        errors will occur.
-        <p></p>
-        To avoid the decoding and disconnection errors, it is recommended that the FPS of the camera be
-        adjusted where possible.  Generally, it is preferable to have the FPS of the camera be slightly
-        lower than the netcam_rate of Motion.  This allows for the decoder to perform better and reduce
-        decode errors.  For example if the netcam_rate is set at 5 and the camera is sending images at
-        30 FPS, the resulting images, processing latency, etc is going to be extremely "poor".  But if
-        the camera FPS is set at 4 instead, the results will be much better.
-        <p></p>
-        Reviews of the Motion log at the INF level can assist in determining whether a higher netcam_rate is
-        required.  In particular, look for the following:
-        <ul>
-          <li> Log messages indicating what the netcam capture rate is versus the log entry
-          for the camera FPS.</li>
-          <li> The network camera is disconnecting and reconnecting frequently.</li>
-          <li> A significant number of ffmpeg_avcodec_log messages</li>
-        </ul>
-        <p></p>
-
-        <h3><a name="netcam_ratehigh"></a> netcam_ratehigh </h3>
-        <p></p>
-        <ul>
-          <li> Type: Int</li>
-          <li> Range / Valid values: Integer</li>
-          <li> Default: <a href="#framerate">framerate</a></li>
-        </ul>
-        <p></p>
-        This option allows for the user to request a specific frame per second (FPS) capture rate for
-        the high resolution network camera.  This option works the same as
-        <a href="#netcam_rate">netcam_rate</a> except that this parameter applies to the camera specified
-        by <a href="#netcam_highres">netcam_highres</a> (if applicable).
-        <p></p>
-
-        <h3><a name="netcam_tolerant_check"></a> netcam_tolerant_check </h3>
-        <p></p>
-        <ul>
-          <li> Type: Boolean</li>
-          <li> Range / Valid values: on, off</li>
-          <li> Default: off</li>
-        </ul>
-        <p></p>
-        Use less strict jpeg checks for network cameras
-        <p></p>
-            Motion will ignore this option for rtsp/rtmp cameras.
-        <p></p>
-
-        <h3><a name="netcam_use_tcp"></a> netcam_use_tcp </h3>
-        <p></p>
-        <ul>
-          <li> Type: Boolean</li>
-          <li> Range / Valid values: on, off</li>
-          <li> Default: on</li>
-        </ul>
-        <p></p>
-        This option specifies the transport method for rtsp/rtmp cameras.  The TCP transport is highly preferred because
-        without this option the rtsp/rtmp images are frequently corrupted and result in many false positive values and
-        images that appear to be smeared.  Off indicates that UDP will be used.
-        <p></p>
         <p></p>
       </ul>
 
@@ -3223,7 +3220,7 @@
             the <a href="#Basic_Setup">Basic Setup</a> section of this guide for further details.
         <p></p>
 
-        <h3><a name="mmalcam_control_params"></a> mmalcam_control_params</h3>
+        <h3><a name="mmalcam_params"></a> mmalcam_params</h3>
         <p></p>
         <ul>
           <li> Type: String</li>
@@ -4493,8 +4490,7 @@
         <p></p>
         For v4l2 cameras to use the movie_passthrough, they must be specified using the
         <a href="#netcam_url">netcam_url</a> parameter and the <code>v4l2</code> prefix.
-        <u>Only</u> webcams that provide mjpeg (<a href="#v4l2_palette">v4l2_palette</a> option 8)
-        or H264 (<a href="#v4l2_palette">v4l2_palette</a> option 21) will work with the
+        <u>Only</u> webcams that provide mjpeg or H264 will work with the
         <a href="#movie_passthrough">movie_passthrough</a>.
         <p></p>
 

--- a/man/motion.1
+++ b/man/motion.1
@@ -1,4 +1,4 @@
-.TH MOTION 1 2020-08-30 "Motion" "Motion Options and Config Files"
+.TH MOTION 1 2020-10-19 "Motion" "Motion Options and Config Files"
 .SH NAME
 motion \-   Detect motion using a video4linux device or network camera
 .SH SYNOPSIS
@@ -234,7 +234,7 @@ This option accepts the conversion specifiers included at the end of this manual
 .RE
 
 .TP
-.B videodevice
+.B video_device
 .RS
 .nf
 Values: User specified string
@@ -242,14 +242,14 @@ Default: /dev/video0
 Description:
 .fi
 .RS
-String to specify the videodevice to be used for capturing.
+String to specify the video device to be used for capturing.
 The format is usually /dev/videoX where X varies depending upon the video devices connected to the computer.
 For FreeBSD certain devices use the bktr subsystem and they will use /dev/bktr0.
 .RE
 .RE
 
 .TP
-.B vid_control_params
+.B video_params
 .RS
 .nf
 Values: User specified string
@@ -257,97 +257,9 @@ Default: None
 Description:
 .fi
 .RS
-String to specify the parameters to pass in for a videodevice.  The parameters
+String to specify the parameters to pass in for a video_device.  The parameters
 permitted are dependent upon the device.  This only applies to V4L2 devices.  The
 Motion log reports all the available options for the device.
-.RE
-.RE
-
-.TP
-.B v4l2_palette
-.RS
-.nf
-Values: 0 to 21
-.RS
-V4L2_PIX_FMT_SN9C10X : 0  'S910'
-V4L2_PIX_FMT_SBGGR16 : 1  'BYR2'
-V4L2_PIX_FMT_SBGGR8  : 2  'BA81'
-V4L2_PIX_FMT_SPCA561 : 3  'S561'
-V4L2_PIX_FMT_SGBRG8  : 4  'GBRG'
-V4L2_PIX_FMT_SGRBG8  : 5  'GRBG'
-V4L2_PIX_FMT_PAC207  : 6  'P207'
-V4L2_PIX_FMT_PJPG    : 7  'PJPG'
-V4L2_PIX_FMT_MJPEG   : 8  'MJPEG'
-V4L2_PIX_FMT_JPEG    : 9  'JPEG'
-V4L2_PIX_FMT_RGB24   : 10 'RGB3'
-V4L2_PIX_FMT_SPCA501 : 11 'S501'
-V4L2_PIX_FMT_SPCA505 : 12 'S505'
-V4L2_PIX_FMT_SPCA508 : 13 'S508'
-V4L2_PIX_FMT_UYVY    : 14 'UYVY'
-V4L2_PIX_FMT_YUYV    : 15 'YUYV'
-V4L2_PIX_FMT_YUV422P : 16 '422P'
-V4L2_PIX_FMT_YUV420  : 17 'YU12'
-V4L2_PIX_FMT_Y10     : 18 'Y10'
-V4L2_PIX_FMT_Y12     : 19 'Y12'
-V4L2_PIX_FMT_GREY    : 20 'GREY'
-V4L2_PIX_FMT_H264    : 21 'H264'
-.RE
-Default: 17
-Description:
-.fi
-.RS
-The v4l2_palette option allows users to choose the preferred palette to be use by motion to capture from the video device.
-If the preferred palette is not available from the video device, Motion will attempt to use palettes that are supported.
-.RE
-.RE
-
-.TP
-.B input
-.RS
-.nf
-Values:
-.RS
-\-1 : USB Cameras
-0 : video/TV cards or uvideo(4) on OpenBSD
-1 : video/TV cards
-.RE
-Default: \-1
-Description:
-.fi
-.RS
-The video input to be used.
-.RE
-.RE
-
-.TP
-.B norm
-.RS
-.nf
-Values:
-.RS
-0 (PAL)
-1 (NTSC)
-2 (SECAM)
-3 (PAL NC no colour)
-.RE
-Default: 0 (PAL)
-Description:
-.fi
-.RS
-The video norm to use when capturing from TV tuner cards
-.RE
-.RE
-
-.TP
-.B frequency
-.RS
-.nf
-Values: Dependent upon video device
-Default: 0
-Description:
-.fi
-.RS
-The frequency to set the tuner in kHz when using a TV tuner card.
 .RE
 .RE
 
@@ -367,7 +279,7 @@ Only recommended for cameras without auto brightness.
 .RE
 
 .TP
-.B tunerdevice
+.B tuner_device
 .RS
 .nf
 Values: User Specified String
@@ -452,7 +364,20 @@ Basic authentication can be specified in the URL or via the netcam_userpass opti
 .RE
 
 .TP
-.B netcam_highres
+.B netcam_params
+.RS
+.nf
+Values: User specified string
+Default: Not Defined
+Description:
+.fi
+.RS
+User specified parameters for the network camera.
+.RE
+.RE
+
+.TP
+.B netcam_high_url
 .RS
 .nf
 Values: User specified string
@@ -478,6 +403,20 @@ Basic authentication can be specified in the URL or via the netcam_userpass opti
 .RE
 
 .TP
+.B netcam_high_params
+.RS
+.nf
+Values: User specified string
+Default: Not Defined
+Description:
+.fi
+.RS
+User specified parameters for the network camera.
+.RE
+.RE
+
+
+.TP
 .B netcam_userpass
 .RS
 .nf
@@ -489,117 +428,6 @@ Description:
 The user id and password required to access the network camera string.
 Only basic authentication is supported at this time.
 Format is in user:password format when both a user name and password are required.
-.RE
-.RE
-
-.TP
-.B netcam_decoder
-.RS
-.nf
-Values: User specified string
-Default: Not Defined
-Description:
-.fi
-.RS
-User requested decoder to use for network cameras.
-.RE
-.RE
-
-.TP
-.B netcam_keepalive
-.RS
-.nf
-Values:
-.RS
-.fi
-off:   The historical implementation using HTTP/1.0, closing the socket after each http request.
-.nf
-
-.fi
-force: Use HTTP/1.0 requests with keep alive header to reuse the same connection.
-.nf
-
-.fi
-on:    Use HTTP/1.1 requests that support keep alive as default.
-.nf
-.RE
-Default: off
-Description:
-.fi
-.RS
-This setting is to keep-alive (open) the network socket between requests.
-When used, this option should improve performance on compatible net cameras.
-This option is not applicable for the rtsp://, rtmp:// and mjpeg:// formats.
-.RE
-.RE
-
-.TP
-.B netcam_proxy
-.RS
-.nf
-Values: User specified string
-Default: Not defined
-Description:
-.fi
-.RS
-If required, the URL to use for a netcam proxy server.
-For example, "http://myproxy".
-If a port number other than 80 is needed, append to the specification.
-For examplet, "http://myproxy:1234".
-.RE
-.RE
-
-.TP
-.B netcam_rate
-.RS
-.nf
-Values: Integer
-Default: framerate
-Description:
-.fi
-.RS
-The FPS that the images will be captured and decoded from the network camera.
-.RE
-.RE
-
-.TP
-.B netcam_ratehigh
-.RS
-.nf
-Values: Integer
-Default: framerate
-Description:
-.fi
-.RS
-The FPS that the images will be captured and decoded from the high resolution network camera.
-.RE
-.RE
-
-.TP
-.B netcam_tolerant_check
-.RS
-.nf
-Values: on/off
-Default: off
-Description:
-.fi
-.RS
-Use a less strict jpeg validation for network cameras.
-This can assist with cameras that have poor or buggy firmware.
-.RE
-.RE
-
-.TP
-.B netcam_use_tcp
-.RS
-.nf
-Values: on/off
-Default: on
-Description:
-.fi
-.RS
-When using a RTSP/RTMP connection for a network camera, use a TCP transport instead of UDP.
-The UDP transport frequently results in "smeared" corrupt images.
 .RE
 .RE
 
@@ -619,7 +447,7 @@ The typical value for the PI camera is vc.ril.camera
 .RE
 
 .TP
-.B mmalcam_control_params
+.B mmalcam_params
 .RS
 .nf
 Values: User specified string

--- a/src/conf.h
+++ b/src/conf.h
@@ -35,11 +35,7 @@ struct config {
 
     /* Capture device configuration parameters */
     const char      *video_device;
-    char            *vid_control_params;
-    int             v4l2_palette;
-    int             input;
-    int             norm;
-    unsigned long   frequency;
+    char            *video_params;
     int             auto_brightness;
     const char      *tuner_device;
     int             roundrobin_frames;
@@ -47,18 +43,13 @@ struct config {
     int             roundrobin_switchfilter;
 
     const char      *netcam_url;
-    const char      *netcam_highres;
+    char            *netcam_params;
+    const char      *netcam_high_url;
+    char            *netcam_high_params;
     const char      *netcam_userpass;
-    const char      *netcam_keepalive;
-    const char      *netcam_proxy;
-    int             netcam_tolerant_check;
-    int             netcam_use_tcp;
-    char            *netcam_decoder;
-    int             netcam_rate;
-    int             netcam_ratehigh;
 
     const char      *mmalcam_name;
-    const char      *mmalcam_control_params;
+    const char      *mmalcam_params;
 
     /* Image processing configuration parameters */
     int             width;

--- a/src/mmalcam.c
+++ b/src/mmalcam.c
@@ -39,12 +39,12 @@
 
 const int MAX_BITRATE = 30000000; // 30Mbits/s
 
-static void parse_camera_control_params(const char *control_params_str, RASPICAM_CAMERA_PARAMETERS *camera_params)
+static void parse_camera_params(const char *params_str, RASPICAM_CAMERA_PARAMETERS *camera_params)
 {
-    char *control_params_tok = alloca(strlen(control_params_str) + 1);
-    strcpy(control_params_tok, control_params_str);
+    char *params_tok = alloca(strlen(params_str) + 1);
+    strcpy(params_tok, params_str);
 
-    char *next_param = strtok(control_params_tok, " ");
+    char *next_param = strtok(params_tok, " ");
 
     while (next_param != NULL) {
         char *param_val = strtok(NULL, " ");
@@ -296,8 +296,8 @@ int mmalcam_start(struct context *cnt)
     mmalcam->height = cnt->conf.height;
     mmalcam->framerate = cnt->conf.framerate;
 
-    if (cnt->conf.mmalcam_control_params) {
-        parse_camera_control_params(cnt->conf.mmalcam_control_params, mmalcam->camera_parameters);
+    if (cnt->conf.mmalcam_params) {
+        parse_camera_params(cnt->conf.mmalcam_params, mmalcam->camera_parameters);
     }
 
     cnt->imgs.width = mmalcam->width;

--- a/src/motion.c
+++ b/src/motion.c
@@ -4169,3 +4169,33 @@ int util_check_passthrough(struct context *cnt){
 #endif
 
 }
+
+/* util_trim
+ * Trim away any leading or trailing whitespace in the string
+*/
+void util_trim(char *parm)
+{
+    int indx, indx_st, indx_en;
+
+    if (parm == NULL) return;
+
+    indx_en = strlen(parm) - 1;
+    if (indx_en == -1) return;
+
+    indx_st = 0;
+
+    while (isspace(parm[indx_st]) && (indx_st <= indx_en)) indx_st++;
+    if (indx_st > indx_en){
+        parm[0]= '\0';
+        return;
+    }
+
+    while (isspace(parm[indx_en]) && (indx_en > indx_st)) indx_en--;
+
+    for (indx = indx_st; indx<=indx_en; indx++)
+    {
+        parm[indx-indx_st] = parm[indx];
+    }
+    parm[indx_en-indx_st+1] = '\0';
+
+}

--- a/src/motion.h
+++ b/src/motion.h
@@ -35,6 +35,7 @@ struct image_data;
 #ifndef __USE_GNU
 #define __USE_GNU
 #endif
+#include <ctype.h>
 #include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -547,5 +548,6 @@ int create_path(const char *);
 void util_threadname_set(const char *abbr, int threadnbr, const char *threadname);
 void util_threadname_get(char *threadname);
 int util_check_passthrough(struct context *cnt);
+void util_trim(char *parm);
 
 #endif /* _INCLUDE_MOTION_H */

--- a/src/motion.h
+++ b/src/motion.h
@@ -104,8 +104,6 @@ struct image_data;
                 while (nanosleep(&tv, &tv) == -1); \
         }
 
-#define DEF_PALETTE             17
-
 /* Default picture settings */
 #define DEF_WIDTH              640
 #define DEF_HEIGHT             480
@@ -118,7 +116,6 @@ struct image_data;
 /* Minimum time between two 'actions' (email, sms, external) */
 #define DEF_EVENT_GAP            60  /* 1 minutes */
 
-#define DEF_INPUT               -1
 #define DEF_VIDEO_DEVICE         "/dev/video0"
 
 #define THRESHOLD_TUNE_LENGTH  256
@@ -219,21 +216,16 @@ enum WEBUI_LEVEL{
   WEBUI_LEVEL_NEVER      = 99
 };
 
-struct vdev_usrctrl_ctx {
-    char          *ctrl_name;       /* The name or description of the ID as requested by user*/
-    int            ctrl_value;      /* The value that the user wants the control set to*/
+struct params_item_ctx {
+    char    *param_name;       /* The name or description of the ID as requested by user*/
+    char    *param_value;      /* The value that the user wants the control set to*/
 };
 
-struct vdev_context {
-    /* As v4l2 and bktr get rewritten, put thread specific items here
-     * Rather than use conf options directly, copy from conf to here
-     * to handle cross thread webui changes which could cause problems
-     */
-    struct vdev_usrctrl_ctx *usrctrl_array;     /*Array of the controls the user specified*/
-    int usrctrl_count;                          /*Count of the controls the user specified*/
-    int update_parms;                           /*Bool for whether to update the parameters on the device*/
+struct params_context {
+    struct params_item_ctx *params_array;     /*Array of the controls the user specified*/
+    int params_count;                         /*Count of the controls the user specified*/
+    int update_params;                        /*Bool for whether to update the parameters on the device*/
 };
-
 
 struct image_data {
     unsigned char *image_norm;
@@ -394,7 +386,7 @@ struct context {
     struct rtsp_context *rtsp;              /* this structure contains the context for normal RTSP connection */
     struct rtsp_context *rtsp_high;         /* this structure contains the context for high resolution RTSP connection */
 
-    struct vdev_context *vdev;              /* Structure for v4l2 and bktr device information */
+    struct params_context *vdev;            /* Structure for v4l2 and bktr device information */
 
     struct image_data *current_image;       /* Pointer to a structure where the image, diffs etc is stored */
     unsigned int new_img;
@@ -456,7 +448,6 @@ struct context {
     int mpipe;
 
     char hostname[PATH_MAX];
-    char *netcam_decoder;
 
     int sql_mask;
 
@@ -549,5 +540,8 @@ void util_threadname_set(const char *abbr, int threadnbr, const char *threadname
 void util_threadname_get(char *threadname);
 int util_check_passthrough(struct context *cnt);
 void util_trim(char *parm);
+void util_parms_free(struct params_context *parameters);
+void util_parms_parse(struct params_context *parameters, char *confparm);
+void util_parms_add_default(struct params_context *parameters, const char *parm_nm, const char *parm_vl);
 
 #endif /* _INCLUDE_MOTION_H */

--- a/src/netcam.h
+++ b/src/netcam.h
@@ -124,9 +124,9 @@ extern struct netcam_caps {                    /* netcam capabilities: */
  * for an individual netcam.
  */
 typedef struct netcam_context {
-    struct context *cnt;        /* pointer to parent motion
-                                   context structure */
-
+    struct context            *cnt;         /* pointer to parent motion context structure */
+    struct params_context     *parameters;  /* User specified parameters for the camera */
+    int haveproxy;              /* bool for whether there is a proxy */
     int finish;                 /* flag to break the camera-
                                    handling thread out of it's
                                    infinite loop in emergency */

--- a/src/netcam_http.c
+++ b/src/netcam_http.c
@@ -396,8 +396,6 @@ int netcam_read_first_header(netcam_context_ptr netcam)
                      * if your netcam often returns bad HTTP result codes.
                      */
                     netcam->connect_keepalive = FALSE;
-                    free((void *)netcam->cnt->conf.netcam_keepalive);
-                    netcam->cnt->conf.netcam_keepalive = strdup("off");
                     MOTION_LOG(NTC, TYPE_NETCAM, NO_ERRNO
                         ,_("Removed netcam Keep-Alive flag "
                         "due to apparent closed HTTP connection."));
@@ -521,8 +519,6 @@ int netcam_read_first_header(netcam_context_ptr netcam)
                         ,_("Both 'Connection: Keep-Alive' and "
                         "'Connection: close' header received. Motion removes keepalive."));
                     netcam->connect_keepalive = FALSE;
-                    free((void *)netcam->cnt->conf.netcam_keepalive);
-                    netcam->cnt->conf.netcam_keepalive = strdup("off");
                 } else {
                    /*
                     * If not a streaming cam, and keepalive is set, and the flag shows we
@@ -555,8 +551,6 @@ int netcam_read_first_header(netcam_context_ptr netcam)
                         ,_("No 'Connection: Keep-Alive' nor 'Connection: close'"
                         " header received.\n Motion removes keepalive."));
                     netcam->connect_keepalive = FALSE;
-                    free((void *)netcam->cnt->conf.netcam_keepalive);
-                    netcam->cnt->conf.netcam_keepalive = strdup("off");
                 } else {
                    /*
                     * If not a streaming cam, and keepalive is set, and the flag shows we
@@ -592,8 +586,6 @@ int netcam_read_first_header(netcam_context_ptr netcam)
                  */
                 if (!netcam->keepalive_thisconn) {
                     netcam->connect_keepalive = FALSE;    /* No further attempts at keep-alive */
-                    free((void *)netcam->cnt->conf.netcam_keepalive);
-                    netcam->cnt->conf.netcam_keepalive = strdup("off");
                     MOTION_LOG(INF, TYPE_NETCAM, NO_ERRNO
                         ,_("Removed netcam Keep-Alive flag because"
                         " 'Connection: close' header received.\n Netcam does not support "
@@ -1316,7 +1308,7 @@ static int netcam_http_build_url(netcam_context_ptr netcam, struct url_t *url)
      * Note: Keep-Alive (but not HTTP 1.1) is disabled if a proxy URL
      * is set, since HTTP 1.0 Keep-alive cannot be transferred through.
      */
-    if (cnt->conf.netcam_proxy) {
+    if ( netcam->haveproxy) {
         /*
          * Allocate space for a working string to contain the path.
          * The extra 4 is for "://" and string terminator.
@@ -1330,8 +1322,6 @@ static int netcam_http_build_url(netcam_context_ptr netcam, struct url_t *url)
         }
 
         netcam->connect_keepalive = FALSE; /* Disable Keepalive if proxy */
-        free((void *)netcam->cnt->conf.netcam_keepalive);
-        netcam->cnt->conf.netcam_keepalive = strdup("off");
 
         MOTION_LOG(NTC, TYPE_NETCAM, NO_ERRNO
             ,_("Removed netcam_keepalive flag due to proxy set."

--- a/src/netcam_rtsp.h
+++ b/src/netcam_rtsp.h
@@ -85,12 +85,13 @@ struct rtsp_context {
     int                       v4l2_palette;     /* Palette from config for v4l2 devices */
     int                       reconnect_count;  /* Count of the times reconnection is tried*/
     int                       src_fps;          /* The fps provided from source*/
-    int                       framerate;        /* The framerate for the capture rate*/
+    int                       capture_rate;     /* The framerate for the capture rate*/
     int64_t                   capture_nbr;      /* The number of images captured since last av_read_play */
 
     struct timeval            frame_prev_tm;    /* The time set before calling the av functions */
     struct timeval            frame_curr_tm;    /* Time during the interrupt to determine duration since start*/
 
+    struct params_context    *parameters;       /* User specified parameters for the camera */
     struct config            *conf;             /* Pointer to conf parms of parent cnt*/
     char                      *decoder_nm;      /* User requested decoder */
     struct context            *cnt;

--- a/src/video_common.c
+++ b/src/video_common.c
@@ -483,151 +483,249 @@ void vid_greytoyuv420p(unsigned char *map, unsigned char *cap_map, int width, in
 
 }
 
-static void vid_parms_add(struct vdev_context *vdevctx, char *config_name, char *config_val){
+/* vid_parms_free
+ * Free all the memory associated with the parameter control array.
+*/
+static void vid_parms_free(struct context *cnt)
+{
+    int indx_parm;
 
-    /* Add the parameter and value to our user control array*/
-    struct vdev_usrctrl_ctx *tmp;
-    int indx;
-
-    tmp = mymalloc(sizeof(struct vdev_usrctrl_ctx)*(vdevctx->usrctrl_count+1));
-    for (indx=0;indx<vdevctx->usrctrl_count;indx++){
-        tmp[indx].ctrl_name = mymalloc(strlen(vdevctx->usrctrl_array[indx].ctrl_name)+1);
-        sprintf(tmp[indx].ctrl_name,"%s",vdevctx->usrctrl_array[indx].ctrl_name);
-        free(vdevctx->usrctrl_array[indx].ctrl_name);
-        vdevctx->usrctrl_array[indx].ctrl_name=NULL;
-        tmp[indx].ctrl_value = vdevctx->usrctrl_array[indx].ctrl_value;
-    }
-    if (vdevctx->usrctrl_array != NULL){
-      free(vdevctx->usrctrl_array);
-      vdevctx->usrctrl_array =  NULL;
+    for (indx_parm=0; indx_parm<cnt->vdev->usrctrl_count; indx_parm++)
+    {
+        free(cnt->vdev->usrctrl_array[indx_parm].ctrl_name);
+        cnt->vdev->usrctrl_array[indx_parm].ctrl_name = NULL;
     }
 
-    vdevctx->usrctrl_array = tmp;
-    vdevctx->usrctrl_array[vdevctx->usrctrl_count].ctrl_name = mymalloc(strlen(config_name)+1);
-    sprintf(vdevctx->usrctrl_array[vdevctx->usrctrl_count].ctrl_name,"%s",config_name);
-    vdevctx->usrctrl_array[vdevctx->usrctrl_count].ctrl_value=atoi(config_val);
-    vdevctx->usrctrl_count++;
+    if (cnt->vdev->usrctrl_array != NULL) {
+      free(cnt->vdev->usrctrl_array);
+      cnt->vdev->usrctrl_array = NULL;
+    }
+
+    cnt->vdev->usrctrl_count = 0;
 
 }
 
-int vid_parms_parse(struct context *cnt){
+/* vid_parms_add
+ * Add the parsed out parameter and value to the control array.
+*/
+static void vid_parms_add(struct context *cnt, const char *parm_nm, const char *parm_val)
+{
+    cnt->vdev->usrctrl_count++;
 
+    if (cnt->vdev->usrctrl_count == 1) {
+        cnt->vdev->usrctrl_array =(struct vdev_usrctrl_ctx *) mymalloc(sizeof(struct vdev_usrctrl_ctx));
+    } else {
+        cnt->vdev->usrctrl_array =(struct vdev_usrctrl_ctx *)realloc(cnt->vdev->usrctrl_array
+            , sizeof(struct vdev_usrctrl_ctx)*cnt->vdev->usrctrl_count);
+    }
+
+    if (parm_nm != NULL) {
+        cnt->vdev->usrctrl_array[cnt->vdev->usrctrl_count-1].ctrl_name =(char*)mymalloc(strlen(parm_nm)+1);
+        sprintf(cnt->vdev->usrctrl_array[cnt->vdev->usrctrl_count-1].ctrl_name,"%s",parm_nm);
+    } else {
+        cnt->vdev->usrctrl_array[cnt->vdev->usrctrl_count-1].ctrl_name = NULL;
+    }
+
+    cnt->vdev->usrctrl_array[cnt->vdev->usrctrl_count-1].ctrl_value = atoi(parm_val);
+
+    MOTION_LOG(INF, TYPE_VIDEO, NO_ERRNO,_("Parsed: >%s< >%d<")
+        ,cnt->vdev->usrctrl_array[cnt->vdev->usrctrl_count-1].ctrl_name
+        ,cnt->vdev->usrctrl_array[cnt->vdev->usrctrl_count-1].ctrl_value);
+
+}
+
+/* vid_parms_set
+ * Extract out of the string the parameter name and values at the location
+ * specified.
+*/
+static void vid_parms_set(struct context *cnt, char *parms
+        ,int indxnm_st, int indxnm_en, int indxvl_st, int indxvl_en)
+{
+    char *parm_nm, *parm_vl;
+    int retcd, chksz;
+
+    if ((indxnm_en != 0) &&
+        (indxvl_st != 0) &&
+        ((indxnm_en - indxnm_st) > 0) &&
+        ((indxvl_en - indxvl_st) > 0))
+    {
+        parm_nm = mymalloc(PATH_MAX);
+        parm_vl = mymalloc(PATH_MAX);
+
+        chksz = indxnm_en - indxnm_st + 1;
+        retcd = snprintf(parm_nm, chksz, "%s", parms + indxnm_st);
+        if (retcd < 0) {
+            MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO,_("Error parsing parm_nm controls: %s"), parms);
+        }
+
+        chksz = indxvl_en - indxvl_st + 1;
+        retcd = snprintf(parm_vl, chksz, "%s", parms + indxvl_st);
+        if (retcd < 0) {
+            MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO,_("Error parsing parm_vl controls: %s"), parms);
+        }
+
+        util_trim(parm_nm);
+        util_trim(parm_vl);
+
+        vid_parms_add(cnt, parm_nm, parm_vl);
+
+        free(parm_nm);
+        free(parm_vl);
+    }
+
+}
+
+/* vid_parms_next
+ * Remove the parameter parsed out in previous steps from the parms string
+ * and set up the string for parsing out the next parameter.
+*/
+static void vid_parms_next(char *parms,int indxnm_st, int indxvl_en)
+{
+    char *parm_tmp;
+    int retcd;
+
+    parm_tmp = mymalloc(PATH_MAX);
+    retcd = snprintf(parm_tmp, PATH_MAX, "%s", parms);
+    if (retcd < 0) {
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO,_("Error setting temp: %s"), parms);
+    }
+
+    if (indxnm_st == 0) {
+        if ((size_t)(indxvl_en + 1) >strlen(parms)) {
+            parms[0]='\0';
+        } else {
+            retcd = snprintf(parms, strlen(parm_tmp) - indxvl_en + 1
+                , "%s", parm_tmp+indxvl_en+1);
+        }
+    } else {
+        if ((size_t)(indxvl_en + 1) > strlen(parms) ) {
+            retcd = snprintf(parms, indxnm_st - 1, "%s", parm_tmp);
+        } else {
+            retcd = snprintf(parms, PATH_MAX, "%.*s%.*s"
+                , indxnm_st - 1, parm_tmp
+                , (int)(strlen(parm_tmp) - indxvl_en)
+                , parm_tmp + indxvl_en);
+        }
+    }
+    if (retcd < 0) {
+        MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO,_("Error reparsing controls: %s"), parms);
+    }
+
+    free(parm_tmp);
+
+}
+
+/* vid_parms_parse_qte
+ * Split out the parameters that have quotes around the name.
+*/
+static void vid_parms_parse_qte(struct context *cnt, char *parms)
+{
+    int indxnm_st, indxnm_en, indxvl_st, indxvl_en;
+
+    while (strstr(parms,"\"") != NULL)
+    {
+        indxnm_st = 0;
+        indxnm_en = 0;
+        indxvl_st = 0;
+        indxvl_en = strlen(parms);
+
+        indxnm_st = strstr(parms,"\"") - parms + 1;
+        if (strstr(parms + indxnm_st,"\"") != NULL) {
+            indxnm_en = strstr(parms + indxnm_st,"\"") - parms;
+            if (strstr(parms + indxnm_en + 1,"=") != NULL) {
+                indxvl_st = strstr(parms + indxnm_en + 1,"=") - parms + 1;
+            }
+            if (strstr(parms + indxvl_st + 1,",") != NULL) {
+                indxvl_en = strstr(parms + indxvl_st + 1,",") - parms;
+            }
+        }
+
+        vid_parms_set(cnt, parms, indxnm_st, indxnm_en, indxvl_st, indxvl_en);
+        vid_parms_next(parms, indxnm_st, indxvl_en);
+    }
+}
+
+/* vid_parms_parse_comma
+ * Split out the parameters between the commas.
+*/
+static void vid_parms_parse_comma(struct context *cnt, char *parms)
+{
+    int indxnm_st, indxnm_en, indxvl_st, indxvl_en;
+
+    while (strstr(parms,",") != NULL)
+    {
+        indxnm_st = 0;
+        indxnm_en = 0;
+        indxvl_st = 0;
+        indxvl_en = strstr(parms, ",") - parms;
+
+        if (strstr(parms, "=") != NULL) {
+            indxnm_en = strstr(parms,"=") - parms;
+            if ((size_t)indxnm_en < strlen(parms)) {
+                indxvl_st = indxnm_en + 1;
+            }
+        }
+        vid_parms_set(cnt, parms, indxnm_st, indxnm_en, indxvl_st, indxvl_en);
+        vid_parms_next(parms, indxnm_st, indxvl_en);
+    }
+
+}
+
+/* vid_parms_parse
+ * Parse the vid_control_params into an array.
+*/
+int vid_parms_parse(struct context *cnt)
+{
     /* Parse through the configuration option to get values
      * The values are separated by commas but may also have
      * double quotes around the names which include a comma.
      * Examples:
-     * vid_control_parms ID01234= 1, ID23456=2
-     * vid_control_parms "Brightness, auto" = 1, ID23456=2
-     * vid_control_parms ID23456=2, "Brightness, auto" = 1,ID2222=5
+     * vid_control_params ID01234= 1, ID23456=2
+     * vid_control_params "Brightness, auto" = 1, ID23456=2
+     * vid_control_params ID23456=2, "Brightness, auto" = 1,ID2222=5
      */
-    int indx_parm;
-    int parmval_st , parmval_len;
-    int parmdesc_st, parmdesc_len;
-    int qte_open;
-    struct vdev_context *vdevctx;
-    char tst;
-    char *parmdesc, *parmval;
+
+    int retcd, indxnm_st, indxnm_en, indxvl_st, indxvl_en;
+    char *parms;
 
     if (!cnt->vdev->update_parms) return 0;
 
-    vdevctx = cnt->vdev;
+    vid_parms_free(cnt);
+    parms = NULL;
 
-    for (indx_parm=0;indx_parm<vdevctx->usrctrl_count;indx_parm++){
-        free(vdevctx->usrctrl_array[indx_parm].ctrl_name);
-        vdevctx->usrctrl_array[indx_parm].ctrl_name=NULL;
-    }
-    if (vdevctx->usrctrl_array != NULL){
-      free(vdevctx->usrctrl_array);
-      vdevctx->usrctrl_array = NULL;
-    }
-    vdevctx->usrctrl_count = 0;
+    if (cnt->conf.vid_control_params != NULL) {
+        MOTION_LOG(INF, TYPE_VIDEO, NO_ERRNO
+            ,_("Parsing controls: %s"), cnt->conf.vid_control_params);
 
-    if (cnt->conf.vid_control_params != NULL){
-        MOTION_LOG(INF, TYPE_VIDEO, NO_ERRNO,_("Parsing controls: %s"),cnt->conf.vid_control_params);
+        parms = mymalloc(PATH_MAX);
 
-        indx_parm = 0;
-        parmdesc_st  = parmval_st  = -1;
-        parmdesc_len = parmval_len = 0;
-        qte_open = FALSE;
-        parmdesc = parmval = NULL;
-        tst = cnt->conf.vid_control_params[indx_parm];
-        while (tst != '\0') {
-            if (!qte_open) {
-                if (tst == '\"') {                    /* This is the opening quotation */
-                    qte_open = TRUE;
-                    parmdesc_st = indx_parm + 1;
-                    parmval_st  = -1;
-                    parmdesc_len = parmval_len = 0;
-                    if (parmdesc != NULL) free(parmdesc);
-                    if (parmval  != NULL) free(parmval);
-                    parmdesc = parmval = NULL;
-                } else if (tst == ','){               /* Designator for next parm*/
-                    if ((parmval_st >= 0) && (parmval_len > 0)){
-                        if (parmval  != NULL) free(parmval);
-                        parmval = mymalloc(parmval_len);
-                        snprintf(parmval, parmval_len,"%s",&cnt->conf.vid_control_params[parmval_st]);
-                    }
-                    parmdesc_st  = indx_parm + 1;
-                    parmval_st  = -1;
-                    parmdesc_len = parmval_len = 0;
-                } else if (tst == '='){               /* Designator for end of desc and start of value*/
-                    if ((parmdesc_st >= 0) && (parmdesc_len > 0)) {
-                        if (parmdesc != NULL) free(parmdesc);
-                        parmdesc = mymalloc(parmdesc_len);
-                        snprintf(parmdesc, parmdesc_len,"%s",&cnt->conf.vid_control_params[parmdesc_st]);
-                    }
-                    parmdesc_st = -1;
-                    parmval_st = indx_parm + 1;
-                    parmdesc_len = parmval_len = 0;
-                    if (parmval != NULL) free(parmval);
-                    parmval = NULL;
-                } else if (tst == ' '){               /* Skip leading spaces */
-                    if (indx_parm == parmdesc_st) parmdesc_st++;
-                    if (indx_parm == parmval_st) parmval_st++;
-                } else if (tst != ' '){               /* Revise the length making sure it is not a space*/
-                    parmdesc_len = indx_parm - parmdesc_st + 2;
-                    parmval_len = indx_parm - parmval_st + 2;
-                    if (parmdesc_st == -1) parmdesc_st = indx_parm;
+        retcd = snprintf(parms, PATH_MAX, "%s", cnt->conf.vid_control_params);
+        if ((retcd < 0) || (retcd > PATH_MAX)) {
+            MOTION_LOG(ERR, TYPE_VIDEO, NO_ERRNO
+                ,_("Error parsing controls: %s"), cnt->conf.vid_control_params);
+            free(parms);
+            return 0;
+        }
+
+        vid_parms_parse_qte(cnt, parms);
+
+        vid_parms_parse_comma(cnt, parms);
+
+        if (strlen(parms) != 0) {
+            indxnm_st = 0;
+            indxnm_en = 0;
+            indxvl_st = 0;
+            indxvl_en = strlen(parms);
+            if (strstr(parms + 1,"=") != NULL) {
+                indxnm_en = strstr(parms + 1,"=") - parms;
+                if ((size_t)indxnm_en < strlen(parms)){
+                    indxvl_st = indxnm_en + 1;
                 }
-            } else if (tst == '\"') {                /* This is the closing quotation */
-                parmdesc_len = indx_parm - parmdesc_st + 1;
-                if (parmdesc_len > 0 ){
-                    if (parmdesc != NULL) free(parmdesc);
-                    parmdesc = mymalloc(parmdesc_len);
-                    snprintf(parmdesc, parmdesc_len,"%s",&cnt->conf.vid_control_params[parmdesc_st]);
-                }
-                parmdesc_st = -1;
-                parmval_st = indx_parm + 1;
-                parmdesc_len = parmval_len = 0;
-                if (parmval != NULL) free(parmval);
-                parmval = NULL;
-                qte_open = FALSE;   /* Reset the open/close on quotation */
-            }
-            if ((parmdesc != NULL) && (parmval  != NULL)){
-                vid_parms_add(vdevctx, parmdesc, parmval);
-                free(parmdesc);
-                free(parmval);
-                parmdesc = parmval = NULL;
             }
 
-            indx_parm++;
-            tst = cnt->conf.vid_control_params[indx_parm];
+            vid_parms_set(cnt, parms, indxnm_st, indxnm_en, indxvl_st, indxvl_en);
         }
-        /* Process the last parameter */
-        if ((parmval_st >= 0) && (parmval_len > 0)){
-            if (parmval  != NULL) free(parmval);
-            parmval = mymalloc(parmval_len+1);
-            snprintf(parmval, parmval_len,"%s",&cnt->conf.vid_control_params[parmval_st]);
-        }
-        if ((parmdesc != NULL) && (parmval  != NULL)){
-            vid_parms_add(vdevctx, parmdesc, parmval);
-            free(parmdesc);
-            free(parmval);
-            parmdesc = parmval = NULL;
-        }
-
-        if (parmdesc != NULL) free(parmdesc);
-        if (parmval  != NULL) free(parmval);
+        free(parms);
     }
 
     cnt->vdev->update_parms = FALSE;
@@ -635,6 +733,7 @@ int vid_parms_parse(struct context *cnt){
     return 0;
 
 }
+
 
 void vid_mutex_init(void)
 {

--- a/src/video_common.h
+++ b/src/video_common.h
@@ -24,7 +24,7 @@ struct video_dev {
     int                      norm;
     int                      width;
     int                      height;
-    unsigned long            frequency;
+    long                     frequency;
     int                      fps;
     int                      owner;
     int                      frames;

--- a/src/webu.c
+++ b/src/webu.c
@@ -717,7 +717,7 @@ static int webu_process_config_set(struct webui_ctx *webui) {
             /*If we are updating vid parms, set the flag to update the device.*/
             if (!strcmp(config_params[indx].param_name, "vid_control_params") &&
                 (webui->cntlst[webui->thread_nbr]->vdev != NULL)){
-                webui->cntlst[webui->thread_nbr]->vdev->update_parms = TRUE;
+                webui->cntlst[webui->thread_nbr]->vdev->update_params = TRUE;
             }
 
             /* If changing language, do it now */


### PR DESCRIPTION
- Add `netcam_params` and `netcam_high_params` options.
  - Allow user specification of any additional options to netcams.
- Implement a standard set of routines for parsing parameters provided for both video devices and netcams.
- Revise option names for consistency
  - `vid_control_params` => `video_params`
  - `mmalcam_control_params` => `mmalcam_params`
  - `videodevice` => `video_device`
  - `tunerdevice` => `tuner_device`
  - `netcam_highres` => `netcam_high_url`
- Conversion to use `video_params` for the following:
  - `v4l2_palette` => `video_params` option of `palette`
  - `input` => `video_params` option of `input`
  - `frequency` => `video_params` option of `frequency`
  - `norm` => `video_params` option of `norm` 
- Conversion to use `netcam_params` for the following:
  - `netcam_rate` => `netcam_params` option of `capture_rate`
  - `netcam_decoder` => `netcam_params` option of `decoder`
  - `netcam_use_tcp` => `netcam_params` option of `rtsp_transport` 
  - `netcam_proxy` => `netcam_params` option of `proxy`
  - `netcam_keepalive` => `netcam_params` option of `keepalive`
  - `netcam_tolerant_check` => `netcam_params` option of `tolerant_check`
 

