### PR TITLE
Corrected value for Content-type when getting current static JPG

### DIFF
--- a/src/webu_stream.c
+++ b/src/webu_stream.c
@@ -351,7 +351,7 @@ int webu_stream_static(struct webui_ctx *webui)
         return MHD_NO;
     }
 
-    response = MHD_create_response_from_buffer (webui->resp_size
+    response = MHD_create_response_from_buffer (webui->resp_used
         ,(void *)webui->resp_page, MHD_RESPMEM_MUST_COPY);
     if (!response) {
         MOTION_LOG(ERR, TYPE_STREAM, NO_ERRNO, _("Invalid response"));


### PR DESCRIPTION
This change is to correctly send back the right Content-length header for getting the current static JPG (/current).

The current code assumes that libmicrohttpd will allow overriding the header later in the process, but it does not validate that it actually accepted the override. According to libmicrohttpd documentation - Content-length is not allowed to be overriden on earlier version and in the most recent version it requires setting up and override flag to do so. However, the code structure around getting the static image is to get the image first, then setup the response element. Therefor, we already know the content-length value BEFORE we start working on the response and just use it directly.

Before the change:
% curl -vvv -m 10 -o temp.jpg http://192.168.1.45:8082/current
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 192.168.1.45...
* TCP_NODELAY set
* Connected to 192.168.1.45 (192.168.1.45) port 8082 (#0)
> GET /current HTTP/1.1
> Host: 192.168.1.45:8082
> User-Agent: curl/7.64.1
> Accept: */*
> 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0< HTTP/1.1 200 OK
< Connection: Keep-Alive
< Content-Length: 3110400
< Content-Type: image/jpeg;
< Date: Tue, 08 Dec 2020 19:32:06 GMT
< 
{ [10220 bytes data]
100 52882  100 3037k    0     0  440k      0 0:00:06 0:00:06 --:--:-- 564k
* Connection #0 to host 192.168.1.45 left intact
* Closing connection 0


After the change:
% curl -vvv -m 10 -o temp.jpg http://192.168.1.45:8082/current
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 192.168.1.45...
* TCP_NODELAY set
* Connected to 192.168.1.45 (192.168.1.45) port 8082 (#0)
> GET /current HTTP/1.1
> Host: 192.168.1.45:8082
> User-Agent: curl/7.64.1
> Accept: */*
> 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0< HTTP/1.1 200 OK
< Connection: Keep-Alive
< Content-Length: 52882
< Content-Type: image/jpeg;
< Date: Tue, 08 Dec 2020 19:34:16 GMT
< 
{ [2896 bytes data]
100 52882  100 52882    0     0  61419      0 --:--:-- --:--:-- --:--:-- 61348
* Connection #0 to host 192.168.1.45 left intact
* Closing connection 0