### PR TITLE
Update the IRC link.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ configuration or use of Motion, we have the following additional resources which
 
   * User guide:  [Motion User Guide](https://motion-project.github.io/motion_guide.html)
   * User Group List:  Please sign-up and send your issue to the list [Motion User](https://lists.sourceforge.net/lists/listinfo/motion-user)  
-  * IRC:  [#motion](irc://chat.freenode.net/motion) on freenode
+  * IRC:  [#motion](ircs://irc.libera.chat:6697/motion) on Libera Chat
 
 It is very important to use these resources for non-code issues since it engages a much wider audience who may have experience resolving
 the particular issue you are trying to resolve.  


### PR DESCRIPTION
The "freenode" channel is essentially no more after the latest network changes resulted in two to three re-registered regulars idling, down from half a dozen or more throughout the changes and the network user base is also down considerably. If you want to see more about what happened just check out the "freenode" website and article archive/history.
As most of the regular users have already migrated to Libera Chat for many other channels, we've also started an unofficial #motion there. We should now call this the official channel. Other options would be another network or remove any IRC channel references altogether.

I can update the website IRC link as well, if this is accepted.