### PR TITLE
Add doc about number of simultaneous streams

### DIFF
--- a/doc/motion_config.html
+++ b/doc/motion_config.html
@@ -136,6 +136,9 @@
           <li> Specify a <a href="#stream_port" >stream_port</a></li>
           <li> Optionally turn off <a href="#stream_localhost" >stream_localhost</a> if you want to view
                the stream from a different computer</li>
+          <li> Optionally adjust the number of persistent connections of your browser. This value will limit
+               the number of simultaneous streams.
+               See: <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x#persistent_connections" rel="nofollow" target="_top">persistent connections</a></li>
         </ul>
         <li>Enable the <a href="#OptDetail_Webcontrol" >web control</a> in the configuration file </li>
         <ul>
@@ -5182,6 +5185,8 @@
         The streams are generated in "multipart jpeg" format (mjpeg) which most browsers can display.  If
         the browser does not directly open the stream, it may be possible to manually create a simple HTML
         page that references the stream.
+        <p></p>
+        Browsers may limit the number of simultaneous streams. See: <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x#persistent_connections" rel="nofollow" target="_top">persistent connections</a>
         <p></p>
         Some regular stream players such as mplayer, ffplay and avplay may open the streams as well by specifying
         the network stream as


### PR DESCRIPTION
Browsers may limit the number of simultaneous streams. The value of
maximum persistent connections needs to be adjusted to be greater than
the number of camera streams.