### PR TITLE
User Specified Webcontrol and Stream Headers

### DIFF
--- a/doc/motion_config.html
+++ b/doc/motion_config.html
@@ -1117,7 +1117,7 @@
           <td align="left"></td>
           <td align="left"></td>
           <td align="left">stream_cors_header</td>
-          <td align="left"><a href="#stream_cors_header" >stream_cors_header</a></td>
+          <td align="left"><a href="#stream_header_params" >stream_header_params</a></td>
         </tr>
         <tr>
           <td align="left"></td>
@@ -1453,7 +1453,7 @@
           <td align="left"></td>
           <td align="left"></td>
           <td align="left">webcontrol_cors_header</td>
-          <td align="left"><a href="#webcontrol_cors_header" >webcontrol_cors_header</a></td>
+          <td align="left"><a href="#webcontrol_header_params" >webcontrol_header_params</a></td>
         </tr>
         <tr>
           <td align="left">webcontrol_html_output</td>
@@ -1893,7 +1893,7 @@
             <tr>
               <td bgcolor="#edf4f9" ><a href="#webcontrol_cert" >webcontrol_cert</a> </td>
               <td bgcolor="#edf4f9" ><a href="#webcontrol_key" >webcontrol_key</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#webcontrol_cors_header" >webcontrol_cors_header</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#webcontrol_header_params" >webcontrol_header_params</a> </td>
             </tr>
             </tbody>
         </table>
@@ -1922,7 +1922,7 @@
             </tr>
             <tr>
               <td bgcolor="#edf4f9" ><a href="#stream_tls" >stream_tls</a> </td>
-              <td bgcolor="#edf4f9" ><a href="#stream_cors_header" >stream_cors_header</a> </td>
+              <td bgcolor="#edf4f9" ><a href="#stream_header_params" >stream_header_params</a> </td>
               <td bgcolor="#edf4f9" ><a href="#stream_preview_scale" >stream_preview_scale</a> </td>
               <td bgcolor="#edf4f9" ><a href="#stream_preview_newline" >stream_preview_newline</a> </td>
             </tr>
@@ -5046,20 +5046,22 @@
         <p></p>
         <p></p>
 
-        <h3><a name="webcontrol_cors_header"></a> webcontrol_cors_header </h3>
+        <h3><a name="webcontrol_header_params"></a> webcontrol_header_params </h3>
         <p></p>
         <ul>
           <li> Type: String</li>
-          <li> Range / Valid values: * or a valid URI</li>
+          <li> Range / Valid values: Max 4095 characters</li>
           <li> Default: Not defined</li>
         </ul>
         <p></p>
-        The Access-Control-Allow-Origin header value to be sent with the webcontrol.
-        If unspecified, no Access-Control-Allow-Origin header is sent.
-        The header allows browsers to access the webcontrol via cross-origin resource sharing (CORS).
-        For example, * allows access from browser client code served from any origin.
+        Comma separated pairs for the header and value.  e.g.
         <p></p>
-
+        <code>webcontrol_header_params Access-Control-Allow-Origin=*, Cache-Control=no-cache</code>
+        <p></p>
+        When Motion parses this parameter, it will only show the values when <a href="#webcontrol_localhost">webcontrol_localhost</a> is
+        set to on.  When the <a href="#webcontrol_localhost">webcontrol_localhost</a> is set to off, the Motion log will redact the
+        values.
+        <p></p>
 
       </ul>
 
@@ -5199,19 +5201,23 @@
         <p></p>
         <p></p>
 
-        <h3><a name="stream_cors_header"></a> stream_cors_header </h3>
+        <h3><a name="stream_header_params"></a> stream_header_params</h3>
         <p></p>
         <ul>
           <li> Type: String</li>
-          <li> Range / Valid values: * or a valid URI</li>
+          <li> Range / Valid values: Max 4095 characters</li>
           <li> Default: Not defined</li>
         </ul>
         <p></p>
-        The Access-Control-Allow-Origin header value to be sent with the stream.
-        If unspecified, no Access-Control-Allow-Origin header is sent.
-        The header allows browsers to access the stream via cross-origin resource sharing (CORS).
-        For example, * allows access from browser client code served from any origin.
+        The comma separated pairs for header values sent with the stream. e.g.
+		    <p></p>
+        <code>stream_header_params Access-Control-Allow-Origin=*, Cache-Control=no-cache</code>
         <p></p>
+        When Motion parses this parameter, it will only show the values when <a href="#stream_localhost">stream_localhost</a> is
+        set to on.  When the <a href="#stream_localhost">stream_localhost</a> is set to off, the Motion log will redact the
+        values.
+        <p></p>
+
 
         <h3><a name="stream_preview_scale"></a> stream_preview_scale </h3>
         <p></p>

--- a/doc/motion_config.html
+++ b/doc/motion_config.html
@@ -5054,13 +5054,16 @@
           <li> Default: Not defined</li>
         </ul>
         <p></p>
-        Comma separated pairs for the header and value.  e.g.
+        User specified header(s) for the webcontrol.  The header/value pair is separated by an equal sign and multiple header/value
+        pairs are separated by commas.  If the header or value includes an equal sign or comma, then the header or value must be
+        enclosed in double quotes.  e.g.
         <p></p>
-        <code>webcontrol_header_params Access-Control-Allow-Origin=*, Cache-Control=no-cache</code>
+        <code>webcontrol_header_params Access-Control-Allow-Origin=*, Cache-Control="no-cache"</code>
         <p></p>
-        When Motion parses this parameter, it will only show the values when <a href="#webcontrol_localhost">webcontrol_localhost</a> is
-        set to on.  When the <a href="#webcontrol_localhost">webcontrol_localhost</a> is set to off, the Motion log will redact the
-        values.
+        When Motion parses this parameter, it only shows the values in the Motion log
+        when <a href="#webcontrol_localhost">webcontrol_localhost</a> is set to on.  When
+        the <a href="#webcontrol_localhost">webcontrol_localhost</a> is set to off, Motion
+        will redact the values in the log.
         <p></p>
 
       </ul>
@@ -5209,15 +5212,17 @@
           <li> Default: Not defined</li>
         </ul>
         <p></p>
-        The comma separated pairs for header values sent with the stream. e.g.
+        User specified header(s) for the stream.  The header/value pair is separated by an equal sign and multiple header/value
+        pairs are separated by commas.  If the header or value includes an equal sign or comma, then the header or value must be
+        enclosed in double quotes.  e.g.
+        <p></p>
+        <code>stream_header_params Access-Control-Allow-Origin=*, Cache-Control="no-cache"</code>
+        <p></p>
+        When Motion parses this parameter, it only shows the values in the Motion log
+        when <a href="#stream_localhost">stream_localhost</a> is set to on.  When
+        the <a href="#stream_localhost">stream_localhost</a> is set to off, Motion
+        will redact the values in the log.
 		    <p></p>
-        <code>stream_header_params Access-Control-Allow-Origin=*, Cache-Control=no-cache</code>
-        <p></p>
-        When Motion parses this parameter, it will only show the values when <a href="#stream_localhost">stream_localhost</a> is
-        set to on.  When the <a href="#stream_localhost">stream_localhost</a> is set to off, the Motion log will redact the
-        values.
-        <p></p>
-
 
         <h3><a name="stream_preview_scale"></a> stream_preview_scale </h3>
         <p></p>

--- a/man/motion.1
+++ b/man/motion.1
@@ -1485,7 +1485,7 @@ The full path to the SSL key file for webcontrol
 .RE
 
 .TP
-.B webcontrol_cors_header
+.B webcontrol_header_params
 .RS
 .nf
 Values: User specified string
@@ -1493,7 +1493,7 @@ Default: Not defined
 Description:
 .fi
 .RS
-The header to add for cross orgin on the webcontrol
+The comma separated header=value pairs to use for the webcontrol responses.
 .RE
 .RE
 
@@ -1569,7 +1569,7 @@ When specified as on, use SSL/TLS for the stream port.
 .RE
 
 .TP
-.B stream_cors_header
+.B stream_header_params
 .RS
 .nf
 Values: User specified string
@@ -1577,10 +1577,7 @@ Default: Not defined
 Description:
 .fi
 .RS
-The Access-Control-Allow-Origin header value to be sent with the stream.
-If unspecified, no Access-Control-Allow-Origin header is sent.
-The header allows browsers to access the stream via cross-origin resource sharing (CORS).
-For example, * allows access from browser client code served from any domain.
+The comma separated header=value pairs to send for the stream responses.
 .RE
 .RE
 

--- a/src/conf.c
+++ b/src/conf.c
@@ -2294,10 +2294,13 @@ static struct context **conf_process(struct context **cnt, FILE *fp)
                  * It is important that we can use "" so that we can use
                  * leading spaces in text_left and text_right.
                  */
-                if ((beg[0] == '"' && beg[strlen(beg)-1] == '"') ||
-                    (beg[0] == '\'' && beg[strlen(beg)-1] == '\'')) {
-                    beg[strlen(beg)-1] = '\0';
-                    beg++;
+                /* For the config values of params we leave on the quotes */
+                if (strstr(cmd, "params") == NULL) {
+                    if ((beg[0] == '"' && beg[strlen(beg)-1] == '"') ||
+                        (beg[0] == '\'' && beg[strlen(beg)-1] == '\'')) {
+                        beg[strlen(beg)-1] = '\0';
+                        beg++;
+                    }
                 }
 
                 arg1 = beg; /* Argument starts here */

--- a/src/conf.c
+++ b/src/conf.c
@@ -175,7 +175,7 @@ struct config conf_template = {
     .webcontrol_tls =                  FALSE,
     .webcontrol_cert =                 NULL,
     .webcontrol_key =                  NULL,
-    .webcontrol_cors_header =          NULL,
+    .webcontrol_header_params =        NULL,
 
     /* Live stream configuration parameters */
     .stream_port =                     0,
@@ -183,7 +183,7 @@ struct config conf_template = {
     .stream_auth_method =              0,
     .stream_authentication =           NULL,
     .stream_tls =                      FALSE,
-    .stream_cors_header =              NULL,
+    .stream_header_params =            NULL,
     .stream_preview_scale =            25,
     .stream_preview_newline =          FALSE,
     .stream_preview_method =           0,
@@ -219,6 +219,8 @@ static struct context **copy_bool(struct context **cnt, const char *str, int val
 static struct context **copy_int(struct context **cnt, const char *str, int val_ptr);
 static struct context **copy_video_params(struct context **cnt, const char *config_val, int config_indx);
 static struct context **copy_netcam_params(struct context **cnt, const char *config_val, int config_indx);
+static struct context **copy_webcontrol_header(struct context **cnt, const char *config_val, int config_indx);
+static struct context **copy_stream_header(struct context **cnt, const char *config_val, int config_indx);
 static struct context **copy_text_double(struct context **cnt, const char *str, int val_ptr);
 static struct context **copy_html_output(struct context **cnt, const char *str, int val_ptr);
 
@@ -1186,11 +1188,11 @@ config_param config_params[] = {
     WEBUI_LEVEL_RESTRICTED
     },
     {
-    "webcontrol_cors_header",
-    "# The cross-origin resource sharing (CORS) header for webcontrol",
+    "webcontrol_header_params",
+    "# The header parameters for webcontrol",
     0,
-    CONF_OFFSET(webcontrol_cors_header),
-    copy_uri,
+    CONF_OFFSET(webcontrol_header_params),
+    copy_string,
     print_string,
     WEBUI_LEVEL_RESTRICTED
     },
@@ -1244,11 +1246,11 @@ config_param config_params[] = {
     WEBUI_LEVEL_RESTRICTED
     },
     {
-    "stream_cors_header",
-    "# The cross-origin resource sharing (CORS) header for the stream",
+    "stream_header_params",
+    "# The header parameters for the stream",
     0,
-    CONF_OFFSET(stream_cors_header),
-    copy_uri,
+    CONF_OFFSET(stream_header_params),
+    copy_string,
     print_string,
     WEBUI_LEVEL_RESTRICTED
     },
@@ -2049,6 +2051,22 @@ dep_config_param dep_config_params[] = {
     "netcam_high_url",
     copy_string
     },
+    {
+    "webcontrol_cors_header",
+    "4.3.2",
+    "\"webcontrol_cors_header\" replaced with \"webcontrol_header_params\"",
+    CONF_OFFSET(webcontrol_header_params),
+    "webcontrol_header_params",
+    copy_string
+    },
+    {
+    "stream_cors_header",
+    "4.3.2",
+    "\"stream_cors_header\" replaced with \"stream_header_params\"",
+    CONF_OFFSET(stream_header_params),
+    "stream_header_params",
+    copy_string
+    },
 
     { NULL, NULL, NULL, 0, NULL, NULL}
 };
@@ -2212,6 +2230,12 @@ struct context **conf_cmdparse(struct context **cnt, const char *cmd, const char
                     mystreq(dep_config_params[i].name,"netcam_keepalive")) {
                     cnt = copy_netcam_params(cnt, arg1, i);
 
+                } else if (mystreq(dep_config_params[i].name,"webcontrol_cors_header"))  {
+                    cnt = copy_webcontrol_header(cnt, arg1, i);
+
+                } else if (mystreq(dep_config_params[i].name,"stream_cors_header"))  {
+                    cnt = copy_stream_header(cnt, arg1, i);
+
                 } else {
                     cnt = dep_config_params[i].copy(cnt, arg1, dep_config_params[i].conf_value);
                 }
@@ -2294,7 +2318,10 @@ static struct context **conf_process(struct context **cnt, FILE *fp)
                  * It is important that we can use "" so that we can use
                  * leading spaces in text_left and text_right.
                  */
-                /* For the config values of params we leave on the quotes */
+                /* For the config values of 'params' we leave on the quotes.
+                 * These parameters use the util_parms_parse routine that
+                 * will strip away the quotes if they are there
+                 */
                 if (strstr(cmd, "params") == NULL) {
                     if ((beg[0] == '"' && beg[strlen(beg)-1] == '"') ||
                         (beg[0] == '\'' && beg[strlen(beg)-1] == '\'')) {
@@ -2602,10 +2629,10 @@ void conf_output_parms(struct context **cnt)
                 if (!strncmp(name, "netcam_url", 10) ||
                     !strncmp(name, "netcam_userpass", 15) ||
                     !strncmp(name, "netcam_highres", 14) ||
-                    !strncmp(name, "stream_cors_header", 18) ||
+                    !strncmp(name, "stream_header_params", 20) ||
                     !strncmp(name, "stream_authentication", 21) ||
                     !strncmp(name, "webcontrol_authentication", 25) ||
-                    !strncmp(name, "webcontrol_cors_header", 22) ||
+                    !strncmp(name, "webcontrol_header_params", 24) ||
                     !strncmp(name, "webcontrol_key", 14) ||
                     !strncmp(name, "webcontrol_cert", 15) ||
                     !strncmp(name, "database_user", 13) ||
@@ -2647,8 +2674,7 @@ static void malloc_strings(struct context *cnt)
     unsigned int i = 0;
     char **val;
     while (config_params[i].param_name != NULL) {
-        if (config_params[i].copy == copy_string ||
-            config_params[i].copy == copy_uri) {
+        if (config_params[i].copy == copy_string) {
             /* if member is a string */
             /* val is made to point to a pointer to the current string. */
             val = (char **)((char *)cnt+config_params[i].conf_value);
@@ -3005,6 +3031,142 @@ static struct context **copy_netcam_params(struct context **cnt, const char *con
 }
 
 /**
+ * copy_webcontrol_header
+ *      Assigns a new string value to a config option.
+ * Returns context struct.
+ */
+static struct context **copy_webcontrol_header(struct context **cnt, const char *config_val, int config_indx)
+{
+
+    int i, indx;
+    int parm_len;
+    char *orig_parm, *parm_new;
+
+    indx = 0;
+    while (config_params[indx].param_name != NULL) {
+        if (mystreq(config_params[indx].param_name,"webcontrol_header_params")) {
+            break;
+        }
+        indx++;
+    }
+
+    if (mystrne(config_params[indx].param_name,"webcontrol_header_params")) {
+        MOTION_LOG(ALR, TYPE_ALL, NO_ERRNO
+            ,_("Unable to locate webcontrol_header_params"));
+        return cnt;
+    }
+
+    if (config_val == NULL) {
+        MOTION_LOG(ALR, TYPE_ALL, NO_ERRNO
+            ,_("No value provided to put into webcontrol_header_params"));
+        return cnt;
+    }
+
+    if (mystreq(dep_config_params[config_indx].name,"webcontrol_cors_header")) {
+        parm_len = strlen("Access-Control-Allow-Origin") + strlen(config_val) + 2;
+        parm_new = mymalloc(parm_len);
+        snprintf(parm_new, parm_len, "%s=%s"
+            ,"Access-Control-Allow-Origin", config_val);
+    } else {
+        return cnt;
+    }
+
+    /* Recall that the current parms have already been processed by time this is called */
+    i = -1;
+    while (cnt[++i]) {
+        if (cnt[i]->conf.webcontrol_header_params != NULL) {
+            parm_len =  strlen(cnt[i]->conf.webcontrol_header_params) + 1;
+            orig_parm = mymalloc(parm_len);
+            snprintf(orig_parm,parm_len,"%s",cnt[i]->conf.webcontrol_header_params);
+
+            parm_len = strlen(parm_new) + strlen(orig_parm) + 2;
+
+            free(cnt[i]->conf.webcontrol_header_params);
+            cnt[i]->conf.webcontrol_header_params = mymalloc(parm_len);
+            snprintf(cnt[i]->conf.webcontrol_header_params, parm_len, "%s,%s",parm_new, orig_parm);
+
+            free(orig_parm);
+        } else {
+            parm_len = strlen(parm_new) + 1;
+            cnt[i]->conf.webcontrol_header_params = mymalloc(parm_len);
+            snprintf(cnt[i]->conf.webcontrol_header_params, parm_len, "%s", parm_new);
+        }
+    }
+
+    free(parm_new);
+
+    return cnt;
+}
+
+/**
+ * copy_stream_header
+ *      Assigns a new string value to a config option.
+ * Returns context struct.
+ */
+static struct context **copy_stream_header(struct context **cnt, const char *config_val, int config_indx)
+{
+
+    int i, indx;
+    int parm_len;
+    char *orig_parm, *parm_new;
+
+    indx = 0;
+    while (config_params[indx].param_name != NULL) {
+        if (mystreq(config_params[indx].param_name,"stream_header_params")) {
+            break;
+        }
+        indx++;
+    }
+
+    if (mystrne(config_params[indx].param_name,"stream_header_params")) {
+        MOTION_LOG(ALR, TYPE_ALL, NO_ERRNO
+            ,_("Unable to locate stream_header_params"));
+        return cnt;
+    }
+
+    if (config_val == NULL) {
+        MOTION_LOG(ALR, TYPE_ALL, NO_ERRNO
+            ,_("No value provided to put into stream_header_params"));
+        return cnt;
+    }
+
+    if (mystreq(dep_config_params[config_indx].name,"stream_cors_header")) {
+        parm_len = strlen("Access-Control-Allow-Origin") + strlen(config_val) + 2;
+        parm_new = mymalloc(parm_len);
+        snprintf(parm_new, parm_len, "%s=%s"
+            ,"Access-Control-Allow-Origin", config_val);
+    } else {
+        return cnt;
+    }
+
+    /* Recall that the current parms have already been processed by time this is called */
+    i = -1;
+    while (cnt[++i]) {
+        if (cnt[i]->conf.stream_header_params != NULL) {
+            parm_len =  strlen(cnt[i]->conf.stream_header_params) + 1;
+            orig_parm = mymalloc(parm_len);
+            snprintf(orig_parm,parm_len,"%s",cnt[i]->conf.stream_header_params);
+
+            parm_len = strlen(parm_new) + strlen(orig_parm) + 2;
+
+            free(cnt[i]->conf.stream_header_params);
+            cnt[i]->conf.stream_header_params = mymalloc(parm_len);
+            snprintf(cnt[i]->conf.stream_header_params, parm_len, "%s,%s",parm_new, orig_parm);
+
+            free(orig_parm);
+        } else {
+            parm_len = strlen(parm_new) + 1;
+            cnt[i]->conf.stream_header_params = mymalloc(parm_len);
+            snprintf(cnt[i]->conf.stream_header_params, parm_len, "%s", parm_new);
+        }
+    }
+
+    free(parm_new);
+
+    return cnt;
+}
+
+/**
  * copy_text_double
  *      Converts the bool of text_double to a 1 or 2 in text_scale
  * Returns context struct.
@@ -3061,33 +3223,6 @@ static struct context **copy_html_output(struct context **cnt, const char *str, 
     return cnt;
 }
 
-struct context **copy_uri(struct context **cnt, const char *str, int val)
-{
-
-    const char *regex_str = "(http|https)://(((.*):(.*))@)?([^/:]|[-_.a-z0-9]+)(:([0-9]+))?($|(/[^*]*))";
-
-    regex_t regex;
-    if (regcomp(&regex, regex_str, REG_EXTENDED) != 0) {
-        MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO
-            ,_("Error compiling regex in copy_uri"));
-        return cnt;
-    }
-
-    // A single asterisk is also valid, so check for that.
-    // Getting a perfect regex for all the uri's that are possible is
-    // almost impossible so if it fails, we warn the user but still accept
-    // that they know what they typed and move on.
-    if (mystrne(str, "*") && regexec(&regex, str, 0, NULL, 0) == REG_NOMATCH) {
-        MOTION_LOG(WRN, TYPE_ALL, NO_ERRNO
-            ,_("The CORS header may not be valid %s"),str);
-    }
-
-    regfree(&regex);
-    cnt = copy_string(cnt, str, val);
-    return cnt;
-
-}
-
 /**
  * config_type
  *      Returns a pointer to string containing value the type of config parameter passed.
@@ -3104,9 +3239,6 @@ const char *config_type(config_param *configparam)
     }
     if (configparam->copy == copy_bool) {
         return "bool";
-    }
-    if (configparam->copy == copy_uri) {
-        return "uri";
     }
 
     return "unknown";
@@ -3493,13 +3625,13 @@ static void config_parms_intl()
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","webcontrol_tls",_("webcontrol_tls"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","webcontrol_cert",_("webcontrol_cert"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","webcontrol_key",_("webcontrol_key"));
-        MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","webcontrol_cors_header",_("webcontrol_cors_header"));
+        MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","webcontrol_header_params",_("webcontrol_header_params"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","stream_port",_("stream_port"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","stream_localhost",_("stream_localhost"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","stream_auth_method",_("stream_auth_method"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","stream_authentication",_("stream_authentication"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","stream_tls",_("stream_tls"));
-        MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","stream_cors_header",_("stream_cors_header"));
+        MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","stream_header_params",_("stream_header_params"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","stream_preview_scale",_("stream_preview_scale"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","stream_preview_newline",_("stream_preview_newline"));
         MOTION_LOG(DBG, TYPE_ALL, NO_ERRNO,"%s:%s","stream_preview_method",_("stream_preview_method"));

--- a/src/conf.h
+++ b/src/conf.h
@@ -158,7 +158,7 @@ struct config {
     int             webcontrol_tls;
     const char      *webcontrol_cert;
     const char      *webcontrol_key;
-    const char      *webcontrol_cors_header;
+    char            *webcontrol_header_params;
 
     /* Live stream configuration parameters */
     int             stream_port;
@@ -166,7 +166,7 @@ struct config {
     int             stream_auth_method;
     const char      *stream_authentication;
     int             stream_tls;
-    const char      *stream_cors_header;
+    char            *stream_header_params;
     int             stream_preview_scale;
     int             stream_preview_newline;
     int             stream_preview_method;

--- a/src/motion.c
+++ b/src/motion.c
@@ -318,7 +318,6 @@ static void context_destroy(struct context *cnt)
     /* Free memory allocated for config parameters */
     for (j = 0; config_params[j].param_name != NULL; j++) {
         if (config_params[j].copy == copy_string ||
-            config_params[j].copy == copy_uri ||
             config_params[j].copy == read_camera_dir) {
             void **val;
             val = (void *)((char *)cnt+(int)config_params[j].conf_value);

--- a/src/motion.h
+++ b/src/motion.h
@@ -24,7 +24,7 @@
 #ifndef _INCLUDE_MOTION_H
 #define _INCLUDE_MOTION_H
 
-/* Forward declarations, used in functional definitions of headers */
+/* Forward declarations of structs */
 struct images;
 struct image_data;
 struct rtsp_context;
@@ -558,6 +558,9 @@ struct context {
     struct stream_data  stream_sub;     /* Copy of the image to use for web stream*/
     struct stream_data  stream_motion;  /* Copy of the image to use for web stream*/
     struct stream_data  stream_source;  /* Copy of the image to use for web stream*/
+
+    struct params_context    *webcontrol_headers;  /* Headers for webcontrol */
+    struct params_context    *stream_headers;  /* Headers for stream */
 
 
 };

--- a/src/netcam.c
+++ b/src/netcam.c
@@ -669,7 +669,7 @@ int netcam_start(struct context *cnt)
 
     netcam->parameters = mymalloc(sizeof(struct params_context));
     netcam->parameters->update_params = TRUE;
-    util_parms_parse(netcam->parameters, (char*)cnt->conf.netcam_params);
+    util_parms_parse(netcam->parameters, (char*)cnt->conf.netcam_params, TRUE);
     util_parms_add_default(netcam->parameters,"proxy","NULL");
     util_parms_add_default(netcam->parameters,"keepalive","off");
     util_parms_add_default(netcam->parameters,"tolerant_check","off"); /*false*/

--- a/src/netcam_rtsp.c
+++ b/src/netcam_rtsp.c
@@ -1465,14 +1465,14 @@ static void netcam_rtsp_set_parms (struct context *cnt, struct rtsp_context *rts
         snprintf(rtsp_data->cameratype,29, "%s",_("highres"));
         rtsp_data->parameters = mymalloc(sizeof(struct params_context));
         rtsp_data->parameters->update_params = TRUE;
-        util_parms_parse(rtsp_data->parameters,(char*)cnt->conf.netcam_high_params);
+        util_parms_parse(rtsp_data->parameters,(char*)cnt->conf.netcam_high_params, TRUE);
     } else {
         rtsp_data->imgsize.width = cnt->conf.width;
         rtsp_data->imgsize.height = cnt->conf.height;
         snprintf(rtsp_data->cameratype,29, "%s",_("norm"));
         rtsp_data->parameters = mymalloc(sizeof(struct params_context));
         rtsp_data->parameters->update_params = TRUE;
-        util_parms_parse(rtsp_data->parameters, (char*)cnt->conf.netcam_params);
+        util_parms_parse(rtsp_data->parameters, (char*)cnt->conf.netcam_params, TRUE);
     }
     MOTION_LOG(INF, TYPE_NETCAM, NO_ERRNO
         ,_("Setting up %s stream."),rtsp_data->cameratype);

--- a/src/util.c
+++ b/src/util.c
@@ -716,7 +716,7 @@ void util_trim(char *parm)
  * Add the parsed out parameter and value to the control array.
 */
 static void util_parms_add(struct params_context *parameters
-            , const char *parm_nm, const char *parm_vl)
+            , const char *parm_nm, const char *parm_vl, int logmsg)
 {
     int indx, retcd;
 
@@ -735,7 +735,11 @@ static void util_parms_add(struct params_context *parameters
         parameters->params_array[indx].param_name = (char*)mymalloc(strlen(parm_nm)+1);
         retcd = sprintf(parameters->params_array[indx].param_name,"%s",parm_nm);
         if (retcd < 0) {
-            MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error setting parm >%s<"),parm_nm);
+            if (logmsg) {
+                MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error setting parm >%s<"),parm_nm);
+            } else {
+                MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error setting parm >redacted<"));
+            }
             free(parameters->params_array[indx].param_name);
             parameters->params_array[indx].param_name = NULL;
         }
@@ -747,7 +751,11 @@ static void util_parms_add(struct params_context *parameters
         parameters->params_array[indx].param_value = (char*)mymalloc(strlen(parm_vl)+1);
         retcd = sprintf(parameters->params_array[indx].param_value,"%s",parm_vl);
         if (retcd < 0) {
-            MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error setting parm >%s<"),parm_vl);
+            if (logmsg) {
+                MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error setting parm >%s<"),parm_vl);
+            } else {
+                MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error setting parm >redacted<"));
+            }
             free(parameters->params_array[indx].param_value);
             parameters->params_array[indx].param_value = NULL;
         }
@@ -755,17 +763,21 @@ static void util_parms_add(struct params_context *parameters
         parameters->params_array[indx].param_value = NULL;
     }
 
-    MOTION_LOG(INF, TYPE_ALL, NO_ERRNO,_("Parsed: >%s< >%s<")
-        ,parameters->params_array[indx].param_name
-        ,parameters->params_array[indx].param_value);
-
+    if (logmsg) {
+        MOTION_LOG(INF, TYPE_ALL, NO_ERRNO,_("Parsed: >%s< >%s<")
+            ,parameters->params_array[indx].param_name
+            ,parameters->params_array[indx].param_value);
+    } else {
+        MOTION_LOG(INF, TYPE_ALL, NO_ERRNO,_("Parsed: >redacted< >redacted<"));
+    }
 }
 
 /* util_parms_extract
  * Extract out of the configuration string the name and values at the location specified.
 */
 static void util_parms_extract(struct params_context *parameters, char *parmlne
-            , size_t indxnm_st, size_t indxnm_en, size_t indxvl_st, size_t indxvl_en)
+            , size_t indxnm_st, size_t indxnm_en, size_t indxvl_st, size_t indxvl_en
+            , int logmsg)
 {
     char *parm_nm, *parm_vl;
     int retcd, chksz;
@@ -787,7 +799,11 @@ static void util_parms_extract(struct params_context *parameters, char *parmlne
         chksz = indxnm_en - indxnm_st + 2;
         retcd = snprintf(parm_nm, chksz, "%s", parmlne + indxnm_st);
         if (retcd < 0) {
-            MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error parsing parm_nm controls: %s"), parmlne);
+            if (logmsg) {
+                MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error parsing parm_nm controls: %s"), parmlne);
+            } else {
+                MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error parsing parm_nm controls: <redacted>"));
+            }
             free(parm_nm);
             parm_nm = NULL;
         }
@@ -795,7 +811,11 @@ static void util_parms_extract(struct params_context *parameters, char *parmlne
         chksz = indxvl_en - indxvl_st + 2;
         retcd = snprintf(parm_vl, chksz, "%s", parmlne + indxvl_st);
         if (retcd < 0) {
-            MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error parsing parm_vl controls: %s"), parmlne);
+            if (logmsg) {
+                MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error parsing parm_vl controls: %s"), parmlne);
+            } else {
+                MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error parsing parm_vl controls: <redacted>"));
+            }
             free(parm_vl);
             parm_vl = NULL;
         }
@@ -803,7 +823,7 @@ static void util_parms_extract(struct params_context *parameters, char *parmlne
         util_trim(parm_nm);
         util_trim(parm_vl);
 
-        util_parms_add(parameters, parm_nm, parm_vl);
+        util_parms_add(parameters, parm_nm, parm_vl, logmsg);
 
         if (parm_nm != NULL) {
             free(parm_nm);
@@ -819,7 +839,7 @@ static void util_parms_extract(struct params_context *parameters, char *parmlne
  * Remove the parameter parsed out in previous steps from the parms string
  * and set up the string for parsing out the next parameter.
 */
-static void util_parms_next(char *parmlne, size_t indxpr_st, size_t indxpr_en)
+static void util_parms_next(char *parmlne, size_t indxpr_st, size_t indxpr_en, int logmsg)
 {
     char *parm_tmp;
     int retcd;
@@ -833,7 +853,11 @@ static void util_parms_next(char *parmlne, size_t indxpr_st, size_t indxpr_en)
     parm_tmp = mymalloc(PATH_MAX);
     retcd = snprintf(parm_tmp, PATH_MAX, "%s", parmlne);
     if (retcd < 0) {
-        MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error setting temp: %s"), parmlne);
+        if (logmsg) {
+            MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error setting temp: %s"), parmlne);
+        } else {
+            MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error setting temp: <redacted>"));
+        }
         free(parm_tmp);
         return;
     }
@@ -855,8 +879,13 @@ static void util_parms_next(char *parmlne, size_t indxpr_st, size_t indxpr_en)
                 , parm_tmp + indxpr_en + 1);
         }
     }
+
     if (retcd < 0) {
-        MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error reparsing controls: %s"), parmlne);
+        if (logmsg) {
+            MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error reparsing controls: %s"), parmlne);
+        } else {
+            MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO,_("Error reparsing controls: <redacted>"));
+        }
     }
 
     free(parm_tmp);
@@ -866,7 +895,7 @@ static void util_parms_next(char *parmlne, size_t indxpr_st, size_t indxpr_en)
 /* util_parms_parse_qte
  * Split out the parameters that have quotes around the name.
 */
-static void util_parms_parse_qte(struct params_context *parameters, char *parmlne)
+static void util_parms_parse_qte(struct params_context *parameters, char *parmlne, int logmsg)
 {
     size_t indxnm_st, indxnm_en, indxvl_st, indxvl_en;
     size_t indxcm, indxeq, indxqte_st, indxqte_en;
@@ -959,15 +988,15 @@ static void util_parms_parse_qte(struct params_context *parameters, char *parmln
             indxpr_en = strlen(parmlne);
         }
 
-        util_parms_extract(parameters, parmlne, indxnm_st, indxnm_en, indxvl_st, indxvl_en);
-        util_parms_next(parmlne, indxpr_st, indxpr_en);
+        util_parms_extract(parameters, parmlne, indxnm_st, indxnm_en, indxvl_st, indxvl_en, logmsg);
+        util_parms_next(parmlne, indxpr_st, indxpr_en, logmsg);
     }
 }
 
 /* util_parms_parse_comma
  * Split out the parameters between the commas.
 */
-static void util_parms_parse_comma(struct params_context *parameters, char *parmlne)
+static void util_parms_parse_comma(struct params_context *parameters, char *parmlne, int logmsg)
 {
     size_t indxnm_st, indxnm_en, indxvl_st, indxvl_en;
 
@@ -981,8 +1010,8 @@ static void util_parms_parse_comma(struct params_context *parameters, char *parm
             indxnm_en = strcspn(parmlne, "=") - 1;
             indxvl_st = indxnm_en + 2;
         }
-        util_parms_extract(parameters, parmlne, indxnm_st, indxnm_en, indxvl_st, indxvl_en);
-        util_parms_next(parmlne, indxnm_st, indxvl_en + 1);
+        util_parms_extract(parameters, parmlne, indxnm_st, indxnm_en, indxvl_st, indxvl_en, logmsg);
+        util_parms_next(parmlne, indxnm_st, indxvl_en + 1, logmsg);
     }
 
 }
@@ -1022,7 +1051,7 @@ void util_parms_free(struct params_context *parameters)
 /* util_parms_parse
  * Parse the user provided string of parameters into a array.
 */
-void util_parms_parse(struct params_context *parameters, char *confparm)
+void util_parms_parse(struct params_context *parameters, char *confparm, int logmsg)
 {
     /* Parse through the configuration option to get values
      * The values are separated by commas but may also have
@@ -1041,22 +1070,31 @@ void util_parms_parse(struct params_context *parameters, char *confparm)
     parmlne = NULL;
 
     if (confparm != NULL) {
-        MOTION_LOG(INF, TYPE_ALL, NO_ERRNO
-            ,_("Parsing controls: %s"), confparm);
-
+        if (logmsg) {
+            MOTION_LOG(INF, TYPE_ALL, NO_ERRNO
+                ,_("Parsing controls: %s"), confparm);
+        } else {
+            MOTION_LOG(INF, TYPE_ALL, NO_ERRNO
+                ,_("Parsing controls: <redacted>"));
+        }
         parmlne = mymalloc(PATH_MAX);
 
         retcd = snprintf(parmlne, PATH_MAX, "%s", confparm);
         if ((retcd < 0) || (retcd > PATH_MAX)) {
-            MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO
-                ,_("Error parsing controls: %s"), confparm);
+            if (logmsg) {
+                MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO
+                    ,_("Error parsing controls: %s"), confparm);
+            } else {
+                MOTION_LOG(ERR, TYPE_ALL, NO_ERRNO
+                    ,_("Error parsing controls: <redacted>"));
+            }
             free(parmlne);
             return;
         }
 
-        util_parms_parse_qte(parameters, parmlne);
+        util_parms_parse_qte(parameters, parmlne, logmsg);
 
-        util_parms_parse_comma(parameters, parmlne);
+        util_parms_parse_comma(parameters, parmlne, logmsg);
 
         if (strlen(parmlne) != 0) {
             indxnm_st = 0;
@@ -1068,7 +1106,7 @@ void util_parms_parse(struct params_context *parameters, char *confparm)
                 indxvl_st = indxnm_en + 2;
             }
 
-            util_parms_extract(parameters, parmlne, indxnm_st, indxnm_en, indxvl_st, indxvl_en);
+            util_parms_extract(parameters, parmlne, indxnm_st, indxnm_en, indxvl_st, indxvl_en, logmsg);
         }
         free(parmlne);
     }
@@ -1089,7 +1127,7 @@ void util_parms_add_default(struct params_context *parameters, const char *parm_
         }
     }
     if (dflt == TRUE) {
-        util_parms_add(parameters, parm_nm, parm_vl);
+        util_parms_add(parameters, parm_nm, parm_vl, TRUE);
     }
 
 }

--- a/src/util.h
+++ b/src/util.h
@@ -114,7 +114,7 @@ void util_threadname_get(char *threadname);
 int util_check_passthrough(struct context *cnt);
 void util_trim(char *parm);
 void util_parms_free(struct params_context *parameters);
-void util_parms_parse(struct params_context *parameters, char *confparm);
+void util_parms_parse(struct params_context *parameters, char *confparm, int logmsg);
 void util_parms_add_default(struct params_context *parameters, const char *parm_nm, const char *parm_vl);
 void util_parms_update(struct params_context *params, struct context *cnt, const char *cfgitm);
 

--- a/src/video_common.c
+++ b/src/video_common.c
@@ -514,7 +514,7 @@ void vid_parms_parse(struct context *cnt)
     }
 
     /* Put in the user specified parameters */
-    util_parms_parse(cnt->vdev, cnt->conf.video_params);
+    util_parms_parse(cnt->vdev, cnt->conf.video_params, TRUE);
 
     /* Now add any missing default items */
     util_parms_add_default(cnt->vdev,"palette","17");

--- a/src/webu_stream.c
+++ b/src/webu_stream.c
@@ -297,6 +297,7 @@ mymhd_retcd webu_stream_mjpeg(struct webui_ctx *webui)
     /* Create the stream for the motion jpeg */
     mymhd_retcd retcd;
     struct MHD_Response *response;
+    int indx;
 
     if (webu_stream_checks(webui) == -1) {
         return MHD_NO;
@@ -315,9 +316,16 @@ mymhd_retcd webu_stream_mjpeg(struct webui_ctx *webui)
         return MHD_NO;
     }
 
-    if (webui->cnt->conf.stream_cors_header != NULL) {
-        MHD_add_response_header (response, MHD_HTTP_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN
-            , webui->cnt->conf.stream_cors_header);
+    for (indx = 0; indx < webui->cnt->stream_headers->params_count; indx++) {
+        retcd = MHD_add_response_header (response
+            , webui->cnt->stream_headers->params_array[indx].param_name
+            , webui->cnt->stream_headers->params_array[indx].param_value);
+        if (retcd == MHD_NO) {
+            MOTION_LOG(ERR, TYPE_STREAM, NO_ERRNO
+                , _("Error adding stream header %s %s")
+                , webui->cnt->stream_headers->params_array[indx].param_name
+                , webui->cnt->stream_headers->params_array[indx].param_value);
+        }
     }
 
     MHD_add_response_header (response, MHD_HTTP_HEADER_CONTENT_TYPE
@@ -335,6 +343,7 @@ mymhd_retcd webu_stream_static(struct webui_ctx *webui)
     mymhd_retcd retcd;
     struct MHD_Response *response;
     char resp_used[20];
+    int indx;
 
     if (webu_stream_checks(webui) == -1) {
         return MHD_NO;
@@ -358,9 +367,16 @@ mymhd_retcd webu_stream_static(struct webui_ctx *webui)
         return MHD_NO;
     }
 
-    if (webui->cnt->conf.stream_cors_header != NULL) {
-        MHD_add_response_header (response, MHD_HTTP_HEADER_ACCESS_CONTROL_ALLOW_ORIGIN
-            , webui->cnt->conf.stream_cors_header);
+    for (indx = 0; indx < webui->cnt->stream_headers->params_count; indx++) {
+        retcd = MHD_add_response_header (response
+            , webui->cnt->stream_headers->params_array[indx].param_name
+            , webui->cnt->stream_headers->params_array[indx].param_value);
+        if (retcd == MHD_NO) {
+            MOTION_LOG(ERR, TYPE_STREAM, NO_ERRNO
+                , _("Error adding stream header %s %s")
+                , webui->cnt->stream_headers->params_array[indx].param_name
+                , webui->cnt->stream_headers->params_array[indx].param_value);
+        }
     }
 
     MHD_add_response_header (response, MHD_HTTP_HEADER_CONTENT_TYPE, "image/jpeg");


### PR DESCRIPTION
Adjust the parse routines to allow for both quoted names and quoted values.

Transition `webcontrol_cors_header` to `webcontrol_header_params`

Transition `stream_cors_header` to `stream_header_parms`

Closes #1330 
 