### PR TITLE
Fix for movie_max_time handling

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -67,7 +67,8 @@ const char *eventList[] = {
     "EVENT_CAMERA_LOST",
     "EVENT_CAMERA_FOUND",
     "EVENT_FFMPEG_PUT",
-    "EVENT_LAST"
+    "EVENT_LAST",
+    "EVENT_MAX_MOVIE"
 };
 
 /**
@@ -877,8 +878,8 @@ static void event_new_video(struct context *cnt, motion_event eventtype
     (void)tv1;
 
     cnt->movie_last_shot = -1;
-
     cnt->movie_fps = cnt->lastrate;
+    cnt->movietime = tv1->tv_sec;
 
     MOTION_LOG(INF, TYPE_EVENTS, NO_ERRNO, _("Source FPS %d"), cnt->movie_fps);
 
@@ -1369,6 +1370,26 @@ struct event_handlers event_handlers[] = {
     {
     EVENT_CAMERA_FOUND,
     event_camera_found
+    },
+    {
+    EVENT_MAX_MOVIE,
+    event_ffmpeg_closefile
+    },
+    {
+    EVENT_MAX_MOVIE,
+    event_extpipe_end
+    },
+    {
+    EVENT_MAX_MOVIE,
+    event_new_video
+    },
+    {
+    EVENT_MAX_MOVIE,
+    event_ffmpeg_newfile
+    },
+    {
+    EVENT_MAX_MOVIE,
+    event_create_extpipe
     },
     {0, NULL}
 };

--- a/src/event.h
+++ b/src/event.h
@@ -47,6 +47,7 @@ typedef enum {
     EVENT_CAMERA_FOUND,
     EVENT_FFMPEG_PUT,
     EVENT_LAST,
+    EVENT_MAX_MOVIE,
 } motion_event;
 
 typedef void(* event_handler)(struct context *cnt, motion_event type, struct image_data *img_data,

--- a/src/motion.c
+++ b/src/motion.c
@@ -2431,8 +2431,8 @@ static void mlp_actions(struct context *cnt)
     /* Check for movie length */
     if ((cnt->conf.movie_max_time > 0) &&
         (cnt->event_nr == cnt->prev_event) &&
-        ((cnt->currenttime - cnt->eventtime) >= cnt->conf.movie_max_time)) {
-        cnt->event_stop = TRUE;
+        (cnt->current_image->timestamp_tv.tv_sec - cnt->movietime >= cnt->conf.movie_max_time)) {
+        event(cnt, EVENT_MAX_MOVIE, NULL, NULL, NULL, &cnt->current_image->timestamp_tv);
     }
 
     /* Check event gap */

--- a/src/motion.h
+++ b/src/motion.h
@@ -455,6 +455,7 @@ struct context {
     time_t currenttime;
     time_t lasttime;
     time_t eventtime;
+    time_t movietime;
     time_t connectionlosttime;               /* timestamp from connection lost */
 
     unsigned int lastrate;


### PR DESCRIPTION
Resolves: https://github.com/Motion-Project/motion/issues/1337
`max_movie_time` incorrectly triggered end of the whole event, while it only supposed to flush the current movie and start recording a new file.

This PR resolves this inconsistency by introducing a new contex timestamp of the movie recording start. As soon as current movie length exceeds the config value a new event will be triggered: `EVENT_MAX_MOVIE` which will close currently recording files and start a new one.

If the `event_gap` is longer than `max_movie_time` user should expect empty movie files to be created as there will be no motion frames to put in.

Examples of running the new code:

extpipe, gap 30, max movie 10:
```
12:07:44 motion[219941]: [1:ml1] [INF] [EVT] event_new_video: Source FPS 10
12:07:44 motion[219941]: [1:ml1] [NTC] [ALL] mycreate_path: creating directory .
12:07:44 motion[219941]: [1:ml1] [NTC] [EVT] event_create_extpipe: pipe: x264 - --input-res 640x480 --fps 10 --bitrate 2000 --preset ultrafast --quiet -o ./0-01-20210414120744.mp4
12:07:44 motion[219941]: [1:ml1] [NTC] [EVT] event_create_extpipe: cnt->moviefps: 10
12:07:44 motion[219941]: [1:ml1] [NTC] [EVT] event_newfile: File of type 8 saved to: ./0-01-20210414120744
12:07:44 motion[219941]: [1:ml1] [NTC] [ALL] motion_detected: Motion detected - starting event 1
12:07:54 motion[219941]: [1:ml1] [NTC] [EVT] event_extpipe_end: CLOSING: extpipe file desc 10, error state 0
12:07:54 motion[219941]: [1:ml1] [NTC] [EVT] event_extpipe_end: pclose return: -1
12:07:54 motion[219941]: [1:ml1] [INF] [EVT] event_new_video: Source FPS 10
12:07:54 motion[219941]: [1:ml1] [NTC] [ALL] mycreate_path: creating directory .
12:07:54 motion[219941]: [1:ml1] [NTC] [EVT] event_create_extpipe: pipe: x264 - --input-res 640x480 --fps 10 --bitrate 2000 --preset ultrafast --quiet -o ./0-01-20210414120754.mp4
12:07:54 motion[219941]: [1:ml1] [NTC] [EVT] event_create_extpipe: cnt->moviefps: 10
12:07:54 motion[219941]: [1:ml1] [NTC] [EVT] event_newfile: File of type 8 saved to: ./0-01-20210414120754
12:08:04 motion[219941]: [1:ml1] [NTC] [EVT] event_extpipe_end: CLOSING: extpipe file desc 10, error state 0
12:08:04 motion[219941]: [1:ml1] [NTC] [EVT] event_extpipe_end: pclose return: -1
12:08:04 motion[219941]: [1:ml1] [INF] [EVT] event_new_video: Source FPS 10
12:08:04 motion[219941]: [1:ml1] [NTC] [ALL] mycreate_path: creating directory .
12:08:04 motion[219941]: [1:ml1] [NTC] [EVT] event_create_extpipe: pipe: x264 - --input-res 640x480 --fps 10 --bitrate 2000 --preset ultrafast --quiet -o ./0-01-20210414120804.mp4
12:08:04 motion[219941]: [1:ml1] [NTC] [EVT] event_create_extpipe: cnt->moviefps: 10
12:08:04 motion[219941]: [1:ml1] [NTC] [EVT] event_newfile: File of type 8 saved to: ./0-01-20210414120804
12:08:14 motion[219941]: [1:ml1] [NTC] [EVT] event_extpipe_end: CLOSING: extpipe file desc 10, error state 0
12:08:14 motion[219941]: [1:ml1] [NTC] [EVT] event_extpipe_end: pclose return: -1
12:08:14 motion[219941]: [1:ml1] [INF] [EVT] event_new_video: Source FPS 10
12:08:14 motion[219941]: [1:ml1] [NTC] [ALL] mycreate_path: creating directory .
12:08:14 motion[219941]: [1:ml1] [NTC] [EVT] event_create_extpipe: pipe: x264 - --input-res 640x480 --fps 10 --bitrate 2000 --preset ultrafast --quiet -o ./0-01-20210414120814.mp4
12:08:14 motion[219941]: [1:ml1] [NTC] [EVT] event_create_extpipe: cnt->moviefps: 10
12:08:14 motion[219941]: [1:ml1] [NTC] [EVT] event_newfile: File of type 8 saved to: ./0-01-20210414120814
12:08:18 motion[219941]: [1:ml1] [NTC] [EVT] event_extpipe_end: CLOSING: extpipe file desc 10, error state 0
12:08:18 motion[219941]: [1:ml1] [NTC] [EVT] event_extpipe_end: pclose return: -1
12:08:18 motion[219941]: [1:ml1] [NTC] [ALL] mlp_actions: End of event 1
```

movie, gap 30, max movie 10:
```
12:04:58 motion[219417]: [1:ml1] [INF] [EVT] event_new_video: Source FPS 10
12:04:58 motion[219417]: [1:ml1] [INF] [ENC] ffmpeg_set_quality: libx264 codec vbr/crf/bit_rate: 28
12:04:58 motion[219417]: [1:ml1] [NTC] [EVT] event_newfile: File of type 8 saved to: ./0-02-20210414120457.mkv
12:04:58 motion[219417]: [1:ml1] [NTC] [ALL] motion_detected: Motion detected - starting event 2
12:05:07 motion[219417]: [1:ml1] [INF] [EVT] event_new_video: Source FPS 10
12:05:07 motion[219417]: [1:ml1] [INF] [ENC] ffmpeg_set_quality: libx264 codec vbr/crf/bit_rate: 28
12:05:07 motion[219417]: [1:ml1] [NTC] [EVT] event_newfile: File of type 8 saved to: ./0-02-20210414120507.mkv
12:05:17 motion[219417]: [1:ml1] [INF] [EVT] event_new_video: Source FPS 10
12:05:17 motion[219417]: [1:ml1] [INF] [ENC] ffmpeg_set_quality: libx264 codec vbr/crf/bit_rate: 28
12:05:17 motion[219417]: [1:ml1] [NTC] [EVT] event_newfile: File of type 8 saved to: ./0-02-20210414120517.mkv
12:05:27 motion[219417]: [1:ml1] [INF] [EVT] event_new_video: Source FPS 10
12:05:27 motion[219417]: [1:ml1] [INF] [ENC] ffmpeg_set_quality: libx264 codec vbr/crf/bit_rate: 28
12:05:27 motion[219417]: [1:ml1] [NTC] [EVT] event_newfile: File of type 8 saved to: ./0-02-20210414120527.mkv
12:05:37 motion[219417]: [1:ml1] [INF] [EVT] event_new_video: Source FPS 10
12:05:37 motion[219417]: [1:ml1] [INF] [ENC] ffmpeg_set_quality: libx264 codec vbr/crf/bit_rate: 28
12:05:37 motion[219417]: [1:ml1] [NTC] [EVT] event_newfile: File of type 8 saved to: ./0-02-20210414120537.mkv
12:05:45 motion[219417]: [1:ml1] [NTC] [ALL] mlp_actions: End of event 2

```