### PR TITLE
Update logger.c

### DIFF
--- a/src/logger.c
+++ b/src/logger.c
@@ -154,11 +154,13 @@ FILE * set_logfile(const char *logfile_name)
  */
 static char *str_time(void)
 {
-    static char buffer[16];
+    //static char buffer[16]; // the month differs depending on the language. ex)LANG=ja_JP.UTF-8
+    static char buffer[18];
     time_t now = 0;
 
     now = time(0);
-    strftime(buffer, 16, "%b %d %H:%M:%S", localtime(&now));
+    //strftime(buffer, 16, "%b %d %H:%M:%S", localtime(&now));
+    strftime(buffer, 18, "%b %d %H:%M:%S", localtime(&now));
     return buffer;
 }
 


### PR DESCRIPTION
Due to the influence of "native_language", the time stamp of the log is missing.
I don't know if it will be unaffected by the locals or if it will be supported by increasing the buffer, but I will tell you.