### PR TITLE
Add Y10B pixel format support

### DIFF
--- a/doc/motion_config.html
+++ b/doc/motion_config.html
@@ -2604,7 +2604,7 @@
         <h4> palette </h4>
         <ul>
           <li> Type: Integer</li>
-          <li> Range / Valid values: 0 - 20</li>
+          <li> Range / Valid values: 0 - 22</li>
           <li> Default: 17</li>
         </ul>
         <p></p>
@@ -2739,6 +2739,11 @@
               <td bgcolor="#edf4f9" align="left" > V4L2_PIX_FMT_GREY</td>
               <td bgcolor="#edf4f9" align="center" >GREY</li>
               <td bgcolor="#edf4f9" align="center" >20</td>
+            </tr>
+            <tr>
+              <td bgcolor="#edf4f9" align="left" > V4L2_PIX_FMT_H264</td>
+              <td bgcolor="#edf4f9" align="center" >H264</li>
+              <td bgcolor="#edf4f9" align="center" >21</td>
             </tr>
             <tr>
               <td bgcolor="#edf4f9" align="left" > V4L2_PIX_FMT_Y10BPACK</td>

--- a/doc/motion_config.html
+++ b/doc/motion_config.html
@@ -2740,6 +2740,11 @@
               <td bgcolor="#edf4f9" align="center" >GREY</li>
               <td bgcolor="#edf4f9" align="center" >20</td>
             </tr>
+            <tr>
+              <td bgcolor="#edf4f9" align="left" > V4L2_PIX_FMT_Y10BPACK</td>
+              <td bgcolor="#edf4f9" align="center" >GREY</li>
+              <td bgcolor="#edf4f9" align="center" >22</td>
+            </tr>
           </tbody>
         </table>
         </div>

--- a/src/video_common.h
+++ b/src/video_common.h
@@ -84,6 +84,7 @@ void vid_uyvyto420p(unsigned char *map, unsigned char *cap_map, int width, int h
 void vid_rgb24toyuv420p(unsigned char *map, unsigned char *cap_map, int width, int height);
 void vid_bayer2rgb24(unsigned char *dst, unsigned char *src, long int width, long int height);
 void vid_y10torgb24(unsigned char *map, unsigned char *cap_map, int width, int height, int shift);
+void vid_y10btoyuv420p(unsigned char *map, unsigned char *cap_map, int width, int height);
 void vid_greytoyuv420p(unsigned char *map, unsigned char *cap_map, int width, int height);
 int vid_sonix_decompress(unsigned char *outp, unsigned char *inp, int width, int height);
 int vid_mjpegtoyuv420p(unsigned char *map, unsigned char *cap_map, int width, int height, unsigned int size);


### PR DESCRIPTION
The Y10B format is notably used by the depth stream from the Kinect, which is provided by the `gspca_kinect` kernel module.
This PR allows Motion to handle this palette and convert the Y10B data to a usable format.

The documentation was updated accordingly, with another small patch also adding V4L2_PIX_FMT_H264 to the documentation since it was missing (although not functional).

A small change was made to the check in `v4l2_pixfmt_stride`: packed formats cannot be expected to have a width that's a multiple of the stride. A switch statement was introduced to handle such formats, should more be added in the future. We're still however able to check that the image buffer size reported by the driver is reasonable given the width, height, and stride.