### PR TITLE
[doc] Added automake dependency install for MacOSX

### DIFF
--- a/doc/motion_build.html
+++ b/doc/motion_build.html
@@ -209,7 +209,7 @@
       </ul>
       Mac OS X
       <ul>
-          <code><strong>brew install ffmpeg pkg-config libjpeg libmicrohttpd</strong></code>
+          <code><strong>brew install ffmpeg pkg-config libjpeg libmicrohttpd automake</strong></code>
           <p></p>
           <code><strong>export PATH="/usr/local/opt/gettext/bin:/usr/local/bin:$PATH"</strong></code>
           <p></p>


### PR DESCRIPTION
This was missing on a default MacOSX 10.15.7 and the default brew install