### PR TITLE
Accept status requests before motion loop has completed

### DIFF
--- a/src/webu.c
+++ b/src/webu.c
@@ -1389,12 +1389,6 @@ static mymhd_retcd webu_answer_strm(void *cls, struct MHD_Connection *connection
         return retcd;
     }
 
-    /* Do not answer a request until the motion loop has completed at least once */
-    if (webui->cnt->passflag == 0) {
-        MOTION_LOG(DBG, TYPE_STREAM, NO_ERRNO, _("Stream picture is not ready yet"));
-        return MHD_NO;
-    }
-
     if (webui->cnt->webcontrol_finish) {
         MOTION_LOG(DBG, TYPE_STREAM, NO_ERRNO, _("Stream is about to finish"));
         return MHD_NO;


### PR DESCRIPTION
Commit c568a40 added HTTP endpoints returning JSON objects describing
one or all cameras and their status. For monitoring it's crucial to have
status information available before a successful connection could be
made.

Modifications made while merging the changes lead to status requests
being terminated by closing the connection and writing "Stream picture
is not ready yet" to the log until the first camera context made
a successful run of the motion loop ("webui->cnt->passflag"). That's
never the case for the global status endpoint ("/status") in at least
the following setup where the test camera is unreachable:

$ cat > motion-test2.conf <<'EOF'
daemon off
setup_mode off
log_level 9
stream_port 8081
stream_localhost off
camera ./motion-test2-cam1.conf
EOF

$ cat > motion-test2-cam1.conf <<'EOF'
camera_name Test
netcam_url rtsp://127.0.0.1:9999/camera/specific/url
EOF

$ ./src/motion -n -c motion-test2.conf -m

$ curl -v http://127.0.0.1:8081/status.json

Signed-off-by: Michael Hanselmann <public@hansmi.ch>