### PR TITLE
Gettext 0.22

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,19 +1,18 @@
 ACLOCAL_AMFLAGS = -I m4
 
-SUBDIRS = src po man
+SUBDIRS = src po
 
-sysconfdir = @sysconfdir@/$(PACKAGE)
-sysconf_DATA = \
+pkgsysconfdir = $(sysconfdir)/@PACKAGE@
+dist_pkgsysconf_DATA = \
 	data/motion-dist.conf \
 	data/camera1-dist.conf \
 	data/camera2-dist.conf \
 	data/camera3-dist.conf \
 	data/camera4-dist.conf
 
-man_MANS = man/motion.1
+dist_man_MANS = man/motion.1
 
-docdir = $(datadir)/doc/@PACKAGE@
-doc_DATA = \
+dist_doc_DATA = \
 	doc/mask1.png \
 	doc/normal.jpg \
 	doc/outputmotion1.jpg  \

--- a/configure.ac
+++ b/configure.ac
@@ -496,7 +496,6 @@ AC_CONFIG_FILES([
 	Makefile
 	src/Makefile
   po/Makefile.in
-  man/Makefile
   data/camera1-dist.conf
   data/camera2-dist.conf
   data/camera3-dist.conf

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -1,1 +1,0 @@
-man_MANS = motion.1

--- a/po/de.po
+++ b/po/de.po
@@ -3458,7 +3458,7 @@ msgstr "Sprache: Deutsch"
 #: src/util.c
 #, c-format
 msgid "Could not allocate %llu bytes of memory!"
-msgstr "%Llu Bytes Speicher konnten nicht zugeordnet werden!"
+msgstr "%llu Bytes Speicher konnten nicht zugeordnet werden!"
 
 #: src/util.c
 #, c-format

--- a/po/fi.po
+++ b/po/fi.po
@@ -3432,7 +3432,7 @@ msgstr "Kieli: englanti"
 #: src/util.c
 #, c-format
 msgid "Could not allocate %llu bytes of memory!"
-msgstr "%Llu-tavua muistia ei voitu varata!"
+msgstr "%llu-tavua muistia ei voitu varata!"
 
 #: src/util.c
 #, c-format

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,17 +1,43 @@
-AM_CPPFLAGS= -Dsysconfdir=\"$(sysconfdir)/motion\" -DLOCALEDIR=\"$(DESTDIR)$(localedir)\"
-
-if INC_MMAL_SRC
-MMAL_SRC=raspicam/RaspiCamControl.c raspicam/RaspiCLI.c
-endif
-
-LIBS = @LIBINTL@ @LIBS@
+AM_CPPFLAGS= -Dsysconfdir=\"$(sysconfdir)/motion\" -DLOCALEDIR=\"$(localedir)\"
+LDADD = $(LIBINTL)
 
 bin_PROGRAMS = motion
 
-motion_SOURCES = motion.c logger.c conf.c draw.c jpegutils.c video_loopback.c \
-	video_v4l2.c video_common.c video_bktr.c netcam.c netcam_http.c netcam_ftp.c \
-	netcam_jpeg.c netcam_wget.c netcam_rtsp.c track.c alg.c event.c picture.c \
-	rotate.c translate.c ffmpeg.c util.c dbse.c webu_status.c \
-	webu.c webu_html.c webu_stream.c webu_text.c mmalcam.c $(MMAL_SRC)
+motion_SOURCES = \
+	alg.h alg.c \
+	conf.h conf.c \
+	dbse.h dbse.c \
+	draw.h draw.c \
+	event.h event.c \
+	ffmpeg.h ffmpeg.c \
+	jpegutils.h jpegutils.c \
+	logger.h logger.c \
+	mmalcam.h mmalcam.c \
+	motion.h motion.c \
+	netcam.h netcam.c \
+	netcam_ftp.h netcam_ftp.c \
+	netcam_http.h netcam_http.c \
+	netcam_jpeg.h netcam_jpeg.c \
+	netcam_rtsp.h netcam_rtsp.c \
+	netcam_wget.h netcam_wget.c \
+	picture.h picture.c \
+	rotate.h rotate.c \
+	track.h track.c \
+	translate.h translate.c \
+	util.h util.c \
+	video_bktr.h video_bktr.c \
+	video_common.h video_common.c \
+	video_loopback.h video_loopback.c \
+	video_v4l2.h video_v4l2.c \
+	webu.h webu.c \
+	webu_html.h webu_html.c \
+	webu_status.h webu_status.c \
+	webu_stream.h webu_stream.c \
+	webu_text.h webu_text.c \
+	mmx.h pwc-ioctl.h
 
-
+if INC_MMAL_SRC
+motion_SOURCES += \
+	raspicam/RaspiCamControl.h raspicam/RaspiCamControl.c \
+	raspicam/RaspiCLI.h raspicam/RaspiCLI.c
+endif


### PR DESCRIPTION
**Autotools: fix `make distcheck`**

* use correct `dist_` specifiers for including files in tarball
* do not override `docdir`, since this is a user variable
* include headers in tarball

**po: fix gettext 0.22 format specifier**

Bug: https://bugs.gentoo.org/908965
Bug: https://savannah.gnu.org/bugs/index.php?64334#comment1
