### PR TITLE
Added a handler for end of file, when processing file:// input

### DIFF
--- a/src/netcam_rtsp.c
+++ b/src/netcam_rtsp.c
@@ -1179,6 +1179,12 @@ static int netcam_rtsp_read_image(struct rtsp_context *rtsp_data)
                 MOTION_LOG(INF, TYPE_NETCAM, NO_ERRNO
                     ,_("%s: av_read_frame: %s")
                     ,rtsp_data->cameratype, errstr);
+
+                if (!strcmp(rtsp_data->service, "file") && !strcmp(errstr, "End of file")) {
+                    MOTION_LOG(ERR, TYPE_NETCAM, NO_ERRNO, "\"%s\" file:// stream detected, process completed, shutdown", errstr);
+                    rtsp_data->finish = TRUE;
+                    rtsp_data->status = RTSP_NOTCONNECTED;
+                }
             } else {
                 MOTION_LOG(INF, TYPE_NETCAM, NO_ERRNO
                     ,_("%s: Excessive tries to get data from camera %d")


### PR DESCRIPTION
There is a usage case when motion processes offline prerecorded streams using `file://` netcam url.

In this case motion should stop and finish when the file has been fully processed. Instead, currently motion will start over processing the same file.

This patch adds a handler of "End of file" error to stop motion of further processing