### PR TITLE
log signals that trigger end of process

### DIFF
--- a/po/pt.po
+++ b/po/pt.po
@@ -1950,6 +1950,11 @@ msgstr "%d De reinicialização do segmento de movimento"
 msgid "Threads finished"
 msgstr "Tópicos concluídos"
 
+#: src/motion.c
+#, c-format
+msgid "Received signal %d."
+msgstr "Sinal %d recebido."
+
 #: src/motion.c src/webu.c
 msgid "Motion terminating"
 msgstr "Movimento terminando"

--- a/src/motion.c
+++ b/src/motion.c
@@ -383,6 +383,8 @@ static void sig_handler(int signo)
          * movie and end up!
          */
 
+        MOTION_LOG(NTC, TYPE_ALL, NO_ERRNO, _("Received signal %d."), signo);
+
         if (cnt_list) {
             i = -1;
             while (cnt_list[++i]) {
@@ -402,8 +404,6 @@ static void sig_handler(int signo)
          */
         finish = 1;
         break;
-    case SIGSEGV:
-        exit(0);
     case SIGVTALRM:
         printf("SIGVTALRM went off\n");
         break;


### PR DESCRIPTION
and remove SIGSEGV, which is not registered

context: I was experiencing an issue where motion would terminate for no apparent reason. Looking at logs, I didn't see any error, just a normal motion graceful shutdown. After a day of investigation, I found that systemd was terminating motion due to a mis-configuration in the systemd unit. Having a log saying that motion received a signal, as implemented by this pull request, would have saved me a good few hours of debugging the problem :smiling_face_with_tear: 

PS: I see gettext .po files are being used for translation, but I'm not familiar with the gettext workflow. If a translation strings needs to be added please let me know how :)